### PR TITLE
adding time in calculations of yesterday and today

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -99,9 +99,11 @@ function getLastWeek() {
 	var today = new Date();
 	var noDays_to_goback = gsoc == 0 ? 7 : 1;
 	var lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - noDays_to_goback);
-	var lastWeekMonth = lastWeek.getMonth() + 1;
-	var lastWeekDay = lastWeek.getDate();
-	var lastWeekYear = lastWeek.getFullYear();
+	lastWeek.setHours(0, 0, 0 , 0);
+	var extendedLastWeek = new Date(lastWeek.getTime() + (14 *60 *60 * 1000));
+	var lastWeekMonth = extendedLastWeek.getMonth() + 1;
+	var lastWeekDay = extendedLastWeek.getDate();
+	var lastWeekYear = extendedLastWeek.getFullYear();
 	var lastWeekDisplayPadded =
 		('0000' + lastWeekYear.toString()).slice(-4) +
 		'-' +
@@ -112,17 +114,19 @@ function getLastWeek() {
 }
 function getToday() {
 	var today = new Date();
-	var Week = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-	var WeekMonth = Week.getMonth() + 1;
-	var WeekDay = Week.getDate();
-	var WeekYear = Week.getFullYear();
-	var WeekDisplayPadded =
-		('0000' + WeekYear.toString()).slice(-4) +
-		'-' +
-		('00' + WeekMonth.toString()).slice(-2) +
-		'-' +
-		('00' + WeekDay.toString()).slice(-2);
-	return WeekDisplayPadded;
+	var today = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+	today.setHours(23, 59, 59, 999);
+	var extendedToday = new Date(today.getTime() + (14 * 60 * 60 * 1000));
+	var todayMonth = extendedToday.getMonth() + 1;
+    var todayDay = extendedToday.getDate();
+    var todayYear = extendedToday.getFullYear();
+    var todayDisplayPadded =
+        ('0000' + todayYear.toString()).slice(-4) +
+        '-' +
+        ('00' + todayMonth.toString()).slice(-2) +
+        '-' +
+        ('00' + todayDay.toString()).slice(-2);
+    return todayDisplayPadded;
 }
 
 function handleGithubUsernameChange() {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -104,7 +104,10 @@ function allIncluded() {
 	function getLastWeek() {
 		var today = new Date();
 		var noDays_to_goback = gsoc == 0 ? 7 : 1;
-		var lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - noDays_to_goback);
+		var lastWeek = new Date(today);
+		lastWeek.setDate(today.getDate() - noDays_to_goback);
+		lastWeek.setHours(0, 0, 0, 0);
+
 		var lastWeekMonth = lastWeek.getMonth() + 1;
 		var lastWeekDay = lastWeek.getDate();
 		var lastWeekYear = lastWeek.getFullYear();
@@ -113,21 +116,24 @@ function allIncluded() {
 			'-' +
 			('00' + lastWeekMonth.toString()).slice(-2) +
 			'-' +
-			('00' + lastWeekDay.toString()).slice(-2);
+			('00' + lastWeekDay.toString()).slice(-2) +
+			'T00:00:00Z';
 		return lastWeekDisplayPadded;
 	}
 	function getToday() {
 		var today = new Date();
-		var Week = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-		var WeekMonth = Week.getMonth() + 1;
-		var WeekDay = Week.getDate();
-		var WeekYear = Week.getFullYear();
+		today.setHours(23, 59, 59, 999);
+		// var Week = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+		var WeekMonth = today.getMonth() + 1;
+		var WeekDay = today.getDate();
+		var WeekYear = today.getFullYear();
 		var WeekDisplayPadded =
 			('0000' + WeekYear.toString()).slice(-4) +
 			'-' +
 			('00' + WeekMonth.toString()).slice(-2) +
 			'-' +
-			('00' + WeekDay.toString()).slice(-2);
+			('00' + WeekDay.toString()).slice(-2) +
+			'T23:59:59Z';
 		return WeekDisplayPadded;
 	}
 	// fetch github data

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -102,31 +102,23 @@ function allIncluded() {
 		startingDate = getLastWeek();
 	}
 
-	function getUTCDate(date) {
-		return new Date(Date.UTC(
-			date.getFullYear(),
-			date.getMonth(),
-			date.getDate(),
-			date.getHours(),
-			date.getMinutes(),
-			date.getSeconds(),
-			date.getMilliseconds(),
-		)).toISOString().slice(0,19) + "Z";
-	}
-
 	function getLastWeek() {
 		var today = new Date();
 		var noDays_to_goback = gsoc == 0 ? 7 : 1;
 		var lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - noDays_to_goback);
 		lastWeek.setHours(0, 0, 0, 0);
 
-		return getUTCDate(lastWeek);
+		const utc = new Date(lastWeek.getTime() + (14 * 60* 60* 1000));
+
+		return utc.toISOString().slice(0,19) + "Z";
 	}
 	function getToday() {
 		var today = new Date();
 		today.setHours(23, 59, 59, 999);
+
+		const utc = new Date(today.getTime() + (14 * 60 * 60 * 1000));
 		
-		return getUTCDate(today);
+		return utc.toISOString().slice(0, 19) + "Z";
 	}	
 	// fetch github data
 	function fetchGithubData() {
@@ -183,6 +175,35 @@ function allIncluded() {
 				githubUserData = data;
 			},
 		});
