### PR TITLE
Fix: Popup crashes due to addEventListener on missing elements

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -691,6 +691,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     }
+    }
 	if (homeButton) {
         homeButton.addEventListener('click', showReportView);
     }


### PR DESCRIPTION
Fixes #295

The popup was crashing because `addEventListener` was being called on elements (like `settingsIcon`, `darkModeToggle`) that might not exist on the page.

This PR adds `if` checks to ensure the elements exist before attaching listeners.