### PR TITLE
fix: resolve github search api malformed queries and 422 errors

### DIFF
--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -565,7 +565,7 @@ function allIncluded(outputTarget = 'email') {
 		console.log('[SCRUM-HELPER] orgName before API query:', orgName);
 		console.log('[SCRUM-HELPER] orgName type:', typeof orgName);
 		console.log('[SCRUM-HELPER] orgName length:', orgName ? orgName.length : 0);
-		const orgPart = orgName && orgName.trim() ? `+org%3A${orgName}` : '';
+		const orgPart = orgName && orgName.trim() ? `org%3A${orgName.trim()}` : '';
 		console.log('[SCRUM-HELPER] orgPart for API:', orgPart);
 		console.log('[SCRUM-HELPER] orgPart length:', orgPart.length);
 
@@ -600,8 +600,9 @@ function allIncluded(outputTarget = 'email') {
 						return `repo:${fullRepoInfo.fullName}`;
 					}
 					logError(`Missing owner for repo ${repo} - search may fail`);
-					return `repo:${repo}`;
+					return null;
 				})
+				.filter(Boolean)
 				.join('+');
 
 			const orgQuery = orgPart ? `+${orgPart}` : '';
@@ -1934,9 +1935,10 @@ async function fetchUserRepositories(username, token, org = '') {
 			const startDate = thirtyDaysAgo.toISOString().split('T')[0];
 			const endDate = today.toISOString().split('T')[0];
 		}
-		const orgPart = org && org !== 'all' ? `+org:${org}` : '';
-		const issuesUrl = `https://api.github.com/search/issues?q=author:${username}${orgPart}${dateRange}&per_page=100`;
-		const commentsUrl = `https://api.github.com/search/issues?q=commenter:${username}${orgPart}${dateRange.replace('created:', 'updated:')}&per_page=100`;
+		const orgPart = org && org !== 'all' ? `org:${org}` : '';
+		const orgQuery = orgPart ? `+${orgPart}` : '';
+		const issuesUrl = `https://api.github.com/search/issues?q=author:${username}${orgQuery}${dateRange}&per_page=100`;
+		const commentsUrl = `https://api.github.com/search/issues?q=commenter:${username}${orgQuery}${dateRange.replace('created:', 'updated:')}&per_page=100`;
 
 		console.log('Search URLs:', { issuesUrl, commentsUrl });
 


### PR DESCRIPTION
### 📌 Fixes #400 
---

### 📝 Summary of Changes

- **Double Plus Encoding**: Fixed a bug where a GitHub search query for an organization added a double plus sign (e.g. `++org%3A{orgName}`) which is an invalid query.
- **422 Unprocessable Entity**: Fixed a bug where entering a repository name without an owner would result in a malformed `repo:` search qualifier, throwing a 422 error from the GitHub API and breaking the report completely. 

---

### 📸 Screenshots / Demo (if UI-related)

_N/A - Logic fix_

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

These fixes address edge cases in the GitHub search query logic that would otherwise completely break user report generation with a fatal 422 error depending on what the user types in the "repositories" filter or "organization" input.

## Summary by Sourcery

Fix GitHub search query construction to avoid malformed organization and repository filters that cause API errors.

Bug Fixes:
- Correct organization search query encoding to avoid introducing invalid leading plus signs.
- Prevent constructing repo search qualifiers without an owner by omitting malformed repo filters from queries.