### PR TITLE
fix: show popup error when GitHub username is invalid

### DIFF
--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -779,10 +779,9 @@ function allIncluded(outputTarget = 'email') {
     const generateBtn = document.getElementById('generateReport');
 
     if (scrumReport) {
-        scrumReport.innerHTML = `<div class="error-message" style="color: #dc2626; font-weight: bold; padding: 10px;">
-            ${err.message || 'An error occurred while generating the report.'}
-        </div>`;
-    }
+    scrumReport.textContent = err.message || 'An error occurred while generating the report.';
+    scrumReport.className = 'error-message';
+}
 
     if (generateBtn) {
         generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate Report';


### PR DESCRIPTION
Fixes #311

Problem
When a wrong or missing GitHub username is entered in the popup:
No error is shown
The Generate Report button stays stuck on “Generating…”

Root cause
fetchGithubData relies on outputTarget (popup vs email) to decide how to display errors.
From the popup flow, this value was never passed, so the function defaulted to 'email'.
Because of this, the popup error path never ran and the button was never reset.

Fix
Pass outputTarget from allIncluded() into fetchGithubData(outputTarget)
Add a safe default: fetchGithubData(outputTarget = 'email')
Replace an incorrect loadFromStorage(...) call with logging

Result
With an invalid username in the popup:
A clear error message is shown
The Generate Report button is restored properly
This is a minimal, popup-only fix using the existing error handling already present in the codebase.

## Summary by Sourcery

Handle invalid GitHub usernames in the popup flow by displaying an error message and restoring the Generate Report button state.

Bug Fixes:
- Show a clear popup error message when the provided GitHub username is invalid or the GitHub API returns an error from the popup flow.
- Ensure the Generate Report button is re-enabled and its label reset when an invalid GitHub username error occurs in the popup.