### PR TITLE
fix: resolve Weblate integration issues with translation key inconsistencies

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -11,9 +11,6 @@
     "enableLabel": {
         "message": "Aktivieren"
     },
-    "homeButtonTitle": {
-        "message": "Zum Bericht"
-    },
     "projectNameLabel": {
         "message": "Projektname (wird im E-Mail-Betreff verwendet)",
         "description": "Label für das Betreff-Feld der E-Mail."

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -11,9 +11,6 @@
     "enableLabel": {
         "message": "Activar"
     },
-    "homeButtonTitle": {
-        "message": "Ir al informe"
-    },
     "projectNameLabel": {
         "message": "Nombre del proyecto (usado en el asunto del correo)"
     },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -11,9 +11,6 @@
     "enableLabel": {
         "message": "Activer"
     },
-    "homeButtonTitle": {
-        "message": "Aller au rapport"
-    },
     "projectNameLabel": {
         "message": "Nom du projet (utilisé dans l'objet de l'e-mail)"
     },

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -11,9 +11,6 @@
     "enableLabel": {
         "message": "सक्षम करें"
     },
-    "homeButtonTitle": {
-        "message": "रिपोर्ट पर जाएं"
-    },
     "projectNameLabel": {
         "message": "ईमेल विषय"
     },

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -11,9 +11,6 @@
     "enableLabel": {
         "message": "Aktifkan"
     },
-    "homeButtonTitle": {
-        "message": "Buka Laporan"
-    },
     "projectNameLabel": {
         "message": "Nama Proyek (digunakan di subjek email)"
     },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -11,9 +11,6 @@
     "enableLabel": {
         "message": "有効にする"
     },
-    "homeButtonTitle": {
-        "message": "レポートに移動"
-    },
     "projectNameLabel": {
         "message": "プロジェクト名（メールの件名に使用）"
     },

--- a/src/_locales/pt/messages.json
+++ b/src/_locales/pt/messages.json
@@ -12,9 +12,6 @@
     "enableLabel": {
         "message": "Ativar"
     },
-    "homeButtonTitle": {
-        "message": "Ir para o Relatório"
-    },
     "projectNameLabel": {
         "message": "Nome do Projeto (usado no assunto do e-mail)"
     },
@@ -134,5 +131,65 @@
     },
     "usernameLabel": {
         "message": "Seu nome de usuário"
+    },
+    "repoFilterLabel": {
+        "message": "Filter by repositories"
+    },
+    "enableFilteringLabel": {
+        "message": "Enable filtering"
+    },
+    "tokenRequiredWarning": {
+        "message": "A GitHub token is required for repository filtering. Please add one in the settings."
+    },
+    "repoSearchPlaceholder": {
+        "message": "Search for a repository to add..."
+    },
+    "repoPlaceholder": {
+        "message": "No repositories selected (all will be included)"
+    },
+    "repoCountNone": {
+        "message": "0 repositories selected"
+    },
+    "repoCount": {
+        "message": "$1 repositories selected"
+    },
+    "repoLoading": {
+        "message": "Loading repositories..."
+    },
+    "repoLoaded": {
+        "message": "Loaded $1 repositories."
+    },
+    "repoNotFound": {
+        "message": "No repositories found"
+    },
+    "repoRefetching": {
+        "message": "Refetching repositories..."
+    },
+    "repoLoadFailed": {
+        "message": "Failed to load repositories."
+    },
+    "repoTokenPrivate": {
+        "message": "Token is invalid or does not have rights for private repos."
+    },
+    "repoRefetchFailed": {
+        "message": "Failed to refetch repositories."
+    },
+    "orgSetMessage": {
+        "message": "Organization set successfully."
+    },
+    "orgClearedMessage": {
+        "message": "Organization cleared. Click 'Generate Report' to fetch all activities."
+    },
+    "orgNotFoundMessage": {
+        "message": "Organization not found on GitHub."
+    },
+    "orgValidationErrorMessage": {
+        "message": "Error validating organization."
+    },
+    "refreshingButton": {
+        "message": "Refreshing..."
+    },
+    "cacheClearFailed": {
+        "message": "Cache clear failed."
     }
 }

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -12,9 +12,6 @@
     "enableLabel": {
         "message": "Ativar"
     },
-    "homeButtonTitle": {
-        "message": "Ir para o Relatório"
-    },
     "projectNameLabel": {
         "message": "Nome do Projeto (usado no assunto do e-mail)"
     },

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -11,9 +11,6 @@
     "enableLabel": {
         "message": "Включить"
     },
-    "homeButtonTitle": {
-        "message": "Перейти к отчету"
-    },
     "projectNameLabel": {
         "message": "Название проекта (используется в теме письма)"
     },

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -11,9 +11,6 @@
     "enableLabel": {
         "message": "Bật"
     },
-    "homeButtonTitle": {
-        "message": "Đi đến Báo cáo"
-    },
     "projectNameLabel": {
         "message": "Tên dự án (sử dụng trong chủ đề email)"
     },

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -12,9 +12,6 @@
     "enableLabel": {
         "message": "启用"
     },
-    "homeButtonTitle": {
-        "message": "前往报告"
-    },
     "projectNameLabel": {
         "message": "项目名称（用于电子邮件主题）"
     },

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -11,9 +11,6 @@
   "enableLabel": {
     "message": "啟用"
   },
-  "homeButtonTitle": {
-    "message": "前往報告"
-  },
   "projectNameLabel": {
     "message": "專案名稱（用於電子郵件主旨）"
   },


### PR DESCRIPTION
### 📌 Fixes

Fixes #240 

---

### 📝 Summary of Changes

- **Fixed translation key inconsistencies** that were causing Weblate merge conflicts
- **Removed extra `homeButtonTitle` key** from 11 non-English locale files (de, es, fr, hi, id, ja, pt_BR, ru, vi, zh_CN, zh_TW)
- **Added 20 missing translation keys** to Portuguese locale file to match English reference
- **Ensured all 12 locale files** now have exactly 64 translation keys, consistent with English
- **No duplicate Chinese files found** 

---

### 📸 Screenshots / Demo (if UI-related)


---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [x] I’ve added tests (if applicable)
- [x] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

## Summary by Sourcery

Fix translation key inconsistencies and align all locale files with the English reference to resolve Weblate integration issues

Bug Fixes:
- Resolve Weblate merge conflicts by correcting translation key discrepancies across locale files

Enhancements:
- Remove extra homeButtonTitle key from 11 non-English locales
- Add 20 missing translation keys to the Portuguese locale file
- Ensure all 12 locale files have exactly 64 keys matching the English reference