+		filterAndStoreData();
+	}
+
+	function filterDataByDate(data){
+		var today = new Date();
+		var noDays_to_goback = gsoc == 0 ? 7 : 1;
+
+		const localStart = new Date(today.getFullYear(), today.getMonth(), today.getDate() - noDays_to_goback);
+		localStart.setHours(0, 0, 0, 0);
+
+		const localEnd = new Date();
+		localEnd.setHours(23, 59, 59 ,999);
+
+		return data.items.filter(item => {
+			const updatedAt = new Date(item.updated_at);
+			return updatedAt >= localStart && updatedAt <= localEnd;
+		})
+	}
+
+	function filterAndStoreData() {
+		if(githubIssuesData) {
+			githubIssuesData.items = filterDataByDate(githubIssuesData);
+		}
+		if(githubPrsReviewData) {
+			githubPrsReviewData.items = filterDataByDate(githubPrsReviewData);
+		}		
+		if(githubUserData) {
+			githubUserData.items = filterDataByDate(githubUserData);
+		}
 	}
 
 	function formatDate(dateString) {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -101,41 +101,33 @@ function allIncluded() {
 		endingDate = getToday();
 		startingDate = getLastWeek();
 	}
+
+	function getUTCDate(date) {
+		return new Date(Date.UTC(
+			date.getFullYear(),
+			date.getMonth(),
+			date.getDate(),
+			date.getHours(),
+			date.getMinutes(),
+			date.getSeconds(),
+			date.getMilliseconds(),
+		)).toISOString().slice(0,19) + "Z";
+	}
+
 	function getLastWeek() {
 		var today = new Date();
 		var noDays_to_goback = gsoc == 0 ? 7 : 1;
 		var lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - noDays_to_goback);
 		lastWeek.setHours(0, 0, 0, 0);
 
-		var lastWeekMonth = lastWeek.getMonth() + 1;
-		var lastWeekDay = lastWeek.getDate();
-		var lastWeekYear = lastWeek.getFullYear();
-		var lastWeekDisplayPadded =
-			('0000' + lastWeekYear.toString()).slice(-4) +
-			'-' +
-			('00' + lastWeekMonth.toString()).slice(-2) +
-			'-' +
-			('00' + lastWeekDay.toString()).slice(-2) +
-			'T00:00:00Z';
-		return lastWeekDisplayPadded;
+		return getUTCDate(lastWeek);
 	}
 	function getToday() {
 		var today = new Date();
 		today.setHours(23, 59, 59, 999);
-		var week = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-		week.setHours(23, 59, 59, 999);
-		var weekMonth = week.getMonth() + 1;
-		var weekDay = week.getDate();
-		var weekYear = week.getFullYear();
-		var weekDisplayPadded =
-			('0000' + weekYear.toString()).slice(-4) +
-			'-' +
-			('00' + weekMonth.toString()).slice(-2) +
-			'-' +
-			('00' + weekDay.toString()).slice(-2) +
-			'T23:59:59Z';
-		return weekDisplayPadded;
-	}
+		
+		return getUTCDate(today);
+	}	
 	// fetch github data
 	function fetchGithubData() {
 		var issueUrl =

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -120,6 +120,7 @@ function allIncluded() {
 		
 		return utc.toISOString().slice(0, 19) + "Z";
 	}	
+
 	// fetch github data
 	function fetchGithubData() {
 		var issueUrl =
@@ -178,15 +179,10 @@ function allIncluded() {
 		filterAndStoreData();
 	}
 
-	function filterDataByDate(data){
-		var today = new Date();
-		var noDays_to_goback = gsoc == 0 ? 7 : 1;
+	function filterDataByDate(data, startingDate, endingDate){
 
-		const localStart = new Date(today.getFullYear(), today.getMonth(), today.getDate() - noDays_to_goback);
-		localStart.setHours(0, 0, 0, 0);
-
-		const localEnd = new Date();
-		localEnd.setHours(23, 59, 59 ,999);
+		const localStart = new Date(startingDate + 'T00:00:00Z');
+		const localEnd = new Date(endingDate + 'T23:59:59Z');
 
 		return data.items.filter(item => {
 			const updatedAt = new Date(item.updated_at);
@@ -196,13 +192,13 @@ function allIncluded() {
 
 	function filterAndStoreData() {
 		if(githubIssuesData) {
-			githubIssuesData.items = filterDataByDate(githubIssuesData);
+			githubIssuesData.items = filterDataByDate(githubIssuesData, startingDate, endingDate);
 		}
 		if(githubPrsReviewData) {
-			githubPrsReviewData.items = filterDataByDate(githubPrsReviewData);
+			githubPrsReviewData.items = filterDataByDate(githubPrsReviewData, startingDate, endingDate);
 		}		
 		if(githubUserData) {
-			githubUserData.items = filterDataByDate(githubUserData);
+			githubUserData.items = filterDataByDate(githubUserData, startingDate, endingDate);
 		}
 	}
 

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -105,10 +105,16 @@ function allIncluded() {
 	function getLastWeek() {
 		var today = new Date();
 		var noDays_to_goback = gsoc == 0 ? 7 : 1;
+
+		// Get user's timezone offset in mins
+		const tzOffset = today.getTimezoneOffset();
+
+		// date for start of day in user's timezone
 		var lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - noDays_to_goback);
 		lastWeek.setHours(0, 0, 0, 0);
 
-		const utc = new Date(lastWeek.getTime() + (14 * 60* 60* 1000));
+		// Adjust timezone to make sure no activity is missed
+		const utc = new Date(lastWeek.getTime() + (tzOffset * 60 * 1000));
 
 		return utc.toISOString().slice(0,19) + "Z";
 	}
@@ -116,7 +122,9 @@ function allIncluded() {
 		var today = new Date();
 		today.setHours(23, 59, 59, 999);
 
-		const utc = new Date(today.getTime() + (14 * 60 * 60 * 1000));
+		// get timezone offset
+		const tzOffset = today.getTimezoneOffset();
+		const utc = new Date(today.getTime() + (tzOffset * 60 * 1000));
 		
 		return utc.toISOString().slice(0, 19) + "Z";
 	}	

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -104,8 +104,7 @@ function allIncluded() {
 	function getLastWeek() {
 		var today = new Date();
 		var noDays_to_goback = gsoc == 0 ? 7 : 1;
-		var lastWeek = new Date(today);
-		lastWeek.setDate(today.getDate() - noDays_to_goback);
+		var lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - noDays_to_goback);
 		lastWeek.setHours(0, 0, 0, 0);
 
 		var lastWeekMonth = lastWeek.getMonth() + 1;
@@ -123,18 +122,19 @@ function allIncluded() {
 	function getToday() {
 		var today = new Date();
 		today.setHours(23, 59, 59, 999);
-		// var Week = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-		var WeekMonth = today.getMonth() + 1;
-		var WeekDay = today.getDate();
-		var WeekYear = today.getFullYear();
-		var WeekDisplayPadded =
-			('0000' + WeekYear.toString()).slice(-4) +
+		var week = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+		week.setHours(23, 59, 59, 999);
+		var weekMonth = week.getMonth() + 1;
+		var weekDay = week.getDate();
+		var weekYear = week.getFullYear();
+		var weekDisplayPadded =
+			('0000' + weekYear.toString()).slice(-4) +
 			'-' +
-			('00' + WeekMonth.toString()).slice(-2) +
+			('00' + weekMonth.toString()).slice(-2) +
 			'-' +
-			('00' + WeekDay.toString()).slice(-2) +
+			('00' + weekDay.toString()).slice(-2) +
 			'T23:59:59Z';
-		return WeekDisplayPadded;
+		return weekDisplayPadded;
 	}
 	// fetch github data
 	function fetchGithubData() {


### PR DESCRIPTION
Fixes issue #65 
Changes: Added time in calculation logic of yesterday and today, earlier it was not given setting it to default at 00:00 causing the issue.

## Summary by Sourcery

Improve date calculation logic to correctly handle time zones and date ranges in GitHub data retrieval

Bug Fixes:
- Fix date calculation for yesterday and today by properly setting time components to ensure accurate data filtering

Enhancements:
- Modify date handling to use UTC time and set precise start and end times for date ranges
- Add a new filter function to accurately select GitHub data within specified date ranges