### PR TITLE
feat(report): add keyboard shortcut for report generation and tooltip

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -50,24 +50,28 @@ function applyI18n() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-		// Keyboard shortcut for report generation
-		document.addEventListener('keydown', (e) => {
-			// Only trigger if popup is focused and not in a textarea/input
-			const active = document.activeElement;
-			const isInput = active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable);
-			if (!isInput) {
-				// Ctrl+Enter or Enter triggers report generation
-				if ((e.ctrlKey && e.key === 'Enter') || (e.key === 'Enter' && !e.ctrlKey)) {
-					const generateBtn = document.getElementById('generateReport');
-					if (generateBtn && !generateBtn.disabled) {
-						generateBtn.click();
-						// Optionally, add a visual feedback
-						generateBtn.classList.add('ring', 'ring-blue-400');
-						setTimeout(() => generateBtn.classList.remove('ring', 'ring-blue-400'), 300);
+		// Keyboard shortcut for report generation (scoped to popup container)
+		const popupContainer = document.querySelector('body');
+		if (popupContainer) {
+			popupContainer.addEventListener('keydown', (e) => {
+				const active = document.activeElement;
+				const isInput = active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable);
+				// Only trigger if focus is on body or main popup elements
+				const isPopupFocus = active === popupContainer || active === document.body || active.id === 'reportSection';
+				if (!isInput && isPopupFocus) {
+					// Ctrl+Enter or Enter triggers report generation
+					if ((e.ctrlKey && e.key === 'Enter') || (e.key === 'Enter' && !e.ctrlKey)) {
+						const generateBtn = document.getElementById('generateReport');
+						if (generateBtn && !generateBtn.disabled) {
+							generateBtn.click();
+							// Add a CSS animation class for feedback
+							generateBtn.classList.add('keyboard-triggered');
+							setTimeout(() => generateBtn.classList.remove('keyboard-triggered'), 300);
+						}
 					}
 				}
-			}
-		});
+			});
+		}
 	// Apply translations as soon as the DOM is ready
 	applyI18n();
 
@@ -475,8 +479,10 @@ document.addEventListener('DOMContentLoaded', () => {
 		const generateBtn = document.getElementById('generateReport');
 		const copyBtn = document.getElementById('copyReport');
 
-		// Add tooltip for keyboard shortcut
-		generateBtn.setAttribute('title', 'Generate report (Ctrl+Enter or Enter)');
+		// Add i18n tooltip for keyboard shortcut
+		const shortcutTooltip = chrome.i18n.getMessage('generateReportShortcutTooltip') || 'Generate report (Ctrl+Enter or Enter)';
+		generateBtn.setAttribute('title', shortcutTooltip);
+
 		generateBtn.addEventListener('click', () => {
 			chrome.storage.local.get(['platform'], (result) => {
 				const platform = result.platform || 'github';


### PR DESCRIPTION
### 📌 Fixes
Fixes #350 

---

### 📝 Summary of Changes
- Added keyboard support to generate scrum reports from the popup
- Implemented keyboard shortcuts (e.g. `Enter` / `Ctrl + Enter`) for the main action
- Improved accessibility for keyboard-only and assistive-technology users

---

### ✅ Checklist
- [x] I’ve tested my changes locally
- [ ] I’ve added tests (not applicable)
- [ ] I’ve updated documentation (not required)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes
This PR improves accessibility and usability by allowing report generation without requiring mouse interaction.

## Summary by Sourcery

Add keyboard-accessible triggering of report generation from the popup and surface the shortcut in the UI.

New Features:
- Enable generating reports from the popup using Enter or Ctrl+Enter when focus is not in an input field.

Enhancements:
- Show a tooltip on the report generation button indicating the available keyboard shortcut.