### PR TITLE
Fix/disable UI when extension of

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -280,11 +280,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
         // Handle repository dropdown
         const repoDropdown = document.getElementById('repoDropdown');
-        if (repoDropdown) {
-            if (!enableToggle) {
-                repoDropdown.classList.add('hidden');
-            }
-            // When enabled, dropdown visibility is controlled by user interaction, so we just ensure pointer events are restored via repoFilterContainer
+        if (repoDropdown && !enableToggle) {
+            repoDropdown.classList.add('hidden');
         }
 
         // Handle useRepoFilter label


### PR DESCRIPTION
### 📌 Fixes

Fixes #285  Fix UI interactivity when Scrum Helper extension is disabled

---

### 📝 Summary of Changes

- Disabled all inputs, buttons, toggles, and dropdowns when the extension is turned off
- Ensured GitHub token visibility toggle respects extension state
- Prevented interaction with repository filtering controls when disabled
- Disabled platform selector on Home page
- Added defensive checks to event handlers

---

## Expected Result
When the extension is disabled:
- UI is visually inactive
- No interactions are possible
- State changes are fully prevented
---

## Summary by Sourcery

Ensure popup UI elements become non-interactive and visually disabled when the extension is turned off.

Bug Fixes:
- Disable platform selector, repository filter controls, and token visibility toggle when the extension is disabled.
- Dim and block interaction with repository filter containers, selected repository entries, and associated remove buttons when the extension is disabled.
- Hide the repository dropdown and disable the repo filter toggle label when the extension is disabled.