### PR TITLE
changing manifest version

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Scrum Helper Extension",
   "version": "1.0",
   "description": "This extension helps in writing Scrums in Google groups, particularly related to FOSSASIA. ",


### PR DESCRIPTION
Fixes issue #56 


manifest_version:2 is deprecated so while loading this extension getting error
changed the version and its working but there might be more things to test to check if anything is breaking or not 
so this is just a small step
As i am not a member of foss asia google group i can not test it further (looking forward to join the foss asia google group)

This is just changing the version number but there are other errors 
for content_security_policy mention in manifest.json
currently i am looking into it

Changes: 
upgrading manifest version from 2 to 3

Screenshots for the change:
![image](https://github.com/user-attachments/assets/4f7254d0-23ea-40a4-b79f-03f5a9af6a13)

## Summary by Sourcery

Bug Fixes:
- Fixes an issue caused by the deprecation of manifest_version:2.