### PR TITLE
fix: update include attribute in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "chore(deps)"
-      include: true
+      include: "scope"


### PR DESCRIPTION
Fixes issue #41

Changes: 
The include attribute should be "scope" instead of a boolean (true)
