### PR TITLE
Enhancement: Gray out section labels and text when extension is disabled

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -883,3 +883,7 @@ hr,
     background-color: #3b82f6;
     color: #fff;
 }
+.extension-disabled {
+  opacity: 0.5;
+  transition: opacity 0.2s ease-in-out;
+}

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -180,6 +180,15 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 
 	function updateContentState(enableToggle) {
+		const reportSection = document.getElementById("reportSection");
+
+		if (reportSection) {
+			if (!enableToggle) {
+				reportSection.classList.add("extension-disabled");
+			} else {
+				reportSection.classList.remove("extension-disabled");
+			}
+		}
 		console.log('[DEBUG] updateContentState called with:', enableToggle);
 		const elementsToToggle = [
 			'startingDate',


### PR DESCRIPTION
## Summary
This PR improves visual clarity when the extension is disabled by applying a dimmed style to the report section.

## Changes
- Added a `.extension-disabled` CSS class to reduce opacity
- Applied class toggle in `updateContentState()` for `#reportSection`
- Maintained existing input disabling logic
- No functional or API changes introduced

## Result
- Labels, headings, and descriptive text now visually reflect the disabled state
- UI consistency improved
- Settings section remains unaffected

## Screenshots

### Before
<img width="472" height="904" alt="image" src="https://github.com/user-attachments/assets/0811c5ab-1d8b-417f-a65a-be3e450314d1" />

### After
<img width="356" height="784" alt="image" src="https://github.com/user-attachments/assets/222dfdfd-2027-4135-bc89-e0e2f146264c" />

## Contribution Checklist

- [x] I have checked existing enhancement requests
- [x] I have clearly described the proposed change
- [x] I have explained the motivation and context

## Summary by Sourcery

Dim disabled report section UI when the extension is turned off to better reflect its inactive state.

Enhancements:
- Add an opacity-based dimming style for report sections via a new `extension-disabled` CSS class.
- Toggle the disabled styling on the report section in `updateContentState` based on the extension enablement state.