### PR TITLE
Docs: added guide for firefox setup in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # SCRUM Helper
 
 **SCRUM Helper** is a Chrome extension designed to simplify writing scrums in Google Groups for FOSSASIA projects. By adding your GitHub username, date range, and other options, it automatically fetches your PRs, Issues, and reviewed PRs via the GitHub API and pre-fills the scrum. You can then edit the scrum to fit your needs.
@@ -12,12 +13,29 @@
 
 ## How to install
 
+### For Chrome:
+
 1. Clone this repository to your local machine.
 2. Go to `chrome://extensions` on your chrome browser.
 3. Enable Developer Mode (toggle in the top-right) if not already.
 4. Click Load unpacked and select the `src` folder inside the cloned repo
 5. Click the Scrum Helper icon on your browser toolbar
 6. Fill in your settings in the popup (GitHub username, date range, etc.)
+
+### For Firefox:
+
+1. Clone this repository to your local machine.
+2. Open Firefox and navigate to `about:debugging`
+3. Click on "This Firefox" in the left sidebar
+4. Click "Load Temporary Add-on..."
+5. Navigate to the `src` folder inside the cloned repo and select the `manifest.json` file
+6. The extension will be loaded temporarily and will remain active only for the current browser session
+7. Click the Scrum Helper icon on your browser toolbar
+8. Fill in your settings in the popup (GitHub username, date range, etc.)
+
+**Note for Firefox users:** The extension will be automatically removed when you close Firefox. You'll need to reload it each time you start a new browser session by repeating steps 2-5.
+
+ If you need to use persistence choose Firefox developer edition it allows persistance on changing xpinstall.signatures.required to false
 
 ## Usage
 
@@ -35,6 +53,7 @@
 - The extension will prefill scrum content for you to edit
 
 ### New Features
+
 1. **Standalone Popup Interface**
    - Generate reports directly from the extension popup
    - Live preview of the report before sending
@@ -56,9 +75,9 @@ $ npm install
 
 ## Screenshots
 
-![SCRUM](/docs/images/scrum.png)
+![SCRUM](docs/images/scrum.png)
 
-![POPUP](/docs/images/popup.png)
+![POPUP](docs/images/popup.png)
 
 ![STANDALONE](docs/images/standalone.png)
 
@@ -70,29 +89,32 @@ Scrum Helper is not limited to the [FOSSASIA](https://github.com/fossasia) organ
 
 1. **Install the Extension**
 
-- Load it into your browser through [Chrome Extension Developer Mode](https://developer.chrome.com/docs/extensions/mv3/getstarted/).
+* For Chrome: Load it into your browser through [Chrome Extension Developer Mode](https://developer.chrome.com/docs/extensions/mv3/getstarted/).
+* For Firefox: Load it as a temporary add-on through `about:debugging` as described above.
 
 2. **Update the Organization**
+   * Currently, the extension uses `org:fossasia` to fetch GitHub issues and PRs.
+   * To make it work with your GitHub organization:
+     * Open `scrumHelper.js` (or wherever the GitHub API URLs are defined).
+     * Replace:
 
-   - Currently, the extension uses `org:fossasia` to fetch GitHub issues and PRs.
-   - To make it work with your GitHub organization:
-     - Open `scrumHelper.js` (or wherever the GitHub API URLs are defined).
-     - Replace:
        ```js
        +org:fossasia+
        ```
+
        with:
+
        ```js
        +org:your-org-name+
        ```
+
        **Example**
        ![Code Snippet ](<Screenshot 2025-05-30 205822.png>)
 
 3. **Build the Extension**
-
-   - Save your changes.
-   - Rebuild or reload the extension in your browser (`chrome://extensions` → Refresh your extension).
-
+   * Save your changes.
+   * For Chrome: Rebuild or reload the extension in your browser (`chrome://extensions` → Refresh your extension).
+   * For Firefox: Reload the temporary add-on by going to `about:debugging` → "This Firefox" → Click "Reload" next to your extension.
 4. **Get Customized SCRUM Reports**
    - The reports will now be generated using contributions from your organization.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 **Note for Firefox users:** The extension will be automatically removed when you close Firefox. You'll need to reload it each time you start a new browser session by repeating steps 2-5.
 
- If you need to use persistence choose Firefox developer edition it allows persistance on changing xpinstall.signatures.required to false
+**Persistence Note:** If you need the extension to persist between sessions, use Firefox Developer Edition. You can enable persistence by setting `xpinstall.signatures.required` to `false` in the browser's configuration.
 
 ## Usage
 


### PR DESCRIPTION
Docs Added #126

## Summary by Sourcery

Add a guide for installing and using the extension in Firefox, including temporary add-on loading and persistence notes, and update README usage instructions and image paths accordingly.

Documentation:
- Add Firefox-specific installation and usage instructions to README with steps for loading a temporary add-on and reloading on each session
- Clarify Chrome vs. Firefox instructions under installation and usage sections
- Note persistence workaround using Firefox Developer Edition and xpinstall.signatures.required flag
- Fix image path formatting for screenshots in documentation