### PR TITLE
remove blockers from the ui

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -28,7 +28,8 @@
 				<img src="icons/night-mode.png" alt="Night Mode" class="w-7 h-7 mx-3 cursor-pointer">
 			</div>
 			<div>
-				<p class="">Report your development progress by auto-fetching your Git activity for a selected period</p>
+				<p class="">Report your development progress by auto-fetching your Git activity for a selected period
+				</p>
 			</div>
 
 			<div class="center mt-2 flex justify-between">
@@ -61,7 +62,8 @@
 						<h4>Your Project Name<span class="tooltip-container ml-2">
 								<i class="fa fa-question-circle question-icon"></i>
 								<span class="tooltip-bubble">
-									This is the name that appears in the subject line of your email, followed by timestamp.
+									This is the name that appears in the subject line of your email, followed by
+									timestamp.
 								</span>
 							</span> </h4>
 						<input id="projectName" type="text"
@@ -102,16 +104,26 @@
 
 					<div class="col s12">
 						<br />
-						<input type="checkbox" id="showOpenLabel" class="form-checkbox h-4 w-4 text-blue-600">
-						<label id="checkboxLabel" for="showOpenLabel" class="text-gray-700 font-medium text-sm">Show Open/Closed
-							Label</label>
+						<input type="checkbox" id="showOpenLabel" class="form-checkbox text-blue-600">
+						<label id="checkboxLabel" for="showOpenLabel" class="text-gray-700 font-medium text-sm"> Show
+							Open/Merged/Closed Labels</label>
 					</div>
-					<div class="my-4">
-						<p class="text-sm font-medium">What is blocking you from making progress?</p>
-						<input id="userReason" type="text" class="w-full text-gray-800 mt-3 rounded-xl px-4 py-1"
-							placeholder="Enter your reason">
-						<hr class="border-t-2 border-gray-700 mt-1 ">
+
+					<div class="col s12 my-4">
+						<div class="flex items-center gap-2">
+							<input type="checkbox" id="showCommits" checked class="form-checkbox text-blue-600 ">
+							<label id="showCommitsLabel" for="showCommits"
+								class="text-gray-700 font-medium text-sm flex items-center gap-1 ">Show commits on open PRs<span
+									class="tooltip-container">
+									<i class="fa fa-question-circle question-icon"></i>
+									<span class="tooltip-bubble">
+										Github Token required, add it in the settings.
+									</span>
+								</span></label>
+						</div>
 					</div>
+
+
 					<div>
 						<div>
 							<h6 class="text-base font-semibold">Scrum Report</h6>
@@ -140,7 +152,8 @@
 								<i class="fa fa-question-circle question-icon"></i>
 								<span class="tooltip-bubble">
 									<b>Which organization's GitHub activity?</b><br>
-									Enter the GitHub organization name to fetch activities for. Leave empty to fetch all your GitHub
+									Enter the GitHub organization name to fetch activities for. Leave empty to fetch all
+									your GitHub
 									activities across all organizations.
 									Organization name is not case-sensitive.
 								</span>
@@ -163,13 +176,17 @@
 									<i class="fa fa-question-circle question-icon"></i>
 									<span class="tooltip-bubble">
 										<b>Why is it recommended to add a GitHub token?</b><br>
-										Scrum Helper works without a GitHub token, but adding a personal access token is recommended for a
-										better experience. It raises your API limits, allows access to private repos (if permitted), and
-										improves accuracy and speed. Tokens are stored locally and never sent to us and used only to fetch
+										Scrum Helper works without a GitHub token, but adding a personal access token is
+										recommended for a
+										better experience. It raises your API limits, allows access to private repos (if
+										permitted), and
+										improves accuracy and speed. Tokens are stored locally and never sent to us and
+										used only to fetch
 										your git data. You can add one anytime in the extension settings.<br><br>
 										<b>How to obtain:</b><br>
 										1. Go to <a href="https://github.com/settings/tokens" target="_blank"
-											style="color:#2563eb;text-decoration:underline;">GitHub Developer Settings</a>.<br>
+											style="color:#2563eb;text-decoration:underline;">GitHub Developer
+											Settings</a>.<br>
 										3. Click "Generate new token", select classic token<br>
 										4. Paste it here.<br>
 										<i>Keep your token secret!</i>
