### PR TITLE
Improve date picker icon visibility in dark mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -91,7 +91,9 @@ hr,
     border-color: #404040 !important;
     transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out;
 }
-
+.dark-mode input[type="date"]::-webkit-calendar-picker-indicator {
+    filter: invert(1);
+}
 .dark-mode input[type="text"],
 .dark-mode input[type="date"],
 .dark-mode #scrumReport {


### PR DESCRIPTION
### 📌 Fixes

Fixes #320 

---

### 📝 Summary of Changes

- Improved visibility of the native date picker (calendar) icon in dark mode
- Applied a dark-mode–specific CSS rule to invert the calendar icon color for better contrast
- Scoped the change only to dark mode, without affecting light mode styling

This enhances accessibility and usability when selecting dates in dark mode.

---

### 📸 Screenshots / Demo (if UI-related)
Before : Calendar icon appears dark and hard to see on dark backgrounds
<img width="319" height="91" alt="image" src="https://github.com/user-attachments/assets/67b5ccfe-c69d-4ef0-9a35-6a78821a72ae" />

After : Calendar icon appears light/white and clearly visible in dark mode
<img width="518" height="131" alt="image" src="https://github.com/user-attachments/assets/a7c98fc9-b2f4-45ca-bd1b-8e67f6479f4f" />

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (not applicable)
- [ ] I’ve updated documentation (not applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

- This solution uses the ::-webkit-calendar-picker-indicator pseudo-element, which is supported in Chromium-based browsers (Chrome, Edge, Brave).
- The change is minimal, low-risk, and isolated to index.css.

## Summary by Sourcery

Bug Fixes:
- Increase contrast of the native date picker icon in dark mode without affecting light mode styling.