### PR TITLE
Enhance UI: gray out labels and sections when extension is disabled

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -225,6 +225,38 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         }
 
+        // Handle labels and section headers - apply disabled styles when extension is disabled
+        const labelSelectors = [
+            // Home page labels
+            'p[data-i18n="platformLabel"]',
+            'p[data-i18n="projectNameLabel"]',
+            '#usernameLabel',
+            'p[data-i18n="contributionsLabel"]',
+            'label[for="startingDate"]',
+            'label[for="endingDate"]',
+            'label[for="yesterdayContribution"]',
+            '#checkboxLabel',
+            '#showCommitsLabel',
+            'h6[data-i18n="scrumReportLabel"]',
+            // Settings page labels
+            'p[data-i18n="githubTokenLabel"]',
+            'p[data-i18n="settingsOrgNameLabel"]',
+            'span[data-i18n="repoFilterLabel"]',
+            'span[data-i18n="cacheTTLLabel"]',
+            'span[data-i18n="cacheTTLUnit"]'
+        ];
+
+        labelSelectors.forEach(selector => {
+            const elements = document.querySelectorAll(selector);
+            elements.forEach(element => {
+                if (!enableToggle) {
+                    element.style.opacity = '0.5';
+                } else {
+                    element.style.opacity = '1';
+                }
+            });
+        });
+
         const scrumReport = document.getElementById('scrumReport');
         if (scrumReport) {
             scrumReport.contentEditable = enableToggle;


### PR DESCRIPTION
### 📌 Fixes

Fixes #287 

---

### 📝 Summary of Changes

This PR improves UX consistency when the Scrum Helper extension is disabled by visually
dimming section labels, headings, and descriptive text to clearly indicate an inactive state.
---

## Changes
- Applied a disabled visual style (greyed out / reduced opacity) to section labels and headings
- Ensured labels and descriptive text reflect the disabled state alongside disabled inputs
- Maintained existing functionality and behavior when the extension is enabled
--- 

### 📸 Screenshots / Demo (if UI-related)

<img width="470" height="749" alt="image" src="https://github.com/user-attachments/assets/3f2f9537-7025-4878-aba6-df3d75166b26" />

<img width="470" height="747" alt="image" src="https://github.com/user-attachments/assets/ae22b961-a590-48c5-b0e6-cf4a3c34981c" />

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [x] I’ve added tests (if applicable)
- [x] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

## Summary by Sourcery

Enhancements:
- Dim popup labels and section headings via opacity changes to visually reflect when the extension is disabled alongside existing disabled inputs.