### PR TITLE
Enhanced selectors for scrum injection in different screen sizes

### DIFF
--- a/src/scripts/emailClientAdapter.js
+++ b/src/scripts/emailClientAdapter.js
@@ -26,7 +26,7 @@ class EmailClientAdapter {
 					body: 'div[role="textbox"][contenteditable="true"][aria-multiline="true"]',
 					subject: [
 						'input[aria-label="Subject"][type="text"]',
-						'input[aria-label="Add a subject"][type="text"]',
+						'input[aria-label="Add a subject"][type="text"][role="textbox"][aria-multiline="false"]',
 					],
 				},
 				eventTypes: {

--- a/src/scripts/emailClientAdapter.js
+++ b/src/scripts/emailClientAdapter.js
@@ -24,7 +24,10 @@ class EmailClientAdapter {
 			outlook: {
 				selectors: {
 					body: 'div[role="textbox"][contenteditable="true"][aria-multiline="true"]',
-					subject: 'input[aria-label="Add a subject"][type="text"]',
+					subject: [
+						'input[aria-label="Subject"][type="text"]',
+						'input[aria-label="Add a subject"][type="text"]',
+					],
 				},
 				eventTypes: {
 					contentChange: 'input',
@@ -34,8 +37,18 @@ class EmailClientAdapter {
 			},
 			yahoo: {
 				selectors: {
-					body: '#editor-container [contenteditable="true"][role="textbox"]',
-					subject: '#compose-subject-input, input[placeholder="Subject"][id="compose-subject-input"]',
+					body: [
+						// Desktop selectors
+						'#editor-container [contenteditable="true"][role="textbox"]',
+						// Mobile selectors
+						'#editoor-container-mobile [contentditable="true"][role="textbox"]',
+					],
+					subject: [
+						// Desktop selectors
+						'#compose-subject-input, input[placeholder="Subject"][id="compose-subject-input"]',
+						// Mobile selectors
+						'#compose-subject-input-mobile, input[placeholder="Subject"][id="compose-subject-input-mobile"]'
+					],
 				},
 				eventTypes: {
 					contentChange: 'input',

--- a/src/scripts/emailClientAdapter.js
+++ b/src/scripts/emailClientAdapter.js
@@ -35,7 +35,7 @@ class EmailClientAdapter {
 			yahoo: {
 				selectors: {
 					body: '#editor-container [contenteditable="true"][role="textbox"]',
-					subject: 'input[placeholder="Subject"][type="text"]',
+					subject: '#compose-subject-input, input[placeholder="Subject"]',
 				},
 				eventTypes: {
 					contentChange: 'input',

--- a/src/scripts/emailClientAdapter.js
+++ b/src/scripts/emailClientAdapter.js
@@ -35,7 +35,7 @@ class EmailClientAdapter {
 			yahoo: {
 				selectors: {
 					body: '#editor-container [contenteditable="true"][role="textbox"]',
-					subject: '#compose-subject-input, input[placeholder="Subject"]',
+					subject: '#compose-subject-input, input[placeholder="Subject"][id="compose-subject-input"]',
 				},
 				eventTypes: {
 					contentChange: 'input',

--- a/src/scripts/emailClientAdapter.js
+++ b/src/scripts/emailClientAdapter.js
@@ -41,7 +41,7 @@ class EmailClientAdapter {
 						// Desktop selectors
 						'#editor-container [contenteditable="true"][role="textbox"]',
 						// Mobile selectors
-						'#editoor-container-mobile [contentditable="true"][role="textbox"]',
+						'#editor-container-mobile [contentditable="true"][role="textbox"]',
 					],
 					subject: [
 						// Desktop selectors


### PR DESCRIPTION
Fixes issue #89 

Changes: Added better selector for mobile like devices or small screen sized devices. This takes care of different UI structure of different screen sizes, specifically in outlook and yahoo

This pr will need a manual rebase after merging of #86

## Summary by Sourcery

Enhance EmailClientAdapter selectors to support both desktop and mobile UI structures in Outlook and Yahoo by converting subject and body selectors into arrays with appropriate fallbacks.

Enhancements:
- Convert Outlook subject selector to an array including both "Subject" and "Add a subject" aria-label variants.
- Convert Yahoo body and subject selectors to arrays with both desktop and mobile-specific selectors.