### PR TITLE
fix: repo-filtering & input search visibility

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -366,11 +366,10 @@
 									filtering. Please add one in the settings.</span>
 							</div>
 
-
-							<input id="repoSearch" type="text" data-i18n-placeholder="repoSearchPlaceholder"
-								class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 pr-10"
-								autocomplete="off">
 							<div id="repoFilterContainer" class="hidden">
+								<input id="repoSearch" type="text" data-i18n-placeholder="repoSearchPlaceholder"
+									class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 pr-10"
+									autocomplete="off">
 								<!-- Typeahead Input -->
 								<div class="relative">
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1004,7 +1004,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				programmaticFocus = false;
 				return;
 			}
-		const searchTerm = repoSearch.value.toLowerCase();
+			const searchTerm = repoSearch.value.toLowerCase();
 			filterAndDisplayRepos(searchTerm);
 		});
 
@@ -1171,7 +1171,7 @@ document.addEventListener('DOMContentLoaded', () => {
 					if (selectedRepos.includes(repo.fullName)) {
 						return false;
 					}
-				if (!query) {
+					if (!query) {
 						return true;
 					}
 					return repo.name.toLowerCase().includes(query) || repo.description?.toLowerCase().includes(query);

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1004,11 +1004,8 @@ document.addEventListener('DOMContentLoaded', () => {
 				programmaticFocus = false;
 				return;
 			}
-			if (repoSearch.value) {
-				filterAndDisplayRepos(repoSearch.value.toLowerCase());
-			} else if (availableRepos.length > 0) {
-				filterAndDisplayRepos('');
-			}
+		const searchTerm = repoSearch.value.toLowerCase();
+			filterAndDisplayRepos(searchTerm);
 		});
 
 		document.addEventListener('click', (e) => {
@@ -1170,9 +1167,15 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 
 			const filtered = availableRepos.filter(
-				(repo) =>
-					!selectedRepos.includes(repo.fullName) &&
-					(repo.name.toLowerCase().includes(query) || repo.description?.toLowerCase().includes(query)),
+				(repo) => {
+					if (selectedRepos.includes(repo.fullName)) {
+						return false;
+					}
+				if (!query) {
+						return true;
+					}
+					return repo.name.toLowerCase().includes(query) || repo.description?.toLowerCase().includes(query);
+				}
 			);
 
 			if (filtered.length === 0) {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -597,13 +597,20 @@ function allIncluded(outputTarget = 'email') {
 					logError(`Missing owner for repo ${repo} - search may fail`);
 					return `repo:${repo}`;
 				})
-				.join('+'); 
+				.join('+');
 
 			const orgQuery = orgPart ? `+${orgPart}` : '';
-			issueUrl = `https://api.github.com/search/issues?q=author%3A${platformUsernameLocal}+${repoQueries}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
-			prUrl = `https://api.github.com/search/issues?q=commenter%3A${platformUsernameLocal}+${repoQueries}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
-			userUrl = `https://api.github.com/users/${platformUsernameLocal}`;
-			log('Repository-filtered URLs:', { issueUrl, prUrl });
+			if (!repoQueries) {
+				loadFromStorage('Repo filter empty, using org wide search');
+				issueUrl = `https://api.github.com/search/issues?q=author%3A${platformUsernameLocal}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
+				prUrl = `https://api.github.com/search/issues?q=commenter%3A${platformUsernameLocal}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
+				userUrl = `https://api.github.com/users/${platformUsernameLocal}`;
+			} else {
+				issueUrl = `https://api.github.com/search/issues?q=author%3A${platformUsernameLocal}+${repoQueries}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
+				prUrl = `https://api.github.com/search/issues?q=commenter%3A${platformUsernameLocal}+${repoQueries}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
+				userUrl = `https://api.github.com/users/${platformUsernameLocal}`;
+				log('Repository-filtered URLs:', { issueUrl, prUrl });
+			}
 		} else {
 			loadFromStorage('Using org wide search');
 			const orgQuery = orgPart ? `+${orgPart}` : '';

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -596,7 +596,8 @@ function allIncluded(outputTarget = 'email') {
 					}
 					logError(`Missing owner for repo ${repo} - search may fail`);
 					return `repo:${repo}`;
-				});
+				})
+				.join('+'); 
 
 			const orgQuery = orgPart ? `+${orgPart}` : '';
 			issueUrl = `https://api.github.com/search/issues?q=author%3A${platformUsernameLocal}+${repoQueries}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;


### PR DESCRIPTION
### 📌 Fixes

Fixes #297  

---

### 📝 Summary of Changes

- **State-based visibility**: Repository filter input now only shows when "Enable filtering" checkbox is checked, and hides when unchecked
- **Enhanced search filtering**: Real-time search filtering by repository name or description while showing all matching repos
- **Fixed multi-repo query bug**: Multiple selected repositories are now properly joined with `+` separator in GitHub search API queries, fixing the "Invalid search query" error (422 response) that occurred when selecting 2+ repos
- **Better UX messages**: Added helpful messages when no repos are found based on search context

**Related Issues**: Repository filtering feature #297

---

### 📸 Screenshots / Demo

**Before:**
- No repo shown on the base on input search
- Error "Loading repositories" 
- Repo input visible even when filtering disabled
<img width="362" height="328" alt="image" src="https://github.com/user-attachments/assets/934e20a1-68ec-4d48-8d1c-f241d541a868" />


**After:**
- All available repos with contributions are listed and searchable
- Multiple repo selection works correctly
- Repo input only shows when filtering is enabled
- Smooth search filtering in real-time
<img width="362" height="400" alt="image" src="https://github.com/user-attachments/assets/657f52f2-b90e-46c4-bb38-9e5f7a750a59" />

https://github.com/user-attachments/assets/3e3e9033-9b3d-48e8-8b40-8ed388db9e6d




---

### ✅ Checklist

- [x] I've tested my changes locally (multiple repo selection, search filtering)
- [x] Code follows the project's code style guidelines
- [x] Repo filtering state toggles properly with checkbox
- [x] Multiple repo selection generates reports without errors

---

### 👀 Reviewer Notes

**Key Changes:**
1. **popup.html**: Moved `repoSearch` input inside `repoFilterContainer` so it's hidden/shown with the entire section
2. **popup.js**: 
   - Fixed `filterAndDisplayRepos()` to show all repos when query is empty, filter with search term
   - Improved focus handler to always display repos
3. **scrumHelper.js**: Fixed `repoQueries` to properly join multiple repos with `+` separator

**Testing Done:**
- ✅ Enable/disable filtering checkbox - input shows/hides correctly
- ✅ Click input with no search - shows all repos
- ✅ Type search term - filters repos by name/description in real-time
- ✅ Select single repo - report generates successfully
- ✅ Select multiple repos - no 422 errors, report generates with filtered data
- ✅ Uncheck filtering - clears selected repos and hides input

---

### 🔗 References

- Fixes repository filtering functionality
- Enables users to filter SCRUM reports by specific repositories
- Resolves multi-repo selection errors

## Summary by Sourcery

Fix repository filtering and search behavior in the popup and correct GitHub multi-repository search query construction.

Bug Fixes:
- Ensure the repository search input is only visible when filtering is enabled by tying it to the filter container.
- Always display all available repositories when no search term is entered, while correctly filtering by name or description when a query is provided.
- Fix construction of multi-repository GitHub search queries by joining selected repositories with a '+' separator to avoid invalid search errors.

Enhancements:
- Simplify repository search handling so that focusing or typing in the input consistently triggers the same filtering path.