### PR TITLE
fix: remove toast for non-existed users

### DIFF
--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -628,9 +628,7 @@ function allIncluded(outputTarget = 'email') {
 			if (userCheckRes.status === 404) {
 				const errorMsg = `GitHub user "${platformUsernameLocal}" not found (404). Please check the username and try again.`;
 				logError(errorMsg);
-				if (outputTarget === 'popup') {
-					Materialize.toast && Materialize.toast(errorMsg, 4000);
-				}
+			
 				throw new Error(errorMsg);
 			}
 

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -628,7 +628,6 @@ function allIncluded(outputTarget = 'email') {
 			if (userCheckRes.status === 404) {
 				const errorMsg = `GitHub user "${platformUsernameLocal}" not found (404). Please check the username and try again.`;
 				logError(errorMsg);
-			
 				throw new Error(errorMsg);
 			}
 


### PR DESCRIPTION
### 📌 Fixes

Closes #380

---

### 📝 Summary of Changes

- Removed the toast notification trigger for the invalid username (`404`) flow in the popup report generation path.
- Kept existing inline error handling intact, so invalid username feedback now appears only inside the popup UI.
- This reduces duplicate/error-noise feedback and makes validation behavior consistent and predictable.

Related issue: #380

---

### 📸 Screenshots / Demo (if UI-related)

- Before: entering an invalid username showed both inline error feedback and a toast.
- 
<img width="557" height="772" alt="image" src="https://github.com/user-attachments/assets/184418da-17a5-4fca-b816-abcb3a74b147" />

- After: entering an invalid username shows inline error feedback only (no toast).
<img width="471" height="750" alt="image" src="https://github.com/user-attachments/assets/2d7ca94e-8c73-49f6-a600-a94984c18fa4" />

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

- This is a focused UI-feedback fix only for the invalid username case.
- No functional changes were made to report generation logic beyond suppressing the toast in that specific scenario.
- Other toast-based notifications (for unrelated cases) are unchanged.

## Summary by Sourcery

Bug Fixes:
- Remove the popup toast notification for non-existent GitHub users to prevent duplicate error messaging while preserving existing inline error handling.