### PR TITLE
Minor: Manual deploy

### DIFF
--- a/.github/workflows/publish-chrome.yml
+++ b/.github/workflows/publish-chrome.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Create ZIP file
         run: |
           cd src
-          zip -r ../extension.zip . -x "*.DS_Store" # Corrected from 'extensionn.zip'
+          zip -r ../extension.zip . -x "*.DS_Store" 
         # This command zips the contents of src directory
 
       - name: Upload to Chrome Web Store

--- a/.github/workflows/publish-chrome.yml
+++ b/.github/workflows/publish-chrome.yml
@@ -1,10 +1,10 @@
 name: Publish to Chrome Web Store
 
 on:
-  workflow_dispatch: #This allows the worklfow to be triggered manually
+  workflow_dispatch: # This allows the workflow to be triggered manually
 
 jobs:
-  pubish:
+  publish: 
     name: Publish Extension
     runs-on: ubuntu-latest
 
@@ -23,7 +23,7 @@ jobs:
       - name: Create ZIP file
         run: |
           cd src
-          zip -r ../extensionn.zip . -x "*.DS_Store"
+          zip -r ../extension.zip . -x "*.DS_Store" # Corrected from 'extensionn.zip'
         # This command zips the contents of src directory
 
       - name: Upload to Chrome Web Store

--- a/.github/workflows/publish-chrome.yml
+++ b/.github/workflows/publish-chrome.yml
@@ -1,0 +1,36 @@
+name: Publish to Chrome Web Store
+
+on:
+  workflow_dispatch: #This allows the worklfow to be triggered manually
+
+jobs:
+  pubish:
+    name: Publish Extension
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Create ZIP file
+        run: |
+          cd src
+          zip -r ../extensionn.zip . -x "*.DS_Store"
+        # This command zips the contents of src directory
+
+      - name: Upload to Chrome Web Store
+        uses: w3c/chrome-webstore-upload-action@v1
+        with:
+          extension-id: ${{ secrets.CHROME_EXTENSION_ID }}
+          client-id: ${{ secrets.CHROME_CLIENT_ID }}
+          client-secret: ${{ secrets.CHROME_CLIENT_SECRET }}
+          refresh-token: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          zip-file: extension.zip

--- a/.github/workflows/publish-chrome.yml
+++ b/.github/workflows/publish-chrome.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: # This allows the workflow to be triggered manually
 
 jobs:
-  publish: 
+  publish:
     name: Publish Extension
     runs-on: ubuntu-latest
 
@@ -20,11 +20,13 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Build the extension
+        run: npm run build
+
       - name: Create ZIP file
         run: |
-          cd src
-          zip -r ../extension.zip . -x "*.DS_Store" 
-        # This command zips the contents of src directory
+          cd dist 
+          zip -r ../extension.zip . -x "*.DS_Store"
 
       - name: Upload to Chrome Web Store
         uses: w3c/chrome-webstore-upload-action@v1

--- a/.github/workflows/publish-chrome.yml
+++ b/.github/workflows/publish-chrome.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: 'master'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
### 📌 Fixes

Fixes #85 
---


### ✅ Checklist

- [ ] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [ ] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_

## Summary by Sourcery

Add a GitHub Actions workflow to enable manual deployment of the Chrome extension by packaging the source and uploading it to the Chrome Web Store using action secrets.

Bug Fixes:
- Fix issue #85 by adding a manual deployment workflow for the Chrome extension

Enhancements:
- Add a GitHub Actions workflow to manually publish the Chrome extension to the Web Store

CI:
- Introduce a 'publish-chrome' workflow that triggers on workflow_dispatch and handles build, packaging, and upload steps

Deployment:
- Configure ZIP creation of the src folder and upload to Chrome Web Store using stored secrets