### PR TITLE
Date bug

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -269,9 +269,28 @@ document.addEventListener('DOMContentLoaded', function () {
         chrome.storage.local.get([
             'selectedTimeframe',
             'lastWeekContribution',
-            'yesterdayContribution'
+            'yesterdayContribution',
+            'startingDate',
+            'endingDate',
         ], (items) => {
             console.log('Restoring state:', items);
+
+            if(items.startingDate && items.endingDate && !items.lastWeekContribution && !items.yesterdayContribution) {
+                const startDateInput = document.getElementById('startingDate');
+                const endDateInput = document.getElementById('endingDate');
+
+                if(startDateInput && endDateInput) {
+                    startDateInput.value = items.startingDate;
+                    endDateInput.value = items.endingDate;
+                    startDateInput.readOnly = false;
+                    endDateInput.readOnly = false;
+                }
+                document.querySelectorAll('input[name="timeframe"]').forEach(radio => {
+                    radio.checked = false;
+                    radio.dataset.wasChecked = 'false';
+                })
+                return;
+            }
 
             if (!items.selectedTimeframe) {
                 items.selectedTimeframe = 'yesterdayContribution';

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -122,7 +122,7 @@ function allIncluded(outputTarget = 'email') {
 					handleLastWeekContributionChange();
 				} else if (items.yesterdayContribution) {
 					handleYesterdayContributionChange();
-				} else if (items.startDate && items.endingDate) {
+				} else if (items.startingDate && items.endingDate) {
 					startingDate = items.startingDate;
 					endingDate = items.endingDate;
 				} else {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -126,7 +126,7 @@ function allIncluded(outputTarget = 'email') {
 					startingDate = items.startingDate;
 					endingDate = items.endingDate;
 				} else {
-					handleLastWeekContributionChange(); //when no date is stored, i.e on fresh unpack - default to last week.
+					handleLastWeekContributionChange(); //when no date is stored i.e on fresh unpack - default to last week.
 					if (outputTarget === 'popup') {
 						chrome.storage.local.set({ lastWeekContribution: true, yesterdayContribution: false });
 					}


### PR DESCRIPTION
### 📌 Fixes

Fixes #172 
Fixes #170 

---

### 📝 Summary of Changes

Custom dates are now being preserved and data is also being fetched in accordance to those without resetting the dates to either of the radios.

---

### 📸 Screenshots / Demo (if UI-related)

![image](https://github.com/user-attachments/assets/8ba1e0ce-f06b-47c2-bf57-e5e21b77363d)

---

### ✅ Checklist

- [ ] I’ve tested my changes locally
- [ ] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_

## Summary by Sourcery

Restore and preserve custom date range selection on popup load, ensure data is fetched using the saved custom dates, and fix property name mismatch in the date restoration logic.

Bug Fixes:
- Retain saved custom date ranges and apply them on popup load instead of defaulting to preset timeframes
- Correct the property name mismatch by using 'startingDate' instead of 'startDate' when restoring stored dates

Enhancements:
- Uncheck timeframe radio buttons and enable custom date inputs when a stored date range is detected