### PR TITLE
Release drafter workflow fix

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -78,7 +78,7 @@ jobs:
           REPO="${{ github.repository }}"
 
           # Push commit (use token to authenticate)
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git" HEAD:refs/heads/${{ github.ref_name }}
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git" HEAD:refs/heads/main
 
           # Create annotated tag if missing and push it
           if git rev-parse "${TAG}" >/dev/null 2>&1; then


### PR DESCRIPTION
### 📌 Fixes

Fixes #363 

---

### 📝 Summary of Changes

Added check to run the workflow only if the repository is ```FOSSASIA/scrum_helper```
Future proofed against default branch name change

---

### 📸 Screenshots / Demo (if UI-related)

_Add screenshots, video, or link to deployed preview if applicable_

---

### ✅ Checklist

- [ ] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [ ] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_

## Summary by Sourcery

Update the Release Drafter GitHub Actions workflow to align with the main branch naming and restrict its execution to the primary FOSSASIA/scrum_helper repository.

CI:
- Change the workflow trigger and push target from the master branch to the main branch and push to the current ref name.
- Add a repository check so the Release Drafter workflow only runs on the FOSSASIA/scrum_helper repository.