@@ -185,27 +202,15 @@
 							placeholder="Required for making authenticated requests">
 
 
-
-						<div class="col s12 my-4 ">
-							<div class="flex items-center gap-2">
-								<input type="checkbox" id="showCommits" checked class="form-checkbox h-4 w-4 text-blue-600 ">
-								<label id="showCommitsLabel" for="showCommits"
-									class="text-gray-700 font-medium text-sm flex items-center gap-1 ">Show commits made within date range
-									in Open PRs</label> <span class="tooltip-container">
-									<i class="fa fa-question-circle question-icon"></i>
-									<span class="tooltip-bubble">
-										Github Token required.
-									</span>
-								</span>
-							</div>
-						</div>
-
-						<p class="text-sm font-medium">Enter cache TTL <span class="text-sm font-normal">(in minutes)</span>
+						<p class="text-sm font-medium">Enter cache TTL <span class="text-sm font-normal">(in
+								minutes)</span>
 							<span class="tooltip-container">
 								<i class="fa fa-question-circle question-icon"></i>
 								<span class="tooltip-bubble">
-									We are caching the data to avoid redundant calls. By default the cache expires after 10 minutes, you
-									can change it here to your desired time. We have given a refresh cache button in case you want to
+									We are caching the data to avoid redundant calls. By default the cache expires after
+									10 minutes, you
+									can change it here to your desired time. We have given a refresh cache button in
+									case you want to
 									fetch fresh data right now.
 								</span>
 							</span>
@@ -234,11 +239,15 @@
 					<div>
 						<h4 class="font-semibold text-xl">Note:</h4>
 						<ul class="text-xs list-disc list-inside">
-							<li>The PRs fetched are based on the most recent review by any contributor. If you reviewed a PR 10 days
-								ago and someone else reviewed it 2 days ago, it will still appear in your activity for the past week.
-								(<a target="_blank" href="https://github.com/fossasia/scrum_helper/issues/20">See this issue</a>.)
+							<li>The PRs fetched are based on the most recent review by any contributor. If you reviewed
+								a PR 10 days
+								ago and someone else reviewed it 2 days ago, it will still appear in your activity for
+								the past week.
+								(<a target="_blank" href="https://github.com/fossasia/scrum_helper/issues/20">See this
+									issue</a>.)
 							</li>
