### PR TITLE
 Add keyboard shortcuts for generate/copy

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -399,11 +399,6 @@ document.addEventListener('DOMContentLoaded', function () {
         });
 
         document.addEventListener('keydown', function (e) {
-            const isEditable = e.target.tagName === 'INPUT' || 
-                               e.target.tagName === 'TEXTAREA' ||
-                               e.target.contentEditable === 'true';
-            if (isEditable) return;
-
             if (e.ctrlKey && e.key.toLowerCase() === 'g') {
                 e.preventDefault();
                 if (!generateBtn.disabled) {
@@ -412,7 +407,9 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'c') {
                 e.preventDefault();
-                copyBtn.click();
+                if (!copyBtn.disabled) {
+                    copyBtn.click();
+                }
             }
         });
 


### PR DESCRIPTION
Added Ctrl+G to generate report and Ctrl+Shift+C to copy it.

Closes #326

## Summary by Sourcery

Add keyboard shortcuts to trigger report generation and copying from the popup UI.

New Features:
- Support Ctrl+G to trigger report generation from the popup.
- Support Ctrl+Shift+C to trigger copying the generated report from the popup.