### PR TITLE
Feature standalone popup

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -50,3 +50,44 @@ li {
 	list-style-type: disc !important;
 	margin-left: 1rem;
 }
+
+/* Checkbox and switch visual feedback styles */
+[type="checkbox"].filled-in + label {
+	color: #757575;
+	transition: color 0.3s ease, font-weight 0.3s ease, background-color 0.3s ease;
+	padding-left: 35px !important; /* Ensure text doesn't overlap with checkbox */
+	border-radius: 2px;
+}
+
+[type="checkbox"].filled-in:checked + label {
+	color: #3f51b5;
+	font-weight: 500;
+	background-color: rgba(63, 81, 181, 0.03); /* Very subtle highlight */
+}
+
+/* Improve spacing for checkbox containers */
+.col.s12 input[type="checkbox"] + label {
+	display: inline-block;
+	line-height: 21px;
+}
+
+/* Special styling for the checkbox that contains a span */
+label[for="lastWeekContribution"] {
+	margin-top: 3px;
+	padding-right: 5px !important;
+}
+
+#noDays {
+	margin: 0 3px;
+}
+
+/* Switch label styling */
+.switch label {
+	color: #757575;
+	transition: color 0.3s ease, font-weight 0.3s ease;
+}
+
+.switch label input[type="checkbox"]:checked ~ span:not(.lever) {
+	color: #3f51b5;
+	font-weight: 500;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -91,3 +91,37 @@ label[for="lastWeekContribution"] {
 	color: #3f51b5;
 	font-weight: 500;
 }
+
+/* Standalone report styles */
+#standalone-report {
+	resize: none;
+	font-family: 'Roboto', sans-serif;
+	min-height: 200px;
+	padding: 10px;
+	margin-bottom: 10px;
+}
+
+#standalone-report:focus {
+	border-bottom: 1px solid #3f51b5;
+	box-shadow: 0 1px 0 0 #3f51b5;
+}
+
+#generate-report, #copy-report {
+	width: 100%;
+	margin-bottom: 10px;
+}
+
+/* Tab styling */
+.tabs .tab a.active {
+	color: #3f51b5 !important;
+	font-weight: 500;
+}
+
+/* Ensure labels in the standalone tab behave consistently */
+#standalone .input-field > label {
+	color: #9e9e9e;
+}
+
+#standalone .input-field > label.active {
+	color: #3f51b5;
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -36,54 +36,81 @@
 		<div class="row">
 			<div class="col s12">
 				<ul class="tabs">
-					<li class="tab col s6" title="I am doing CodeHeat!"><a id="codeheatTab" href="#codeheatBox">CodeHeat</a></li>
-					<li class="tab col s6" title="I am doing GSoC!"><a id="gsocTab" href="#gsocBox">GSoC</a></li>
+					<li class="tab col s4" title="I am doing CodeHeat!"><a id="codeheatTab" href="#codeheatBox">CodeHeat</a></li>
+					<li class="tab col s4" title="I am doing GSoC!"><a id="gsocTab" href="#gsocBox">GSoC</a></li>
+					<li class="tab col s4" title="Generate standalone report"><a id="standaloneTab" href="#standalone">Standalone</a></li>
 				</ul>
 			</div>
 		</div>
-		<div class="row">
-            <div class="input-field col s12">
-                <input placeholder="Your Project Name" id="projectName" type="text">
-                <label for="projectName">Your Project Name</label>
-            </div>
-			<div class="input-field col s12">
-				<input placeholder="Required for getting data from github" id="githubUsername" type="text">
-				<label for="githubUsername">Your Github Username</label>
-			</div>
-			<div class="col s12"><span>Fetch your contributions between:</span>
-				<input type="checkbox" class="filled-in" id="lastWeekContribution"/>
-				<label for="lastWeekContribution">Show past <span id="noDays"></span> from today</label>
-			</div>
+		
+		<!-- Main settings section -->
+		<div id="main-settings">
+			<div class="row">
+				<div class="input-field col s12">
+					<input placeholder="Your Project Name" id="projectName" type="text">
+					<label for="projectName">Your Project Name</label>
+				</div>
+				<div class="input-field col s12">
+					<input placeholder="Required for getting data from github" id="githubUsername" type="text">
+					<label for="githubUsername">Your Github Username</label>
+				</div>
+				<div class="col s12"><span>Fetch your contributions between:</span>
+					<input type="checkbox" class="filled-in" id="lastWeekContribution"/>
+					<label for="lastWeekContribution">Show past <span id="noDays"></span> from today</label>
+				</div>
 