-							<li>Please note that some discrepancies may occur in the generated SCRUM. We recommend manually reviewing
+							<li>Please note that some discrepancies may occur in the generated SCRUM. We recommend
+								manually reviewing
 								and editing the report to ensure accuracy before sharing
 							</li>
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -8,7 +8,7 @@ let yesterdayContributionElement = document.getElementById('yesterdayContributio
 let startingDateElement = document.getElementById('startingDate');
 let endingDateElement = document.getElementById('endingDate');
 let showOpenLabelElement = document.getElementById('showOpenLabel');
-let userReasonElement = document.getElementById('userReason');
+let userReasonElement = null; // userReason element removed from UI
 let showCommitsElement = document.getElementById('showCommits');
 
 function handleBodyOnLoad() {
@@ -60,9 +60,7 @@ function handleBodyOnLoad() {
 				showOpenLabelElement.checked = true;
 				handleOpenLabelChange();
 			}
-			if (items.userReason) {
-				userReasonElement.value = items.userReason;
-			}
+
 			if (items.lastWeekContribution) {
 				lastWeekContributionElement.checked = items.lastWeekContribution;
 				handleLastWeekContributionChange();
@@ -79,7 +77,7 @@ function handleBodyOnLoad() {
 				yesterdayContributionElement.checked = true;
 				handleYesterdayContributionChange();
 			}
-			if (items.showCommits){
+			if (items.showCommits) {
 				showCommitsElement.checked = items.showCommits;
 			} else {
 				showCommitsElement.checked = false;
@@ -245,14 +243,11 @@ function handleOpenLabelChange() {
 	chrome.storage.local.set({ showOpenLabel: value });
 }
 
-function handleUserReasonChange() {
-	let value = userReasonElement.value;
-	chrome.storage.local.set({ userReason: value });
-}
+
 
 function handleShowCommitsChange() {
-    let value = showCommitsElement.checked;
-    chrome.storage.local.set({ showCommits: value });
+	let value = showCommitsElement.checked;
+	chrome.storage.local.set({ showCommits: value });
 }
 
 enableToggleElement.addEventListener('change', handleEnableChange);
@@ -266,5 +261,5 @@ endingDateElement.addEventListener('change', handleEndingDateChange);
 lastWeekContributionElement.addEventListener('change', handleLastWeekContributionChange);
 yesterdayContributionElement.addEventListener('change', handleYesterdayContributionChange);
 showOpenLabelElement.addEventListener('change', handleOpenLabelChange);
-userReasonElement.addEventListener('keyup', handleUserReasonChange);
+// userReasonElement event listener removed - element no longer exists in UI
 document.addEventListener('DOMContentLoaded', handleBodyOnLoad);

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -119,7 +119,6 @@ document.addEventListener('DOMContentLoaded', function () {
         const elementsToToggle = [
             'startingDate',
             'endingDate',
-            'userReason',
             'generateReport',
             'copyReport',
             'refreshCache',

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -90,25 +90,24 @@ function allIncluded(outputTarget = 'email') {
                 if (outputTarget === 'popup') {
                     const usernameFromDOM = document.getElementById('githubUsername')?.value;
                     const projectFromDOM = document.getElementById('projectName')?.value;
-                    const reasonFromDOM = document.getElementById('userReason')?.value;
                     const tokenFromDOM = document.getElementById('githubToken')?.value;
 
                     items.githubUsername = usernameFromDOM || items.githubUsername;
                     items.projectName = projectFromDOM || items.projectName;
-                    items.userReason = reasonFromDOM || items.userReason;
                     items.githubToken = tokenFromDOM || items.githubToken;
 
                     chrome.storage.local.set({
                         githubUsername: items.githubUsername,
                         projectName: items.projectName,
-                        userReason: items.userReason,
                         githubToken: items.githubToken
                     });
                 }
 
                 githubUsername = items.githubUsername;
                 projectName = items.projectName;
-                userReason = items.userReason || 'No Blocker at the moment';
+
+                userReason = 'No Blocker at the moment';
+                chrome.storage.local.remove(['userReason']);
                 githubToken = items.githubToken;
                 lastWeekContribution = items.lastWeekContribution;
                 yesterdayContribution = items.yesterdayContribution;
@@ -361,7 +360,7 @@ function allIncluded(outputTarget = 'email') {
         const isCacheKeyMatch = githubCache.cacheKey === cacheKey;
         const needsToken = !!githubToken;
         const cacheUsedToken = !!githubCache.usedToken;
-        if (githubCache.data && isCacheFresh && isCacheKeyMatch) { 
+        if (githubCache.data && isCacheFresh && isCacheKeyMatch) {
             if (needsToken && !cacheUsedToken) {
                 log('Cache was fetched without token, but user now has a token. Invalidating cache.');
                 githubCache.data = null;


### PR DESCRIPTION
### 📌 Fixes

Fixes #190
---

### 📝 Summary of Changes

- Removed the blockers question from the ui
- The question is visible in the email clients as it is where user can edit that.

---

### 📸 Screenshots / Demo (if UI-related)
<img width="431" height="728" alt="image" src="https://github.com/user-attachments/assets/67329f3c-e662-4cd5-bf22-d4e322275551" />
<img width="765" height="700" alt="image" src="https://github.com/user-attachments/assets/b794a240-e835-4440-b2d0-9f9ea9363abf" />

---

### ✅ Checklist

- [ ] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [ ] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_

## Summary by Sourcery

Remove the blockers section from the popup UI and underlying code, and update related labels and formatting

Bug Fixes:
- Remove blocker input field and associated storage/event listener logic

Enhancements:
- Rename 'Show Open/Closed Label' to 'Show Open/Merged/Closed Labels'
- Reposition 'Show commits on open PRs' checkbox with tooltip for GitHub token requirement
- Clean up paragraph breaks and tooltip formatting in the popup UI