### PR TITLE
Fix Email Subject Line Modification in Reply Emails

### DIFF
--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -291,7 +291,7 @@ ${userReason}`;
 		else if (projectUrl === 'open-event') project = 'Open Event';
 		return project;
 	}
-	var intervalSubject = setInterval(() => {
+	const intervalSubject = setInterval(() => {
 		if (!window.emailClientAdapter) {
 			return;
 		}
@@ -358,7 +358,9 @@ ${userReason}`;
 
 			// Create and set new subject
 			const newSubject = `[Scrum] ${name} - ${project} - ${dateCode} - False`;
-			console.log('Setting new subject:', newSubject);
+			if (window.DEBUG) {
+				console.log('Setting new subject:', newSubject);
+			}
 
 			scrumSubject.value = newSubject;
 			scrumSubject.dispatchEvent(new Event('input', { bubbles: true }));

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -293,23 +293,20 @@ ${userReason}`;
 	}
 	var intervalSubject = setInterval(() => {
 		if (!window.emailClientAdapter) {
-			console.log('Waiting for email client adapter to initialize...');
 			return;
 		}
 
 		const elements = window.emailClientAdapter.getEditorElements();
 		if (!elements || !elements.subject) {
-			console.log('Waiting for email elements to be ready...');
 			return;
 		}
 
-		// Only proceed if we have all required data
+	
 		if (!githubUserData) {
-			console.log('Waiting for GitHub user data...');
 			return;
 		}
 
-		console.log('All requirements met, initializing subject handling');
+		
 		clearInterval(intervalSubject);
 		scrumSubject = elements.subject;
 
@@ -321,30 +318,30 @@ ${userReason}`;
 
 	function scrumSubjectLoaded() {
 		try {
-			console.log('Starting subject processing...');
+			
 
 			if (!enableToggle) {
-				console.log('Subject modification skipped: extension is disabled');
+				
 				return;
 			}
 
 			if (!scrumSubject) {
-				console.log('Subject element not found, skipping modification');
+				
 				return;
 			}
 
 			// Get the current subject value
 			const currentSubject = scrumSubject.value || '';
-			console.log('Current subject:', currentSubject);
+			
 
 			// Don't modify the subject if it's a reply or already has [Scrum]
 			if (currentSubject.startsWith('Re:')) {
-				console.log('Subject modification skipped: this is a reply email');
+				
 				return;
 			}
 
 			if (currentSubject.includes('[Scrum]')) {
-				console.log('Subject modification skipped: already contains [Scrum]');
+				
 				return;
 			}
 

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -291,22 +291,83 @@ ${userReason}`;
 		else if (projectUrl === 'open-event') project = 'Open Event';
 		return project;
 	}
-	function scrumSubjectLoaded() {
-		if (!enableToggle) return;
+	var intervalSubject = setInterval(() => {
+		if (!window.emailClientAdapter) {
+			console.log('Waiting for email client adapter to initialize...');
+			return;
+		}
+
+		const elements = window.emailClientAdapter.getEditorElements();
+		if (!elements || !elements.subject) {
+			console.log('Waiting for email elements to be ready...');
+			return;
+		}
+
+		// Only proceed if we have all required data
+		if (!githubUserData) {
+			console.log('Waiting for GitHub user data...');
+			return;
+		}
+
+		console.log('All requirements met, initializing subject handling');
+		clearInterval(intervalSubject);
+		scrumSubject = elements.subject;
+
+		// Add a small delay to ensure the subject field is fully initialized
 		setTimeout(() => {
-			var name = githubUserData.name || githubUsername;
-			var project = getProject();
-			var curDate = new Date();
-			var year = curDate.getFullYear().toString();
-			var date = curDate.getDate();
-			var month = curDate.getMonth();
-			month++;
-			if (month < 10) month = '0' + month;
-			if (date < 10) date = '0' + date;
-			var dateCode = year.toString() + month.toString() + date.toString();
-			scrumSubject.value = '[Scrum] ' + name + ' - ' + project + ' - ' + dateCode + ' - False';
+			scrumSubjectLoaded();
+		}, 100);
+	}, 500);
+
+	function scrumSubjectLoaded() {
+		try {
+			console.log('Starting subject processing...');
+
+			if (!enableToggle) {
+				console.log('Subject modification skipped: extension is disabled');
+				return;
+			}
+
+			if (!scrumSubject) {
+				console.log('Subject element not found, skipping modification');
+				return;
+			}
+
+			// Get the current subject value
+			const currentSubject = scrumSubject.value || '';
+			console.log('Current subject:', currentSubject);
+
+			// Don't modify the subject if it's a reply or already has [Scrum]
+			if (currentSubject.startsWith('Re:')) {
+				console.log('Subject modification skipped: this is a reply email');
+				return;
+			}
+
+			if (currentSubject.includes('[Scrum]')) {
+				console.log('Subject modification skipped: already contains [Scrum]');
+				return;
+			}
+
+			// Get user name and project
+			const name = githubUserData.name || githubUsername;
+			const project = getProject();
+
+			// Format date
+			const curDate = new Date();
+			const year = curDate.getFullYear().toString();
+			const month = (curDate.getMonth() + 1).toString().padStart(2, '0');
+			const date = curDate.getDate().toString().padStart(2, '0');
+			const dateCode = year + month + date;
+
+			// Create and set new subject
+			const newSubject = `[Scrum] ${name} - ${project} - ${dateCode} - False`;
+			console.log('Setting new subject:', newSubject);
+
+			scrumSubject.value = newSubject;
 			scrumSubject.dispatchEvent(new Event('input', { bubbles: true }));
-		});
+			} catch (error) {
+			console.error('Error during subject modification:', error);
+		}
 	}
 
 	function writeGithubPrsReviews() {
@@ -442,16 +503,6 @@ ${userReason}`;
 		writeScrumBody();
 	}, 500);
 
-	var intervalSubject = setInterval(() => {
-		if (!githubUserData || !window.emailClientAdapter) return;
-
-		const elements = window.emailClientAdapter.getEditorElements();
-		if (!elements || !elements.subject) return;
-
-		clearInterval(intervalSubject);
-		scrumSubject = elements.subject;
-		scrumSubjectLoaded();
-	}, 500);
 
 	//check for github safe writing for both issues/prs and pr reviews
 	var intervalWriteGithub = setInterval(() => {


### PR DESCRIPTION
Fixes issue #106 - Subject line modification issue in reply emails

This PR fixes the issue where the Scrum Helper extension was incorrectly modifying email subject lines during replies. The extension now properly handles subject lines for new emails and replies separately.


Changes: 
- Preserves original subjects in all reply scenarios
- Only modifies subjects for new scrum emails
- Maintains proper email threading

## Summary by Sourcery

Apply Scrum subject prefix only to new emails while preserving original subjects in replies by detecting reply indicators and existing tags.

Bug Fixes:
- Prevent modification of subject lines in reply emails to maintain original threading.

Enhancements:
- Defer subject initialization until the email editor is ready and skip subjects that start with 'Re:' or already contain '[Scrum]'