-			<div class="input-field col s6">
-				<div>Starting Date:</div>
-				<input id="startingDate" type="date" class="datepicker" placeholder=" ">
-				
+				<div class="input-field col s6">
+					<div>Starting Date:</div>
+					<input id="startingDate" type="date" class="datepicker" placeholder=" ">
+					
+				</div>
+				<div class="input-field col s6">
+					<div>Ending Date</div>
+					<input id="endingDate" type="date" class="datepicker" placeholder=" ">
+				</div>
+				<div class="col s12">
+					<br />
+					<input type="checkbox" class="filled-in" id="showOpenLabel"/>
+					<label for="showOpenLabel">Show Open/Closed Label</label>
+				</div>
+				<div class="input-field col s12">
+					<input placeholder="Reason" id="userReason" type="text">
+					<label for="userReason">What is stopping you from doing your work?</label>
+				</div>
+				<div class="col s12">
+					
+					<h5>Note:</h5>
+					<h6>
+						<ul>
+							<li>The PRs fetched are according to the date last reviewed by anyone. So if you reviewed a PR 10 days back, and someone reviewed it 2 days back, it will appear in your last week's activity. See <a target="_blank" href="https://github.com/fossasia/scrum_helper/issues/20">this issue</a>.
+							</li>
+							<li>By using the extension you understand that there might be discrepancies in the SCRUM generated. You are advised to edit the SCRUM afterwards to remove any discrepancies.
+							</li>
+						</ul>
+					</h6>
+				</div>
 			</div>
-			<div class="input-field col s6">
-				<div>Ending Date</div>
-				<input id="endingDate" type="date" class="datepicker" placeholder=" ">
+		</div>
+		
+		<!-- Standalone tab content -->
+		<div id="standalone" style="display:none;">
+			<div class="row">
+				<div class="input-field col s12">
+					<textarea id="standalone-report" class="materialize-textarea" style="height: 250px; overflow-y: auto;"></textarea>
+					<label for="standalone-report">Generated Report</label>
+				</div>
 			</div>
-			<div class="col s12">
-				<br />
-				<input type="checkbox" class="filled-in" id="showOpenLabel"/>
-				<label for="showOpenLabel">Show Open/Closed Label</label>
-			</div>
-			<div class="input-field col s12">
-				<input placeholder="Reason" id="userReason" type="text">
-				<label for="userReason">What is stopping you from doing your work?</label>
-			</div>
-			<div class="col s12">
-				
-				<h5>Note:</h5>
-				<h6>
-					<ul>
-						<li>The PRs fetched are according to the date last reviewed by anyone. So if you reviewed a PR 10 days back, and someone reviewed it 2 days back, it will appear in your last week's activity. See <a target="_blank" href="https://github.com/fossasia/scrum_helper/issues/20">this issue</a>.
-						</li>
-						<li>By using the extension you understand that there might be discrepancies in the SCRUM generated. You are advised to edit the SCRUM afterwards to remove any discrepancies.
-						</li>
-					</ul>
-				</h6>
+			<div class="row">
+				<div class="col s6">
+					<button id="generate-report" class="btn waves-effect waves-light blue">
+						Generate Report
+					</button>
+				</div>
+				<div class="col s6">
+					<button id="copy-report" class="btn waves-effect waves-light teal">
+						Copy to Clipboard
+					</button>
+				</div>
 			</div>
 		</div>
 

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1,0 +1,16 @@
+// Listen for messages from the popup
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === "generateStandaloneReport") {
+    // Forward the message to the active tab
+    chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
+      if (tabs[0]) {
+        chrome.tabs.sendMessage(tabs[0].id, message, (response) => {
+          sendResponse(response);
+        });
+      } else {
+        sendResponse({content: "No active tab found. Please open a supported page."});
+      }
+    });
+    return true; // Keep the message channel open for the async response
+  }
+});


### PR DESCRIPTION
Changes made: I've added a standalone tab to the SCRUM Helper extension, enabling users to generate and copy reports directly from the popup without needing email clients. The implementation includes a clean, user-friendly interface with a text area for editing reports and buttons for convenient report generation and clipboard copying. The design follows the extension's existing style patterns, ensuring a seamless experience while giving users more flexibility in how they create and share their SCRUM reports.

Screenshots for the change:
<img width="351" alt="Screenshot 2025-04-03 at 12 43 04 AM" src="https://github.com/user-attachments/assets/68465869-71b6-4169-9a3f-d5e7144b1b64" />
<img width="348" alt="Screenshot 2025-04-03 at 12 53 01 AM" src="https://github.com/user-attachments/assets/bb2158a1-1915-4f6e-92b4-9b35dadbbb90" />

<img width="265" alt="Screenshot 2025-04-03 at 12 55 52 AM" src="https://github.com/user-attachments/assets/7234bdbe-ed68-4c98-b3b7-151b17da77cb" />

## Summary by Sourcery

Add a standalone report generation tab to the SCRUM Helper extension, allowing users to create and copy reports directly from the popup

New Features:
- Introduce a new 'Standalone' tab in the extension popup that enables users to generate and copy SCRUM reports without needing an email client

Enhancements:
- Modify the existing tab layout to accommodate the new standalone report feature
- Implement report generation and clipboard copying functionality within the popup

Chores:
- Update the extension's user interface to support a third tab
- Add event listeners for the new standalone report functionality