### PR TITLE
fix: Input text box color does not change along with rest of the interface

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -696,6 +696,10 @@ hr,
     text-decoration: underline;
 }
 
+#platformDropdownBtn {
+    transition: background-color 0.3s ease-in-out, border-color 0.3s ease-in-out, color 0.3s ease-in-out;
+}
+
 .dark-mode #platformDropdownBtn {
     background-color: #404040 !important;
     border-color: #505050 !important;


### PR DESCRIPTION
### 📌 Fixes

Fixes #248 

---

### 📝 Summary of Changes

- Fixed `#cacheInput` to transition smoothly when toggling between dark and light modes
- Fixed `#platformDropdownBtn` to transition smoothly with consistent timing
- Updated `#cacheInput` transition from `0.2s` (border-only) to `0.3s` (all properties) to match other interface elements
- Added dark mode styling for `#cacheInput` with proper background, border and text colors
- Added transition property to existing `#platformDropdownBtn` dark mode rule

---

### 📸 After Fix:



https://github.com/user-attachments/assets/050e899d-d604-474f-bbcf-8ddbb5cd0ac3





### ✅ Checklist

- [x] I’ve tested my changes locally
- [x] I’ve added tests (if applicable)
- [x] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

## Summary by Sourcery

Fix the theme responsiveness of the cache input field by updating its transition and applying the appropriate dark-mode styles

Bug Fixes:
- Make #cacheInput element update its background, border, and text color when switching between light and dark modes

Enhancements:
- Extend #cacheInput transition to cover background-color and text color with a 0.3s ease-in-out duration to match other interface elements