### PR TITLE
Fetch all github activities

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -212,6 +212,8 @@
 							<li>Please note that some discrepancies may occur in the generated SCRUM. We recommend manually reviewing
 								and editing the report to ensure accuracy before sharing
 							</li>
+							<li><b>Tip:</b> Leave the Organization field blank to fetch <b>all</b> your GitHub activity, not just for
+								a specific organization.</li>
 						</ul>
 					</div>
 				</div>

--- a/src/popup.html
+++ b/src/popup.html
@@ -212,8 +212,7 @@
 							<li>Please note that some discrepancies may occur in the generated SCRUM. We recommend manually reviewing
 								and editing the report to ensure accuracy before sharing
 							</li>
-							<li><b>Tip:</b> Leave the Organization field blank to fetch <b>all</b> your GitHub activity, not just for
-								a specific organization.</li>
+
 						</ul>
 					</div>
 				</div>

--- a/src/popup.html
+++ b/src/popup.html
@@ -135,7 +135,8 @@
 								<i class="fa fa-question-circle question-icon"></i>
 								<span class="tooltip-bubble">
 									<b>Which organization's GitHub activity?</b><br>
-									Enter the GitHub organization name to fetch activites for. Default is <b>fossasia</b>.
+									Enter the GitHub organization name to fetch activities for. Leave empty to fetch all your GitHub
+									activities across all organizations.
 									Organization name is not case-sensitive.
 								</span>
 							</span>
@@ -143,7 +144,7 @@
 						<div class="flex items-center mt-4 gap-2">
 							<input id="orgInput" type="text"
 								class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2"
-								placeholder="Enter organization name(Default: fossasia)">
+								placeholder="Enter organization name">
 							<button id="setOrgBtn" type="button"
 								class="px-5 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-xl text-base my-2 h-[44px] flex-shrink-0"
 								style="min-width:60px;">Set</button>
@@ -174,19 +175,23 @@
 								<i id="tokenEyeIcon" class="fa fa-eye text-gray-600"></i>
 							</button>
 						</div>
-						<input id="githubToken" type="password" class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2 pr-10" placeholder="Required for making authenticated requests">
+						<input id="githubToken" type="password"
+							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2 pr-10"
+							placeholder="Required for making authenticated requests">
 
-						
+
 
 						<div class="col s12 my-4 ">
 							<div class="flex items-center gap-2">
 								<input type="checkbox" id="showCommits" checked class="form-checkbox h-4 w-4 text-blue-600 ">
-								<label id="showCommitsLabel" for="showCommits" class="text-gray-700 font-medium text-sm flex items-center gap-1 ">Show commits made within date range in Open PRs</label> <span class="tooltip-container">
-								<i class="fa fa-question-circle question-icon"></i>
-								<span class="tooltip-bubble">
-									Github Token required.
+								<label id="showCommitsLabel" for="showCommits"
+									class="text-gray-700 font-medium text-sm flex items-center gap-1 ">Show commits made within date range
+									in Open PRs</label> <span class="tooltip-container">
+									<i class="fa fa-question-circle question-icon"></i>
+									<span class="tooltip-bubble">
+										Github Token required.
+									</span>
 								</span>
