### PR TITLE
Fix popup crash on dark mode toggle due to missing tokenPreview

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -68,6 +68,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const githubTokenInput = document.getElementById('githubToken');
     const toggleTokenBtn = document.getElementById('toggleTokenVisibility');
     const tokenEyeIcon = document.getElementById('tokenEyeIcon');
+    const tokenPreview = document.getElementById('tokenPreview');
     let tokenVisible = false;
 
     const orgInput = document.getElementById('orgInput');
@@ -145,6 +146,7 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 
     function renderTokenPreview() {
+        if (!tokenPreview || !githubTokenInput) return;
         tokenPreview.innerHTML = '';
         const value = githubTokenInput.value;
         const isDark = document.body.classList.contains('dark-mode');


### PR DESCRIPTION
### What this PR does

- Fixes popup crash caused by missing `tokenPreview` DOM reference
- Adds defensive checks to prevent null access
- Ensures token preview renders safely during dark/light mode toggling

### Issue Reference
Fixes #299

### Testing
- Verified token preview renders correctly
- Dark/light mode toggle no longer throws console errors
- Popup remains stable during repeated theme toggles

## Summary by Sourcery

Bug Fixes:
- Avoid null DOM access for the token preview element when rendering in the popup during dark/light mode changes.

Uploading [Bug] Popup crashes on dark mode toggle due to missing tokenPreview reference · Issue #299 · fossasia_scrum_helper and 20 more pages - Personal - Microsoft​ Edge 2026-01-10 22-20-55.mp4…

