### PR TITLE
fix(popup): remove invalid Tailwind runtime directives

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,3 @@
-@import "tailwindcss";
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 body {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
### 📌 Fixes

Fixes #303

---

### 📝 Summary of Changes

- Removed Tailwind CSS build-time directives from `src/index.css`
- Prevents Chrome from attempting to resolve `tailwindcss` at runtime
- Relies solely on the already compiled `tailwindcss.css` included in the extension

This resolves a popup console error without affecting UI or behavior.

---

### 📸 Screenshots / Demo (if UI-related)

<img width="1264" height="808" alt="image" src="https://github.com/user-attachments/assets/baec8b76-6658-4363-b177-a26bf236d790" />

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [x] I’ve added tests (if applicable)
- [x] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

Tailwind directives such as `@tailwind` and `@import "tailwindcss"` are build-time
instructions and cannot be resolved by the browser at runtime. Since the extension
loads CSS directly without a Tailwind/PostCSS pipeline, these directives caused a
`ERR_FILE_NOT_FOUND tailwindcss` console error.

The project already includes compiled Tailwind output (`tailwindcss.css`), so this
change removes the invalid runtime directives and keeps styling intact.

## Summary by Sourcery

Bug Fixes:
- Eliminate runtime attempts by Chrome to resolve Tailwind CSS directives that caused console errors in the popup.