### PR TITLE
Resolve snap bug

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -897,3 +897,13 @@ hr,
     background-color: #3b82f6;
     color: #fff;
 }
+
+html.mode-sidepanel, body.mode-sidepanel {
+    width: 100%;
+    min-width: 360px;
+}
+
+html.mode-popup, body.mode-popup {
+    width: 360px; 
+    min-width: 360px;
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="en" class="mode-sidepanel">
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -14,6 +13,8 @@
 
 			margin: 0;
 			background: #eae4e4;
+			width: 100%;
+            height: 100%;
 		}
 
 		body {
@@ -22,12 +23,12 @@
 
 		html.mode-sidepanel,
 		body.mode-sidepanel {
-			width: 100vw !important;
-			height: 100vh !important;
-			max-width: 100vw !important;
-			max-height: 100vh !important;
-			min-width: 360px;
-			min-height: 100vh !important;
+			width: 100% !important;
+            height: 100% !important;
+            max-width: 100% !important;
+            max-height: 100% !important;
+            min-width: 360px;
+            min-height: 100% !important;
 		}
 
 		html.mode-popup,
@@ -42,6 +43,9 @@
 
 		#popupRoot {
 			flex: 1;
+			min-width: 360px; 
+			flex-shrink: 0;
+
 			height: 100%;
 			overflow-y: auto;
 			overflow-x: hidden;
@@ -69,8 +73,7 @@
 		}
 	</style>
 </head>
-
-<body>
+<body class="mode-sidepanel text-gray-800 bg-gray-50 flex flex-col font-sans">
 	<div id="popupRoot" class="pl-1 py-2 rounded-2xl">
 		<div class="bg-white px-4 py-4 mx-2 mb-2 rounded-3xl">
 			<div class="flex justify-between py-2">

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -633,10 +633,12 @@ document.addEventListener('DOMContentLoaded', () => {
 		// Apply the stored display mode class on next launch
 		function applyDisplayModeClass(mode) {
 			const className = mode === 'popup' ? 'mode-popup' : 'mode-sidepanel';
-			document.documentElement.classList.remove('mode-popup', 'mode-sidepanel');
-			body.classList.remove('mode-popup', 'mode-sidepanel');
-			document.documentElement.classList.add(className);
-			body.classList.add(className);
+			if(!document.documentElement.classList.contains(className)){
+				document.documentElement.classList.remove('mode-popup', 'mode-sidepanel');
+				body.classList.remove('mode-popup', 'mode-sidepanel');
+				document.documentElement.classList.add(className);
+				body.classList.add(className);
+			}
 		}
 
 		chrome?.storage.local.get({ displayMode: 'sidePanel' }, (result) => {


### PR DESCRIPTION
In some cases a snap bug was observed which caused the extension to clamp to left side for few ms.


### 📝 Summary of Changes

Gave popupRoot a min width to tackle this behavior

---

### 📸 Screenshots / Demo (if UI-related)

_Add screenshots, video, or link to deployed preview if applicable_

---

### ✅ Checklist

- [ ] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [ ] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_

## Summary by Sourcery

Adjust popup and sidepanel layout to prevent the extension UI from momentarily snapping to the left edge and ensure consistent sizing across modes.

Bug Fixes:
- Prevent the popup root from shrinking below 360px to avoid brief snapping/clamping to the left side.
- Stabilize sidepanel and popup sizing by normalizing HTML/body dimensions and minimum widths for each mode.
- Avoid redundant mode class reapplication on the document and body when the display mode is already set.

Enhancements:
- Set default HTML and body attributes/classes to better align the popup with the sidepanel layout and overall styling.