### PR TITLE
Scrum subject and body message are now correctly added in Outlook

### DIFF
--- a/src/scripts/emailClientAdapter.js
+++ b/src/scripts/emailClientAdapter.js
@@ -23,8 +23,8 @@ class EmailClientAdapter {
 			},
 			outlook: {
 				selectors: {
-					body: 'div[role="textbox"][contenteditable="true"][aria-multiline="true"]',
-					subject: 'input[aria-label="Add a subject"][type="text"]',
+					body: 'div[role="textbox"][contenteditable="true"][aria-multiline="true"][aria-label="Message body, press Alt+F10 to exit"]',
+					subject: 'input[aria-label="Subject"][type="text"]',
 				},
 				eventTypes: {
 					contentChange: 'input',

--- a/src/scripts/emailClientAdapter.js
+++ b/src/scripts/emailClientAdapter.js
@@ -24,7 +24,7 @@ class EmailClientAdapter {
 			outlook: {
 				selectors: {
 					body: 'div[role="textbox"][contenteditable="true"][aria-multiline="true"][aria-label="Message body, press Alt+F10 to exit"]',
-					subject: 'input[aria-label="Subject"][type="text"]',
+					subject: 'input[aria-label="Subject"][type="text"][maxlength="255"][placeholder="Add a subject"]',
 				},
 				eventTypes: {
 					contentChange: 'input',


### PR DESCRIPTION
Closes #80 
Changes: The selectors of outlook are updated in the latest changes and now works properly by injecting the scrum `body` in the body area and `subject` in the subject area.

Screenshots for the change:
![image](https://github.com/user-attachments/assets/4736c7e5-9e6c-4cc8-98f1-32ce7d7fe892)

## Summary by Sourcery

Bug Fixes:
- Fix Outlook email client selector issues by updating the body and subject element selectors to match the latest Outlook web interface