### PR TITLE
[Fixes #56] Migrate to Manifest V3

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,34 +2,36 @@
   "manifest_version": 3,
   "name": "Scrum Helper Extension",
   "version": "1.0",
-  "description": "This extension helps in writing Scrums in Google groups, particularly related to FOSSASIA. ",
-  "browser_action": {
+  "description": "This extension helps in writing Scrums in Google groups, particularly related to FOSSASIA.",
+  
+  "action": {
     "default_popup": "popup.html",
-    "default_title" : "SCRUM Helper"
+    "default_title": "SCRUM Helper"
   },
-  "icons": {
-   "96": "icons/icon.png",
-   "48": "icons/icon.png"
- },
-  "background": {
-  "scripts": ["scripts/background.js"]
-  },
-  "content_scripts": [
-  {
-    "matches": ["*://groups.google.com/forum/*", "*://groups.google.com/g/*"],
-    "js": ["scripts/jquery-3.2.1.min.js","scripts/scrumHelper.js"]
-  }
-],
-  "content_security_policy": "script-src 'self' https://cdn.jsdelivr.net/ https://api.github.com/ https://use.fontawesome.com/; object-src 'self'",
 
-  "permissions":[
-    "http://*/*",
-    "tabs",
-    "https://*/*",
+  "icons": {
+    "96": "icons/icon.png",
+    "48": "icons/icon.png"
+  },
+
+  "background": {
+    "service_worker": "scripts/background.js"
+  },
+
+  "content_scripts": [
+    {
+      "matches": ["*://groups.google.com/forum/*", "*://groups.google.com/g/*"],
+      "js": ["scripts/jquery-3.2.1.min.js", "scripts/scrumHelper.js"]
+    }
+  ],
+
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  },
+
+  "permissions": [
     "storage",
     "activeTab",
-    "<all_urls>",
     "notifications"
   ]
-
 }


### PR DESCRIPTION
Fixes issue #56 

**Changes**

- Replace `background.scripts `with `service_worker` as required in Manifest V3.
- Update `content_security_policy` to comply with Manifest V3 restrictions (external scripts aren't allowed). It requires a structured format.  
- Rename `browser_action` to `action` as required in Manifest V3.
- Remove broad permissions (`http://*/* `and `https://*/*`) to align with Chrome extension policies.

## Summary by Sourcery

Migrate the extension to Manifest V3 to comply with the latest Chrome extension policies.