### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(deps)"
+      include: true


### PR DESCRIPTION
Fixes issue #41 

Changes:
- Added dependabot.yml with the following configuration:
  - package-ecosystem: "npm"
  - directory: "/"
  - schedule: interval: "daily"
  - commit-message: prefix: "chore(deps)"
  
Please do let me know in case there are any changes requires to be done.