-							</span>
 							</div>
 						</div>
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -366,9 +366,9 @@ document.addEventListener('DOMContentLoaded', function () {
         // }
         console.log('[Org Check] Checking organization:', org);
         if (!org) {
-            // If org is empty, clear orgName in storage and fetch all user activity
+            // If org is empty, clear orgName in storage but don't auto-generate report
             chrome.storage.local.set({ orgName: '' }, function () {
-                if (window.generateScrumReport) window.generateScrumReport();
+                console.log('[Org Check] Organization cleared from storage');
             });
             return;
         }
@@ -406,9 +406,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 const oldToast = document.getElementById('invalid-org-toast');
                 if (oldToast) oldToast.parentNode.removeChild(oldToast);
                 console.log('[Org Check] Organization exists on GitHub:', org);
-                // Valid org: update storage and fetch data
+                // Valid org: update storage but don't auto-generate report
                 chrome.storage.local.set({ orgName: org }, function () {
-                    if (window.generateScrumReport) window.generateScrumReport();
+                    console.log('[Org Check] Organization saved to storage:', org);
                 });
             })
             .catch((err) => {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -295,7 +295,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     endDateInput.value = getToday();
                 }
                 startDateInput.readOnly = endDateInput.readOnly = true;
-    
+
                 chrome.storage.local.set({
                     startingDate: startDateInput.value,
                     endingDate: endDateInput.value,

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -360,10 +360,18 @@ document.addEventListener('DOMContentLoaded', function () {
     // Validate and set org as user types
     const handleOrgInput = debounce(function () {
         let org = orgInput.value.trim().toLowerCase();
-        if (!org) {
-            org = 'fossasia';
-        }
+        // Do not default to any org, allow empty string
+        // if (!org) {
+        //     org = 'fossasia';
+        // }
         console.log('[Org Check] Checking organization:', org);
+        if (!org) {
+            // If org is empty, clear orgName in storage and fetch all user activity
+            chrome.storage.local.set({ orgName: '' }, function () {
+                if (window.generateScrumReport) window.generateScrumReport();
+            });
+            return;
+        }
         fetch(`https://api.github.com/orgs/${org}`)
             .then(res => {
                 console.log('[Org Check] Response status for', org, ':', res.status);

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -129,7 +129,7 @@ document.addEventListener('DOMContentLoaded', function () {
             'githubToken',
             'projectName',
             'settingsToggle',
-            
+
         ];
 
         const radios = document.querySelectorAll('input[name="timeframe"]');
@@ -217,9 +217,7 @@ document.addEventListener('DOMContentLoaded', function () {
         generateBtn.addEventListener('click', function () {
             // Check org input value before generating report
             let org = orgInput.value.trim().toLowerCase();
-            if (!org) {
-                org = 'fossasia';
-            }
+            // Allow empty org to fetch all GitHub activities
             chrome.storage.local.set({ orgName: org }, () => {
                 generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
                 generateBtn.disabled = true;
@@ -379,9 +377,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // Auto-update orgName in storage on input change
     orgInput.addEventListener('input', function () {
         let org = orgInput.value.trim().toLowerCase();
-        if (!org) {
-            org = 'fossasia';
-        }
+        // Allow empty org to fetch all GitHub activities
         chrome.storage.local.set({ orgName: org }, function () {
             chrome.storage.local.remove('githubCache'); // Clear cache on org change
         });

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -566,16 +566,10 @@ function allIncluded(outputTarget = 'email') {
 		// For popup context, immediately process the data
 		if (outputTarget === 'popup') {
 			log('Processing data for popup context');
-			if (githubIssuesData) {
-				log('Calling writeGithubIssuesPrs');
-				writeGithubIssuesPrs();
-			} else {
+			if (!githubIssuesData) {
 				logError('No githubIssuesData available for popup processing');
 			}
-			if (githubPrsReviewData) {
-				log('Calling writeGithubPrsReviews');
-				writeGithubPrsReviews();
-			} else {
+			if (!githubPrsReviewData) {
 				logError('No githubPrsReviewData available for popup processing');
 			}
 		} else {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -18,11 +18,6 @@ let scrumGenerationInProgress = false;
 let orgName = '';
 
 function allIncluded(outputTarget = 'email') {
-
-		
-
-	
-
     if (scrumGenerationInProgress) {
         console.warn('[SCRUM-HELPER]: Scrum generation already in progress, aborting new call.');
         return;
@@ -182,10 +177,10 @@ function allIncluded(outputTarget = 'email') {
                     log('Restored cache from storage');
                 }
 
-               if (typeof items.orgName !== 'undefined') {
-					orgName = items.orgName || '';
-					console.log('[SCRUM-HELPER] orgName set to:', orgName);
-				}
+                if (typeof items.orgName !== 'undefined') {
+                    orgName = items.orgName || '';
+                    console.log('[SCRUM-HELPER] orgName set to:', orgName);
+                }
             },
         );
     }
@@ -332,7 +327,7 @@ function allIncluded(outputTarget = 'email') {
     }
 
     async function fetchGithubData() {
-       	const cacheKey = `${githubUsername}-${startingDate}-${endingDate}-${orgName || 'all'}`;
+        const cacheKey = `${githubUsername}-${startingDate}-${endingDate}-${orgName || 'all'}`;
 
         if (githubCache.fetching || (githubCache.cacheKey === cacheKey && githubCache.data)) {
             log('Fetch already in progress or data already fetched. Skipping fetch.');
@@ -404,19 +399,19 @@ function allIncluded(outputTarget = 'email') {
             log('Making public requests');
         }
 
-       	// Build org part for query only if orgName is set and not empty
-		console.log('[SCRUM-HELPER] orgName before API query:', orgName);
-		console.log('[SCRUM-HELPER] orgName type:', typeof orgName);
-		console.log('[SCRUM-HELPER] orgName length:', orgName ? orgName.length : 0);
-		let orgPart = orgName && orgName.trim() ? `+org%3A${orgName}` : '';
-		console.log('[SCRUM-HELPER] orgPart for API:', orgPart);
-		console.log('[SCRUM-HELPER] orgPart length:', orgPart.length);
-		let issueUrl = `https://api.github.com/search/issues?q=author%3A${githubUsername}${orgPart}+created%3A${startingDate}..${endingDate}&per_page=100`;
-		let prUrl = `https://api.github.com/search/issues?q=commenter%3A${githubUsername}${orgPart}+updated%3A${startingDate}..${endingDate}&per_page=100`;
-		console.log('[SCRUM-HELPER] issueUrl:', issueUrl);
-		console.log('[SCRUM-HELPER] prUrl:', prUrl);
-		let userUrl = `https://api.github.com/users/${githubUsername}`;
-        
+        // Build org part for query only if orgName is set and not empty
+        console.log('[SCRUM-HELPER] orgName before API query:', orgName);
+        console.log('[SCRUM-HELPER] orgName type:', typeof orgName);
+        console.log('[SCRUM-HELPER] orgName length:', orgName ? orgName.length : 0);
+        let orgPart = orgName && orgName.trim() ? `+org%3A${orgName}` : '';
+        console.log('[SCRUM-HELPER] orgPart for API:', orgPart);
+        console.log('[SCRUM-HELPER] orgPart length:', orgPart.length);
+        let issueUrl = `https://api.github.com/search/issues?q=author%3A${githubUsername}${orgPart}+updated%3A${startingDate}..${endingDate}&per_page=100`;
+        let prUrl = `https://api.github.com/search/issues?q=commenter%3A${githubUsername}${orgPart}+updated%3A${startingDate}..${endingDate}&per_page=100`;
+        console.log('[SCRUM-HELPER] issueUrl:', issueUrl);
+        console.log('[SCRUM-HELPER] prUrl:', prUrl);
+        let userUrl = `https://api.github.com/users/${githubUsername}`;
+
         try {
             // throttling 500ms to avoid burst
             await new Promise(res => setTimeout(res, 500));
@@ -681,7 +676,6 @@ function allIncluded(outputTarget = 'email') {
             let content;
             if (lastWeekContribution == true || yesterdayContribution == true) {
                 content = `<b>1. What did I do ${weekOrDay}?</b><br>
-
 ${lastWeekUl}<br>
 <b>2. What do I plan to do ${weekOrDay2}?</b><br>
 ${nextWeekUl}<br>

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -2,7 +2,7 @@ console.log('Script loaded, adapter exists:', !!window.emailClientAdapter);
 let refreshButton_Placed = false;
 let enableToggle = true;
 let hasInjectedContent = false;
-let orgName = 'fossasia'; // default
+let orgName = '';
 function allIncluded(outputTarget = 'email') {
 	console.log('allIncluded called with outputTarget:', outputTarget);
 	console.log('Current window context:', window.location.href);
@@ -86,7 +86,7 @@ function allIncluded(outputTarget = 'email') {
 				}
 				if (items.githubUsername) {
 					githubUsername = items.githubUsername;
-					console.log("About to fetch GitHub data for:", githubUsername);
+					console.log('[SCRUM-HELPER] About to fetch GitHub data for:', githubUsername, 'with orgName:', orgName);
 					fetchGithubData();
 				} else {
 					if (outputTarget === 'popup') {
@@ -134,8 +134,11 @@ function allIncluded(outputTarget = 'email') {
 					githubCache.timestamp = items.githubCache.timestamp;
 					log('Restored cache from storage');
 				}
-				if (items.orgName) {
-					orgName = items.orgName;
+				// LOG: orgName from storage
+				console.log('[SCRUM-HELPER] orgName from storage:', items.orgName);
+				if (typeof items.orgName !== 'undefined') {
+					orgName = items.orgName || '';
+					console.log('[SCRUM-HELPER] orgName set to:', orgName);
 				}
 			},
 		);
@@ -360,9 +363,13 @@ function allIncluded(outputTarget = 'email') {
 		}
 
 		// Build org part for query only if orgName is set and not empty
+		console.log('[SCRUM-HELPER] orgName before API query:', orgName);
 		let orgPart = orgName && orgName.trim() ? `+org%3A${orgName}` : '';
+		console.log('[SCRUM-HELPER] orgPart for API:', orgPart);
 		let issueUrl = `https://api.github.com/search/issues?q=author%3A${githubUsername}${orgPart}+created%3A${startingDate}..${endingDate}&per_page=100`;
 		let prUrl = `https://api.github.com/search/issues?q=commenter%3A${githubUsername}${orgPart}+updated%3A${startingDate}..${endingDate}&per_page=100`;
+		console.log('[SCRUM-HELPER] issueUrl:', issueUrl);
+		console.log('[SCRUM-HELPER] prUrl:', prUrl);
 		let userUrl = `https://api.github.com/users/${githubUsername}`;
 
 		try {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -359,8 +359,10 @@ function allIncluded(outputTarget = 'email') {
 			log('Making public requests');
 		}
 
-		let issueUrl = `https://api.github.com/search/issues?q=author%3A${githubUsername}+org%3A${orgName}+created%3A${startingDate}..${endingDate}&per_page=100`;
-		let prUrl = `https://api.github.com/search/issues?q=commenter%3A${githubUsername}+org%3A${orgName}+updated%3A${startingDate}..${endingDate}&per_page=100`;
+		// Build org part for query only if orgName is set and not empty
+		let orgPart = orgName && orgName.trim() ? `+org%3A${orgName}` : '';
+		let issueUrl = `https://api.github.com/search/issues?q=author%3A${githubUsername}${orgPart}+created%3A${startingDate}..${endingDate}&per_page=100`;
+		let prUrl = `https://api.github.com/search/issues?q=commenter%3A${githubUsername}${orgPart}+updated%3A${startingDate}..${endingDate}&per_page=100`;
 		let userUrl = `https://api.github.com/users/${githubUsername}`;
 
 		try {


### PR DESCRIPTION
### 📌 Fixes

Fixes #142

---

### 📝 Summary of Changes

- Fetch all your GitHub activities on public repositories when the organization name is not provided.

---

### 📸 Screenshots / Demo (if UI-related)

![image](https://github.com/user-attachments/assets/ec97074b-acc2-40ce-87bc-013bee4b6176)


---

### ✅ Checklist

- [ ] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [ ] My code follows the project’s code style guidelines

## Summary by Sourcery

Allow fetching GitHub activities from all public repositories by making the organization filter optional, updating cache keys and query construction accordingly, and enhancing the popup input handling and debug logging

New Features:
- Fetch user GitHub activities across all public repositories when no organization is specified

Enhancements:
- Include organization name in cache key and API payload to separate caches per organization
- Omit the `org:` filter in GitHub API queries when the organization name is empty
- Allow clearing the organization input in the popup to reset orgName and fetch across all public repos
- Add extensive console logging throughout the data fetch, processing, and rendering functions for improved debugging and traceability