### PR TITLE
fixed behaviour of open /closed checbox

### DIFF
--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -924,7 +924,7 @@ ${userReason}`;
                     let prText = '';
                     prText +=
                         "<a href='" + pr_arr.html_url + "' target='_blank'>#" + pr_arr.number + '</a> (' + pr_arr.title + ') ';
-                    if (pr_arr.state === 'open') prText += issue_opened_button;
+                    if (showOpenLabel && pr_arr.state === 'open') prText += issue_opened_button;
                     // Do not show closed label for reviewed PRs
                     prText += '&nbsp;&nbsp;';
                     repoLi += prText;
@@ -942,7 +942,7 @@ ${userReason}`;
                         '</a> (' +
                         pr_arr1.title +
                         ') ';
-                    if (pr_arr1.state === 'open') prText1 += issue_opened_button;
+                    if (showOpenLabel && pr_arr1.state === 'open') prText1 += issue_opened_button;
                     // Do not show closed label for reviewed PRs
                     prText1 += '&nbsp;&nbsp;</li>';
                     repoLi += prText1;
@@ -1074,9 +1074,9 @@ ${userReason}`;
                 } else { }
                 const prAction = isNewPR ? 'Made PR' : 'Existing PR';
                 if (isDraft) {
-                    li = `<li><i>(${project})</i> - Made PR (#${number}) - <a href='${html_url}'>${title}</a> ${pr_draft_button}</li>`;
+                    li = `<li><i>(${project})</i> - Made PR (#${number}) - <a href='${html_url}'>${title}</a>${showOpenLabel ? ' ' + pr_draft_button : ''}</li>`;
                 } else if (item.state === 'open') {
-                    li = `<li><i>(${project})</i> - ${prAction} (#${number}) - <a href='${html_url}'>${title}</a> ${pr_open_button}`;
+                    li = `<li><i>(${project})</i> - ${prAction} (#${number}) - <a href='${html_url}'>${title}</a>${showOpenLabel ? ' ' + pr_open_button : ''}`;
                     if (showCommits && item._allCommits && item._allCommits.length && !isNewPR) {
                         log(`[PR DEBUG] Rendering commits for existing PR #${number}:`, item._allCommits);
                         item._allCommits.forEach(commit => {
@@ -1093,9 +1093,9 @@ ${userReason}`;
                         merged = mergedStatusResults[`${owner}/${repo}#${number}`];
                     }
                     if (merged === true) {
-                        li = `<li><i>(${project})</i> - Made PR (#${number}) - <a href='${html_url}'>${title}</a> ${pr_merged_button}</li>`;
+                        li = `<li><i>(${project})</i> - Made PR (#${number}) - <a href='${html_url}'>${title}</a>${showOpenLabel ? ' ' + pr_merged_button : ''}</li>`;
                     } else {
-                        li = `<li><i>(${project})</i> - Made PR (#${number}) - <a href='${html_url}'>${title}</a> ${pr_closed_button}</li>`;
+                        li = `<li><i>(${project})</i> - Made PR (#${number}) - <a href='${html_url}'>${title}</a>${showOpenLabel ? ' ' + pr_closed_button : ''}</li>`;
                     }
                 }
                 lastWeekArray.push(li);
@@ -1112,16 +1112,15 @@ ${userReason}`;
                         html_url +
                         "' target='_blank'>" +
                         title +
-                        '</a> ' +
-                        issue_opened_button +
+                        '</a>' + (showOpenLabel ? ' ' + issue_opened_button : '') +
                         '&nbsp;&nbsp;</li>';
                     nextWeekArray.push(li2);
                 }
                 if (item.state === 'open') {
-                    li = `<li><i>(${project})</i> - Opened Issue(#${number}) - <a href='${html_url}'>${title}</a> ${issue_opened_button}</li>`;
+                    li = `<li><i>(${project})</i> - Opened Issue(#${number}) - <a href='${html_url}'>${title}</a>${showOpenLabel ? ' ' + issue_opened_button : ''}</li>`;
                 } else if (item.state === 'closed') {
                     // Always show closed label for closed issues
-                    li = `<li><i>(${project})</i> - Opened Issue(#${number}) - <a href='${html_url}'>${title}</a> ${issue_closed_button}</li>`;
+                    li = `<li><i>(${project})</i> - Opened Issue(#${number}) - <a href='${html_url}'>${title}</a>${showOpenLabel ? ' ' + issue_closed_button : ''}</li>`;
                 } else {
                     li =
                         '<li><i>(' +


### PR DESCRIPTION
### 📌 Fixes

Fixes #194 

---

### 📝 Summary of Changes

- Showing labels only on open/closed/merged checkbox selection and not shown when unchecked.
- Corrected the behaviour of open/closed/merged label checkbox.

---

### 📸 Screenshots / Demo (if UI-related)

<img width="447" height="722" alt="image" src="https://github.com/user-attachments/assets/b9e3a5c0-78aa-4572-a7b7-f64a10b3308e" />

---

### ✅ Checklist

- [ ] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [ ] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_

## Summary by Sourcery

Bug Fixes:
- Wrap all open, closed, merged and draft button insertions in showOpenLabel checks to fix open/closed checkbox behavior across PR and issue entries.