### PR TITLE
Improve CONTRIBUTING.md and fix broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This document provides guidelines for contributing to the project. Please feel f
 
 ## How Can I Contribute?
 
-- **Reporting Bugs:** If you find a bug, please open an issue on our [GitHub Issues page](https://github.com/fossasia/scrum_helper/issues~). Make sure to use the "Bug Report" template and provide as much detail as possible.
+- **Reporting Bugs:** If you find a bug, please open an issue on our [GitHub Issues page](https://github.com/fossasia/scrum_helper/issues). Make sure to use the "Bug Report" template and provide as much detail as possible.
 - **Suggesting Enhancements:** If you have an idea for a new feature or an improvement to an existing one, you can open an issue using the "Feature or Enhancement Request" template.
 - **Pull Requests:** If you're ready to contribute code, we'd be happy to review your pull request.
 


### PR DESCRIPTION
### 📌 Fixes
N/A (documentation-only change)

---

### 📝 Summary of Changes
- Fixed a broken GitHub Issues link in `CONTRIBUTING.md`
- Improved clarity of contribution instructions for new contributors

This is an important fix because contributors should be able to easily access the Issues page, and the previous link was broken.

---

### 📸 Screenshots / Demo
N/A

---

### ✅ Checklist
- [x] I’ve tested my changes locally
- [ ] I’ve added tests (not applicable)
- [x] I’ve updated documentation
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes
This is a small documentation-only change to improve onboarding for new contributors.

## Summary by Sourcery

Documentation:
- Adjust the GitHub Issues link in CONTRIBUTING.md for the bug reporting section.