### PR TITLE
Improved navigation, added home button

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -346,6 +346,7 @@ body,input,div,h3,h4,p,label,hr, #scrumReport{
     cursor: pointer;
     display: flex;
     align-items: center;
+    font-size: 1.5rem;
 }
 #homeButton:active {
     background: #e5e7eb;

--- a/src/index.css
+++ b/src/index.css
@@ -339,3 +339,17 @@ body,input,div,h3,h4,p,label,hr, #scrumReport{
 .dark-mode .tooltip-container.tooltip-right .tooltip-bubble::after {
     border-color: transparent #374151 transparent transparent;
 }
+#homeButton {
+    background: none;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+}
+#homeButton:active {
+    background: #e5e7eb;
+}
+.dark-mode #homeButton:active {
+    background: #374151;
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -37,11 +37,11 @@
 						Enable
 					</label>
 					<div class="flex">
-						<button id="homeButton" title="Go to Report" class="ml-1 p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition" style="font-size: 2.5rem;">
-							<i class="fa fa-home text-4xl text-gray-600 dark:text-gray-300"></i>
+						<button id="homeButton" title="Go to Report" class="ml-1 p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition">
+							<i class="fa fa-home text-2xl text-gray-600 dark:text-gray-300"></i>
 						</button>
 						<button id="settingsToggle">
-							<img id="settingsIcon" src="icons/settings-light.png" alt="Settings" class="w-7 h-7 mx-3 cursor-pointer">
+							<img id="settingsIcon" src="icons/settings-light.png" alt="Settings" class="w-6 h-6 mx-3 cursor-pointer">
 						</button>
 					</div>
 			</div>

--- a/src/popup.html
+++ b/src/popup.html
@@ -21,7 +21,7 @@
 	<div class="pl-1 py-4 rounded-2xl">
 		<div class="bg-white px-4 py-4 mx-2 mb-2 rounded-3xl">
 				<div class="flex justify-between py-2">
-					<h3  class="text-3xl font-semibold ">Scrum Helper</h3>
+					<h3 id="scrumHelperHeading" class="text-3xl font-semibold cursor-pointer">Scrum Helper</h3>
 					<img src="icons/night-mode.png" alt="Night Mode" class="w-7 h-7 mx-3 cursor-pointer">
 				</div>
 				<div>
@@ -36,9 +36,14 @@
 						<span class=""></span>
 						Enable
 					</label>
-					<button id="settingsToggle">
-						<img id="settingsIcon" src="icons/settings-light.png" alt="Settings" class="w-7 h-7 mx-3 cursor-pointer">
-					</button>
+					<div class="flex">
+						<button id="homeButton" title="Go to Report" class="ml-1 p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition" style="font-size: 2.5rem;">
+							<i class="fa fa-home text-4xl text-gray-600 dark:text-gray-300"></i>
+						</button>
+						<button id="settingsToggle">
+							<img id="settingsIcon" src="icons/settings-light.png" alt="Settings" class="w-7 h-7 mx-3 cursor-pointer">
+						</button>
+					</div>
 			</div>
 		</div>
 		

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -47,6 +47,13 @@ document.addEventListener('DOMContentLoaded', function() {
     const darkModeToggle = document.querySelector('img[alt="Night Mode"]');
     const settingsIcon = document.getElementById('settingsIcon');
     const body = document.body;
+    const homeButton = document.getElementById('homeButton');
+    const scrumHelperHeading = document.getElementById('scrumHelperHeading');
+    const settingsToggle = document.getElementById('settingsToggle');
+    const reportSection = document.getElementById('reportSection');
+    const settingsSection = document.getElementById('settingsSection');
+
+    let isSettingsVisible = false;
 
     chrome.storage.local.get(['darkMode'], function(result) {
         if(result.darkMode) {
@@ -261,12 +268,6 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    const settingsToggle = document.getElementById('settingsToggle');
-    const reportSection = document.getElementById('reportSection');
-    const settingsSection = document.getElementById('settingsSection');
-
-    let isSettingsVisible = false;
-
     function showReportView() {
         isSettingsVisible = false;
         reportSection.classList.remove('hidden');
@@ -291,6 +292,13 @@ document.addEventListener('DOMContentLoaded', function() {
                 showSettingsView();
             }
         });
+    }
+
+    if (homeButton) {
+        homeButton.addEventListener('click', showReportView);
+    }
+    if (scrumHelperHeading) {
+        scrumHelperHeading.addEventListener('click', showReportView);
     }
 
     showReportView();


### PR DESCRIPTION
### 📌 Fixes

Fixes #139 

---

### 📝 Summary of Changes

Added home button to go back to report section, users can also click the scum helper heading to go back to the reports section. 

---

### 📸 Screenshots / Demo (if UI-related)

![image](https://github.com/user-attachments/assets/d480e449-2513-407f-8ce4-658b7efbc931)

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_

## Summary by Sourcery

Restore navigation to the report section by adding a Home button and making the Scrum Helper heading clickable.

New Features:
- Allow navigation back to the report section via a Home button or by clicking the Scrum Helper heading.

Bug Fixes:
- Fix issue #139 to restore navigation back to the report section.