### PR TITLE
chore: refactor api calls to use wrappers with rate-limit handling

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Berichten Sie über Ihren Entwicklungsfortschritt, indem Sie Ihre Git-Aktivität für einen ausgewählten Zeitraum automatisch abrufen"
-    },
-    "disableLabel": {
-        "message": "Deaktivieren"
-    },
-    "enableLabel": {
-        "message": "Aktivieren"
-    },
-    "projectNameLabel": {
-        "message": "Projektname (wird im E-Mail-Betreff verwendet)",
-        "description": "Label für das Betreff-Feld der E-Mail."
-    },
-    "projectNamePlaceholder": {
-        "message": "Geben Sie Ihren Projektnamen ein"
-    },
-    "githubUsernameLabel": {
-        "message": "Ihr GitHub-Benutzername"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Ihr GitLab-Benutzername"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Erforderlich, um Ihre Beiträge abzurufen"
-    },
-    "contributionsLabel": {
-        "message": "Ihre Beiträge abrufen für:"
-    },
-    "last1DayLabel": {
-        "message": "Vorheriger Tag"
-    },
-    "startDateLabel": {
-        "message": "Von:"
-    },
-    "endDateLabel": {
-        "message": "Bis:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Offen/Geschlossen-Status anzeigen"
-    },
-    "blockersLabel": {
-        "message": "Was hindert Sie am Fortschritt?"
-    },
-    "blockersPlaceholder": {
-        "message": "Geben Sie hier den Grund ein"
-    },
-    "scrumReportLabel": {
-        "message": "Scrum-Bericht"
-    },
-    "generateReportButton": {
-        "message": "Erstellen"
-    },
-    "copyReportButton": {
-        "message": "Kopieren"
-    },
-    "insertInEmailButton": {
-        "message": "In E-Mail einfügen"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Name der Organisation"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Namen der Organisation eingeben"
-    },
-    "setButton": {
-        "message": "Festlegen"
-    },
-    "githubTokenLabel": {
-        "message": "Ihr GitHub-Token"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Erforderlich für authentifizierte Anfragen"
-    },
-    "githubTokenTooltip": {
-        "message": "Warum wird empfohlen, ein GitHub-Token hinzuzufügen? Scrum Helper funktioniert ohne ein GitHub-Token, aber das Hinzufügen eines persönlichen Zugriffstokens wird für ein besseres Erlebnis empfohlen."
-    },
-    "gitlabTokenLabel": {
-        "message": "Ihr GitLab-Token"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Erforderlich für private Repos"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Warum wird empfohlen, ein GitLab-Token hinzuzufügen? Scrum Helper funktioniert ohne ein GitLab-Token für öffentliche Projekte, aber das Hinzufügen eines persönlichen Zugriffstokens wird für ein besseres Erlebnis empfohlen."
-    },
-    "showCommitsLabel": {
-        "message": "Commits in offenen PRs/ Entwurfs-PRs anzeigen"
-    },
-    "showCommitsTooltip": {
-        "message": "Github-Token erforderlich, bitte in den Einstellungen hinzufügen."
-    },
-    "onlyIssuesLabel": {
-        "message": "Nur Probleme in den Bericht aufnehmen"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Wenn diese Option aktiviert ist, enthält der Bericht nur Probleme, die vom Benutzer erstellt oder ihm zugewiesen wurden."
-    },
-    "onlyPRsLabel": {
-        "message": "Nur PRs in den Bericht aufnehmen"
-    },
-    "onlyPRsTooltip": {
-        "message": "Wenn diese Option aktiviert ist, enthält der Bericht nur von Ihnen erstellte Pull Requests; überprüfte PRs werden ausgeschlossen."
-    },
-    "cacheTTLLabel": {
-        "message": "Cache-TTL eingeben"
-    },
-    "cacheTTLUnit": {
-        "message": "(in Minuten)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Cache-TTL in Minuten (Standard: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Daten aktualisieren (Cache umgehen)"
-    },
-    "refreshDataInfo": {
-        "message": "Verwenden Sie diese Schaltfläche, um neue Daten sofort abzurufen."
-    },
-    "noteTitle": {
-        "message": "Hinweis:"
-    },
-    "viewCodeButton": {
-        "message": "Code ansehen"
-    },
-    "reportIssueButton": {
-        "message": "Problem melden"
-    },
-    "repoFilterLabel": {
-        "message": "Nach Repositories filtern"
-    },
-    "enableFilteringLabel": {
-        "message": "Filterung aktivieren"
-    },
-    "tokenRequiredWarning": {
-        "message": "Für die Repository-Filterung ist ein GitHub-Token erforderlich. Bitte fügen Sie einen in den Einstellungen hinzu."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Repository zum Hinzufügen suchen..."
-    },
-    "repoPlaceholder": {
-        "message": "Keine Repositories ausgewählt (alle werden einbezogen)"
-    },
-    "repoCountNone": {
-        "message": "0 Repositories ausgewählt"
-    },
-    "repoCount": {
-        "message": "$1 Repositories ausgewählt"
-    },
-    "repoLoading": {
-        "message": "Lade Repositories..."
-    },
-    "repoLoaded": {
-        "message": "$1 Repositories geladen."
-    },
-    "repoNotFound": {
-        "message": "Keine Repositories gefunden"
-    },
-    "repoRefetching": {
-        "message": "Lade Repositories neu..."
-    },
-    "repoLoadFailed": {
-        "message": "Laden der Repositories fehlgeschlagen."
-    },
-    "repoTokenPrivate": {
-        "message": "Token ist ungültig oder hat keine Rechte für private Repos."
-    },
-    "repoRefetchFailed": {
-        "message": "Neuladen der Repositories fehlgeschlagen."
-    },
-    "orgSetMessage": {
-        "message": "Organisation erfolgreich festgelegt."
-    },
-    "orgClearedMessage": {
-        "message": "Organisation gelöscht. Klicken Sie auf 'Bericht erstellen', um alle Aktivitäten abzurufen."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organisation auf GitHub nicht gefunden."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Fehler bei der Validierung der Organisation."
-    },
-    "refreshingButton": {
-        "message": "Wird aktualisiert..."
-    },
-    "cacheClearFailed": {
-        "message": "Cache-Löschung fehlgeschlagen."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Wird generiert..."
-    },
-    "copiedButton": {
-        "message": "Kopiert!"
-    },
-    "orgChangedMessage": {
-        "message": "Organisation geändert. Klicken Sie auf 'Bericht erstellen', um die GitHub-Aktivitäten abzurufen."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache erfolgreich geleert. Klicken Sie auf 'Bericht erstellen', um neue Daten abzurufen."
-    },
-    "cacheExpiredMessage": {
-        "message": "Cache abgelaufen. Klicken Sie auf \"Erstellen\", um neue Daten abzurufen.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Cache geleert!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Erweiterung ist deaktiviert. Aktivieren Sie sie in den Einstellungen, um Scrum-Berichte zu erstellen."
-    },
-    "notePoint1": {
-        "message": "Pull-Requests werden basierend auf der letzten Review-Aktivität eines beliebigen Beitragenden abgerufen, nicht nur Ihrer eigenen. Bitte überprüfen und passen Sie den generierten SCRUM-Bericht an, um sicherzustellen, dass er Ihre Arbeit korrekt widerspiegelt, bevor Sie ihn teilen."
-    },
-    "noteSeeIssue": {
-        "message": "Siehe dieses Issue"
-    },
-    "platformLabel": {
-        "message": "Plattform"
-    },
-    "usernameLabel": {
-        "message": "Ihr Benutzername"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Nur überprüfte PRs in den Bericht aufnehmen"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Wenn diese Option aktiviert ist, enthält der Bericht nur PRs, die von Ihnen überprüft wurden."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-   },
-        "usernameRequiredError": {
-        "message": "Bitte geben Sie Ihren Benutzernamen ein, um einen Bericht zu erstellen."
-    },
-    "unknownPlatformError": {
-        "message": "Unbekannte Plattform ausgewählt."
-    },
-    "gitlabFetchingError": {
-        "message": "Beim Abrufen der GitLab-Daten ist ein Fehler aufgetreten."
-    },
-    "reportGenerationError": {
-        "message": "Beim Erstellen des Berichts ist ein Fehler aufgetreten."
-    },
-    "githubUserNotFoundError": {
-        "message": "GitHub-Benutzer \"$1\" nicht gefunden (404). Bitte überprüfen Sie den Benutzernamen und versuchen Sie es erneut."
-    },
-    "githubUserValidationError": {
-        "message": "Fehler bei der Validierung des GitHub-Benutzers: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Ungültige Suchanfrage oder Datumsbereich. Bitte überprüfen Sie das Format Ihres Datumsbereichs und versuchen Sie es erneut."
-    },
-    "githubIssuesFetchError": {
-        "message": "Fehler beim Abrufen von GitHub-Issues: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Fehler beim Abrufen der GitHub-PR-Review-Daten: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Fehler beim Abrufen der GitHub-Benutzerdaten: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Ungültiges oder abgelaufenes GitHub-Token. Bitte überprüfen Sie Ihr Token in den Scrum Helper-Einstellungen und versuchen Sie es erneut."
-    },
-    "displayModeNotice": {
-        "message": "Die Erweiterung wird beim nächsten Start im $1-Modus geöffnet."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Repository-Filterung ist nur für GitHub verfügbar."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Repository-Laden ist nur für GitHub verfügbar."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Repository-Abruf ist nur für GitHub verfügbar."
-    },
-    "loadingReposAutomatically": {
-        "message": "Lade Repositories automatisch..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Fehler beim Abrufen des GitLab-Benutzers: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "GitLab-Benutzer '$1' nicht gefunden"
-    },
-    "gitlabMembershipError": {
-        "message": "Fehler beim Abrufen der GitLab-Mitgliedschaftsprojekte: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Fehler beim Abrufen der GitLab-Beitragsprojekte: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Benutzername erforderlich."
-    },
-    "generatingReportNotification": {
-        "message": "Bericht wird erstellt..."
-    },
-    "copyingReportNotification": {
-        "message": "Bericht wird kopiert..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Bericht wird in E-Mail eingefügt..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Bericht in E-Mail eingefügt!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Berichten Sie über Ihren Entwicklungsfortschritt, indem Sie Ihre Git-Aktivität für einen ausgewählten Zeitraum automatisch abrufen"
+  },
+  "disableLabel": {
+    "message": "Deaktivieren"
+  },
+  "enableLabel": {
+    "message": "Aktivieren"
+  },
+  "projectNameLabel": {
+    "message": "Projektname (wird im E-Mail-Betreff verwendet)",
+    "description": "Label für das Betreff-Feld der E-Mail."
+  },
+  "projectNamePlaceholder": {
+    "message": "Geben Sie Ihren Projektnamen ein"
+  },
+  "githubUsernameLabel": {
+    "message": "Ihr GitHub-Benutzername"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Ihr GitLab-Benutzername"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Erforderlich, um Ihre Beiträge abzurufen"
+  },
+  "contributionsLabel": {
+    "message": "Ihre Beiträge abrufen für:"
+  },
+  "last1DayLabel": {
+    "message": "Vorheriger Tag"
+  },
+  "startDateLabel": {
+    "message": "Von:"
+  },
+  "endDateLabel": {
+    "message": "Bis:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Offen/Geschlossen-Status anzeigen"
+  },
+  "blockersLabel": {
+    "message": "Was hindert Sie am Fortschritt?"
+  },
+  "blockersPlaceholder": {
+    "message": "Geben Sie hier den Grund ein"
+  },
+  "scrumReportLabel": {
+    "message": "Scrum-Bericht"
+  },
+  "generateReportButton": {
+    "message": "Erstellen"
+  },
+  "copyReportButton": {
+    "message": "Kopieren"
+  },
+  "insertInEmailButton": {
+    "message": "In E-Mail einfügen"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Name der Organisation"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Namen der Organisation eingeben"
+  },
+  "setButton": {
+    "message": "Festlegen"
+  },
+  "githubTokenLabel": {
+    "message": "Ihr GitHub-Token"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Erforderlich für authentifizierte Anfragen"
+  },
+  "githubTokenTooltip": {
+    "message": "Warum wird empfohlen, ein GitHub-Token hinzuzufügen? Scrum Helper funktioniert ohne ein GitHub-Token, aber das Hinzufügen eines persönlichen Zugriffstokens wird für ein besseres Erlebnis empfohlen."
+  },
+  "gitlabTokenLabel": {
+    "message": "Ihr GitLab-Token"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Erforderlich für private Repos"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Warum wird empfohlen, ein GitLab-Token hinzuzufügen? Scrum Helper funktioniert ohne ein GitLab-Token für öffentliche Projekte, aber das Hinzufügen eines persönlichen Zugriffstokens wird für ein besseres Erlebnis empfohlen."
+  },
+  "showCommitsLabel": {
+    "message": "Commits in offenen PRs/ Entwurfs-PRs anzeigen"
+  },
+  "showCommitsTooltip": {
+    "message": "Github-Token erforderlich, bitte in den Einstellungen hinzufügen."
+  },
+  "onlyIssuesLabel": {
+    "message": "Nur Probleme in den Bericht aufnehmen"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Wenn diese Option aktiviert ist, enthält der Bericht nur Probleme, die vom Benutzer erstellt oder ihm zugewiesen wurden."
+  },
+  "onlyPRsLabel": {
+    "message": "Nur PRs in den Bericht aufnehmen"
+  },
+  "onlyPRsTooltip": {
+    "message": "Wenn diese Option aktiviert ist, enthält der Bericht nur von Ihnen erstellte Pull Requests; überprüfte PRs werden ausgeschlossen."
+  },
+  "cacheTTLLabel": {
+    "message": "Cache-TTL eingeben"
+  },
+  "cacheTTLUnit": {
+    "message": "(in Minuten)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Cache-TTL in Minuten (Standard: 10)"
+  },
+  "refreshDataButton": {
+    "message": "Daten aktualisieren (Cache umgehen)"
+  },
+  "refreshDataInfo": {
+    "message": "Verwenden Sie diese Schaltfläche, um neue Daten sofort abzurufen."
+  },
+  "noteTitle": {
+    "message": "Hinweis:"
+  },
+  "viewCodeButton": {
+    "message": "Code ansehen"
+  },
+  "reportIssueButton": {
+    "message": "Problem melden"
+  },
+  "repoFilterLabel": {
+    "message": "Nach Repositories filtern"
+  },
+  "enableFilteringLabel": {
+    "message": "Filterung aktivieren"
+  },
+  "tokenRequiredWarning": {
+    "message": "Für die Repository-Filterung ist ein GitHub-Token erforderlich. Bitte fügen Sie einen in den Einstellungen hinzu."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Repository zum Hinzufügen suchen..."
+  },
+  "repoPlaceholder": {
+    "message": "Keine Repositories ausgewählt (alle werden einbezogen)"
+  },
+  "repoCountNone": {
+    "message": "0 Repositories ausgewählt"
+  },
+  "repoCount": {
+    "message": "$1 Repositories ausgewählt"
+  },
+  "repoLoading": {
+    "message": "Lade Repositories..."
+  },
+  "repoLoaded": {
+    "message": "$1 Repositories geladen."
+  },
+  "repoNotFound": {
+    "message": "Keine Repositories gefunden"
+  },
+  "repoRefetching": {
+    "message": "Lade Repositories neu..."
+  },
+  "repoLoadFailed": {
+    "message": "Laden der Repositories fehlgeschlagen."
+  },
+  "repoTokenPrivate": {
+    "message": "Token ist ungültig oder hat keine Rechte für private Repos."
+  },
+  "repoRefetchFailed": {
+    "message": "Neuladen der Repositories fehlgeschlagen."
+  },
+  "orgSetMessage": {
+    "message": "Organisation erfolgreich festgelegt."
+  },
+  "orgClearedMessage": {
+    "message": "Organisation gelöscht. Klicken Sie auf 'Bericht erstellen', um alle Aktivitäten abzurufen."
+  },
+  "orgNotFoundMessage": {
+    "message": "Organisation auf GitHub nicht gefunden."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Fehler bei der Validierung der Organisation."
+  },
+  "refreshingButton": {
+    "message": "Wird aktualisiert..."
+  },
+  "cacheClearFailed": {
+    "message": "Cache-Löschung fehlgeschlagen."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Wird generiert..."
+  },
+  "copiedButton": {
+    "message": "Kopiert!"
+  },
+  "orgChangedMessage": {
+    "message": "Organisation geändert. Klicken Sie auf 'Bericht erstellen', um die GitHub-Aktivitäten abzurufen."
+  },
+  "cacheClearedMessage": {
+    "message": "Cache erfolgreich geleert. Klicken Sie auf 'Bericht erstellen', um neue Daten abzurufen."
+  },
+  "cacheExpiredMessage": {
+    "message": "Cache abgelaufen. Klicken Sie auf \"Erstellen\", um neue Daten abzurufen.",
+    "description": "Message shown when the cached data has expired and user needs to regenerate."
+  },
+  "cacheClearedButton": {
+    "message": "Cache geleert!"
+  },
+  "extensionDisabledMessage": {
+    "message": "Erweiterung ist deaktiviert. Aktivieren Sie sie in den Einstellungen, um Scrum-Berichte zu erstellen."
+  },
+  "notePoint1": {
+    "message": "Pull-Requests werden basierend auf der letzten Review-Aktivität eines beliebigen Beitragenden abgerufen, nicht nur Ihrer eigenen. Bitte überprüfen und passen Sie den generierten SCRUM-Bericht an, um sicherzustellen, dass er Ihre Arbeit korrekt widerspiegelt, bevor Sie ihn teilen."
+  },
+  "noteSeeIssue": {
+    "message": "Siehe dieses Issue"
+  },
+  "platformLabel": {
+    "message": "Plattform"
+  },
+  "usernameLabel": {
+    "message": "Ihr Benutzername"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Nur überprüfte PRs in den Bericht aufnehmen"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Wenn diese Option aktiviert ist, enthält der Bericht nur PRs, die von Ihnen überprüft wurden."
+  },
+  "usernameRequiredError": {
+    "message": "Bitte geben Sie Ihren Benutzernamen ein, um einen Bericht zu erstellen."
+  },
+  "unknownPlatformError": {
+    "message": "Unbekannte Plattform ausgewählt."
+  },
+  "gitlabFetchingError": {
+    "message": "Beim Abrufen der GitLab-Daten ist ein Fehler aufgetreten."
+  },
+  "reportGenerationError": {
+    "message": "Beim Erstellen des Berichts ist ein Fehler aufgetreten."
+  },
+  "githubUserNotFoundError": {
+    "message": "GitHub-Benutzer \"$1\" nicht gefunden (404). Bitte überprüfen Sie den Benutzernamen und versuchen Sie es erneut."
+  },
+  "githubUserValidationError": {
+    "message": "Fehler bei der Validierung des GitHub-Benutzers: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Ungültige Suchanfrage oder Datumsbereich. Bitte überprüfen Sie das Format Ihres Datumsbereichs und versuchen Sie es erneut."
+  },
+  "githubIssuesFetchError": {
+    "message": "Fehler beim Abrufen von GitHub-Issues: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Fehler beim Abrufen der GitHub-PR-Review-Daten: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Fehler beim Abrufen der GitHub-Benutzerdaten: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Ungültiges oder abgelaufenes GitHub-Token. Bitte überprüfen Sie Ihr Token in den Scrum Helper-Einstellungen und versuchen Sie es erneut."
+  },
+  "displayModeNotice": {
+    "message": "Die Erweiterung wird beim nächsten Start im $1-Modus geöffnet."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Repository-Filterung ist nur für GitHub verfügbar."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Repository-Laden ist nur für GitHub verfügbar."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Repository-Abruf ist nur für GitHub verfügbar."
+  },
+  "loadingReposAutomatically": {
+    "message": "Lade Repositories automatisch..."
+  },
+  "gitlabUserFetchError": {
+    "message": "Fehler beim Abrufen des GitLab-Benutzers: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "GitLab-Benutzer '$1' nicht gefunden"
+  },
+  "gitlabMembershipError": {
+    "message": "Fehler beim Abrufen der GitLab-Mitgliedschaftsprojekte: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Fehler beim Abrufen der GitLab-Beitragsprojekte: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Benutzername erforderlich."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Bericht wird erstellt..."
+  },
+  "copyingReportNotification": {
+    "message": "Bericht wird kopiert..."
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Bericht wird in E-Mail eingefügt..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Bericht in E-Mail eingefügt!"
+  },
+  "tokenSetupTitle": {
+    "message": "GitHub-Token hinzufügen"
+  },
+  "tokenSetupDescription": {
+    "message": "Erweiterte Funktionen durch Hinzufügen Ihres GitHub-Tokens aktivieren"
+  },
+  "tokenSetupBenefits": {
+    "message": "Vorteile"
+  },
+  "tokenSetupBenefit1": {
+    "message": "Höhere API-Ratenlimits"
+  },
+  "tokenSetupBenefit2": {
+    "message": "Zugriff auf private Repositories"
+  },
+  "tokenSetupBenefit3": {
+    "message": "Commits auf PRs anzeigen"
+  },
+  "addTokenButton": {
+    "message": "Token hinzufügen"
+  },
+  "learnMoreLink": {
+    "message": "Mehr erfahren"
+  }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -303,19 +303,7 @@
   },
   "onlyRevPRsTooltip": {
     "message": "If checked, the report will only include PRs reviewed by you.",
-    "description": "Tooltip for the reviewed PRs filter checkbox."
-  },
-  "onlyMergedPRsLabel": {
-    "message": "Include only merged PRs in the report",
-    "description": "Label for the checkbox to include only merged PRs."
-  },
-  "onlyMergedPRsTooltip": {
-    "message": "If checked, the report will only include PRs that have been merged. A GitHub token is required.",
-    "description": "Tooltip for the merged PRs filter checkbox."
-  },
-  "tokenRequiredMergedPRsWarning": {
-    "message": "A GitHub token is required to filter by merged PRs. Please add one in the settings.",
-    "description": "Warning shown when merged PRs filter is enabled without a GitHub token."
+    "description": "Tooltip for the checkbox to include only reviewed PRs."
   },
   "usernameRequiredError": {
     "message": "Please enter your username to generate a report.",
@@ -400,7 +388,7 @@
   "usernameMissingError": {
     "message": "Username required.",
     "description": "Error shown when username is missing."
-   },
+  },
   "generateReportTooltip": {
     "message": "Ctrl+G",
     "description": "Tooltip shortcut for the Generate button. Dynamically replaced with Cmd+G on macOS."
@@ -432,5 +420,37 @@
   "insertedInEmailNotification": {
     "message": "Report inserted into email!",
     "description": "Notification shown when report is successfully inserted into email."
+  },
+  "tokenSetupTitle": {
+    "message": "Add GitHub Token",
+    "description": "Title for the token setup section in the scrum report placeholder."
+  },
+  "tokenSetupDescription": {
+    "message": "Enable advanced features by adding your GitHub token",
+    "description": "Description for the token setup section."
+  },
+  "tokenSetupBenefits": {
+    "message": "Benefits",
+    "description": "Title for the benefits section in token setup."
+  },
+  "tokenSetupBenefit1": {
+    "message": "Higher API rate limits",
+    "description": "First benefit of adding a GitHub token."
+  },
+  "tokenSetupBenefit2": {
+    "message": "Access to private repositories",
+    "description": "Second benefit of adding a GitHub token."
+  },
+  "tokenSetupBenefit3": {
+    "message": "Show commits on PRs",
+    "description": "Third benefit of adding a GitHub token."
+  },
+  "addTokenButton": {
+    "message": "Add Token",
+    "description": "Text for the button to add a GitHub token."
+  },
+  "learnMoreLink": {
+    "message": "Learn More",
+    "description": "Text for the learn more link in token setup."
   }
 }

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Informe sobre su progreso de desarrollo obteniendo automáticamente su actividad de Git para un período seleccionado."
-    },
-    "disableLabel": {
-        "message": "Desactivar"
-    },
-    "enableLabel": {
-        "message": "Activar"
-    },
-    "projectNameLabel": {
-        "message": "Nombre del proyecto (usado en el asunto del correo)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Ingrese el nombre de su proyecto"
-    },
-    "githubUsernameLabel": {
-        "message": "Su nombre de usuario de GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Su nombre de usuario de GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Requerido para obtener sus contribuciones"
-    },
-    "contributionsLabel": {
-        "message": "Obtener sus contribuciones de:"
-    },
-    "last1DayLabel": {
-        "message": "Día anterior"
-    },
-    "startDateLabel": {
-        "message": "Desde:"
-    },
-    "endDateLabel": {
-        "message": "Hasta:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Mostrar estado Abierto/Cerrado"
-    },
-    "blockersLabel": {
-        "message": "¿Qué le impide progresar?"
-    },
-    "blockersPlaceholder": {
-        "message": "Ingrese su motivo"
-    },
-    "scrumReportLabel": {
-        "message": "Informe de Scrum"
-    },
-    "generateReportButton": {
-        "message": "Generar"
-    },
-    "copyReportButton": {
-        "message": "Copiar"
-    },
-    "insertInEmailButton": {
-        "message": "Insertar en correo"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nombre de la organización"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Ingrese el nombre de la organización"
-    },
-    "setButton": {
-        "message": "Establecer"
-    },
-    "githubTokenLabel": {
-        "message": "Su token de GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Requerido para realizar solicitudes autenticadas"
-    },
-    "githubTokenTooltip": {
-        "message": "¿Por qué se recomienda agregar un token de GitHub? Scrum Helper funciona sin un token de GitHub, pero se recomienda agregar un token de acceso personal para una mejor experiencia."
-    },
-    "gitlabTokenLabel": {
-        "message": "Tu token de GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Requerido para repos privados"
-    },
-    "gitlabTokenTooltip": {
-        "message": "¿Por qué se recomienda agregar un token de GitLab? Scrum Helper funciona sin un token de GitLab para proyectos públicos, pero se recomienda agregar un token de acceso personal para una mejor experiencia."
-    },
-    "showCommitsLabel": {
-        "message": "Mostrar commits en PRs abiertos/ borradores de PRs"
-    },
-    "showCommitsTooltip": {
-        "message": "Se requiere un token de GitHub, agréguelo en la configuración."
-    },
-    "onlyIssuesLabel": {
-        "message": "Incluir solo incidencias en el informe"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Si está marcado, el informe solo incluirá las incidencias creadas o asignadas al usuario."
-    },
-    "onlyPRsLabel": {
-        "message": "Incluir solo PRs en el informe"
-    },
-    "onlyPRsTooltip": {
-        "message": "Si está marcado, el informe solo incluirá pull requests creados por el usuario; los pull requests revisados se excluirán."
-    },
-    "cacheTTLLabel": {
-        "message": "Introducir TTL de caché",
-        "description": "Etiqueta para la entrada de tiempo de vida de la caché."
-    },
-    "cacheTTLUnit": {
-        "message": "(en minutos)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Escriba el TTL del caché en minutos (Predeterminado: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Actualizar datos (omitir caché)"
-    },
-    "refreshDataInfo": {
-        "message": "Use este botón para obtener datos nuevos inmediatamente."
-    },
-    "noteTitle": {
-        "message": "Nota:"
-    },
-    "viewCodeButton": {
-        "message": "Ver código"
-    },
-    "reportIssueButton": {
-        "message": "Reportar un problema"
-    },
-    "repoFilterLabel": {
-        "message": "Filtrar por repositorios"
-    },
-    "enableFilteringLabel": {
-        "message": "Activar filtrado"
-    },
-    "tokenRequiredWarning": {
-        "message": "Se requiere un token de GitHub para filtrar repositorios. Por favor, agregue uno en la configuración."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Buscar un repositorio para agregar..."
-    },
-    "repoPlaceholder": {
-        "message": "No hay repositorios seleccionados (se incluirán todos)"
-    },
-    "repoCountNone": {
-        "message": "0 repositorios seleccionados"
-    },
-    "repoCount": {
-        "message": "$1 repositorios seleccionados"
-    },
-    "repoLoading": {
-        "message": "Cargando repositorios..."
-    },
-    "repoLoaded": {
-        "message": "$1 repositorios cargados."
-    },
-    "repoNotFound": {
-        "message": "No se encontraron repositorios"
-    },
-    "repoRefetching": {
-        "message": "Recargando repositorios..."
-    },
-    "repoLoadFailed": {
-        "message": "Error al cargar los repositorios."
-    },
-    "repoTokenPrivate": {
-        "message": "El token no es válido o no tiene derechos para repositorios privados."
-    },
-    "repoRefetchFailed": {
-        "message": "Error al recargar los repositorios."
-    },
-    "orgSetMessage": {
-        "message": "Organización establecida correctamente."
-    },
-    "orgClearedMessage": {
-        "message": "Organización eliminada. Haga clic en 'Generar informe' para obtener todas las actividades."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organización no encontrada en GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Error al validar la organización."
-    },
-    "refreshingButton": {
-        "message": "Actualizando..."
-    },
-    "cacheClearFailed": {
-        "message": "Error al borrar el caché."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Generando..."
-    },
-    "copiedButton": {
-        "message": "¡Copiado!"
-    },
-    "orgChangedMessage": {
-        "message": "Organización cambiada. Haga clic en 'Generar informe' para obtener las actividades de GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Caché borrado con éxito. Haga clic en 'Generar informe' para obtener datos nuevos."
-    },
-    "cacheExpiredMessage": {
-        "message": "La caché ha expirado. Haga clic en \"Generar\" para obtener datos nuevos.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "¡Caché borrado!"
-    },
-    "extensionDisabledMessage": {
-        "message": "La extensión está deshabilitada. Habilítela desde las opciones para generar informes de scrum."
-    },
-    "notePoint1": {
-        "message": "Las solicitudes de extracción se obtienen en función de la actividad de revisión más reciente de cualquier colaborador, no solo la suya. Revise y ajuste el informe SCRUM generado para asegurarse de que refleje con precisión su trabajo antes de compartirlo."
-    },
-    "noteSeeIssue": {
-        "message": "Ver este issue"
-    },
-    "platformLabel": {
-        "message": "Plataforma"
-    },
-    "usernameLabel": {
-        "message": "Su nombre de usuario"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Incluir solo PRs revisados en el informe"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Si está marcado, el informe solo incluirá PRs revisados por usted."
-    },
-	"usernameRequiredError": {
-		"message": "Por favor, introduzca su nombre de usuario para generar un informe."
-	},
-	"unknownPlatformError": {
-		"message": "Plataforma desconocida seleccionada."
-	},
-	"gitlabFetchingError": {
-		"message": "Se produjo un error al obtener los datos de GitLab."
-	},
-	"reportGenerationError": {
-		"message": "Se produjo un error al generar el informe."
-	},
-	"githubUserNotFoundError": {
-		"message": "Usuario de GitHub \"$1\" no encontrado (404). Por favor, verifique el nombre de usuario e inténtelo de nuevo."
-	},
-	"githubUserValidationError": {
-		"message": "Error al validar el usuario de GitHub: $1 $2"
-	},
-	"invalidSearchQueryError": {
-		"message": "Consulta de búsqueda o rango de fechas no válido. Por favor, verifique el formato de su rango de fechas e inténtelo de nuevo."
-	},
-	"githubIssuesFetchError": {
-		"message": "Error al obtener los issues de GitHub: $1 $2"
-	},
-	"githubPRReviewFetchError": {
-		"message": "Error al obtener los datos de revisión de PR de GitHub: $1 $2"
-	},
-	"githubUserFetchError": {
-		"message": "Error al obtener los datos del usuario de GitHub: $1 $2"
-	},
-	"invalidTokenError": {
-		"message": "Token de GitHub no válido o caducado. Por favor, verifique su token en la configuración de Scrum Helper e inténtelo de nuevo."
-	},
-	"displayModeNotice": {
-		"message": "La extensión se abrirá en modo $1 en el próximo inicio."
-	},
-	"repoFilteringGithubOnly": {
-		"message": "El filtrado de repositorios solo está disponible para GitHub."
-	},
-	"repoLoadingGithubOnly": {
-		"message": "La carga de repositorios solo está disponible para GitHub."
-	},
-	"repoFetchingGithubOnly": {
-		"message": "La obtención de repositorios solo está disponible para GitHub."
-	},
-	"loadingReposAutomatically": {
-		"message": "Cargando repositorios automáticamente.."
-	},
-	"gitlabUserFetchError": {
-		"message": "Error al obtener el usuario de GitLab: $1 $2"
-	},
-	"gitlabUserNotFoundError": {
-		"message": "Usuario de GitLab '$1' no encontrado"
-	},
-	"gitlabMembershipError": {
-		"message": "Error al obtener los proyectos de membresía de GitLab: $1 $2"
-	},
-	"gitlabContributedError": {
-		"message": "Error al obtener los proyectos a los que contribuyó en GitLab: $1 $2"
-	},
-	"usernameMissingError": {
-		"message": "Nombre de usuario requerido."
-	},
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-   },
-    "generatingReportNotification": {
-        "message": "Generando informe..."
-   },
-    "copyingReportNotification": {
-        "message": "Copiando informe..."
-   },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Insertando informe en el correo..."
-    },
-    "insertedInEmailNotification": {
-        "message": "¡Informe insertado en el correo!"
-   }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Informe sobre su progreso de desarrollo obteniendo automáticamente su actividad de Git para un período seleccionado."
+  },
+  "disableLabel": {
+    "message": "Desactivar"
+  },
+  "enableLabel": {
+    "message": "Activar"
+  },
+  "projectNameLabel": {
+    "message": "Nombre del proyecto (usado en el asunto del correo)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Ingrese el nombre de su proyecto"
+  },
+  "githubUsernameLabel": {
+    "message": "Su nombre de usuario de GitHub"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Su nombre de usuario de GitLab"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Requerido para obtener sus contribuciones"
+  },
+  "contributionsLabel": {
+    "message": "Obtener sus contribuciones de:"
+  },
+  "last1DayLabel": {
+    "message": "Día anterior"
+  },
+  "startDateLabel": {
+    "message": "Desde:"
+  },
+  "endDateLabel": {
+    "message": "Hasta:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Mostrar estado Abierto/Cerrado"
+  },
+  "blockersLabel": {
+    "message": "¿Qué le impide progresar?"
+  },
+  "blockersPlaceholder": {
+    "message": "Ingrese su motivo"
+  },
+  "scrumReportLabel": {
+    "message": "Informe de Scrum"
+  },
+  "generateReportButton": {
+    "message": "Generar"
+  },
+  "copyReportButton": {
+    "message": "Copiar"
+  },
+  "insertInEmailButton": {
+    "message": "Insertar en correo"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Nombre de la organización"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Ingrese el nombre de la organización"
+  },
+  "setButton": {
+    "message": "Establecer"
+  },
+  "githubTokenLabel": {
+    "message": "Su token de GitHub"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Requerido para realizar solicitudes autenticadas"
+  },
+  "githubTokenTooltip": {
+    "message": "¿Por qué se recomienda agregar un token de GitHub? Scrum Helper funciona sin un token de GitHub, pero se recomienda agregar un token de acceso personal para una mejor experiencia."
+  },
+  "gitlabTokenLabel": {
+    "message": "Tu token de GitLab"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Requerido para repos privados"
+  },
+  "gitlabTokenTooltip": {
+    "message": "¿Por qué se recomienda agregar un token de GitLab? Scrum Helper funciona sin un token de GitLab para proyectos públicos, pero se recomienda agregar un token de acceso personal para una mejor experiencia."
+  },
+  "showCommitsLabel": {
+    "message": "Mostrar commits en PRs abiertos/ borradores de PRs"
+  },
+  "showCommitsTooltip": {
+    "message": "Se requiere un token de GitHub, agréguelo en la configuración."
+  },
+  "onlyIssuesLabel": {
+    "message": "Incluir solo incidencias en el informe"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Si está marcado, el informe solo incluirá las incidencias creadas o asignadas al usuario."
+  },
+  "onlyPRsLabel": {
+    "message": "Incluir solo PRs en el informe"
+  },
+  "onlyPRsTooltip": {
+    "message": "Si está marcado, el informe solo incluirá pull requests creados por el usuario; los pull requests revisados se excluirán."
+  },
+  "cacheTTLLabel": {
+    "message": "Introducir TTL de caché",
+    "description": "Etiqueta para la entrada de tiempo de vida de la caché."
+  },
+  "cacheTTLUnit": {
+    "message": "(en minutos)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Escriba el TTL del caché en minutos (Predeterminado: 10)"
+  },
+  "refreshDataButton": {
+    "message": "Actualizar datos (omitir caché)"
+  },
+  "refreshDataInfo": {
+    "message": "Use este botón para obtener datos nuevos inmediatamente."
+  },
+  "noteTitle": {
+    "message": "Nota:"
+  },
+  "viewCodeButton": {
+    "message": "Ver código"
+  },
+  "reportIssueButton": {
+    "message": "Reportar un problema"
+  },
+  "repoFilterLabel": {
+    "message": "Filtrar por repositorios"
+  },
+  "enableFilteringLabel": {
+    "message": "Activar filtrado"
+  },
+  "tokenRequiredWarning": {
+    "message": "Se requiere un token de GitHub para filtrar repositorios. Por favor, agregue uno en la configuración."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Buscar un repositorio para agregar..."
+  },
+  "repoPlaceholder": {
+    "message": "No hay repositorios seleccionados (se incluirán todos)"
+  },
+  "repoCountNone": {
+    "message": "0 repositorios seleccionados"
+  },
+  "repoCount": {
+    "message": "$1 repositorios seleccionados"
+  },
+  "repoLoading": {
+    "message": "Cargando repositorios..."
+  },
+  "repoLoaded": {
+    "message": "$1 repositorios cargados."
+  },
+  "repoNotFound": {
+    "message": "No se encontraron repositorios"
+  },
+  "repoRefetching": {
+    "message": "Recargando repositorios..."
+  },
+  "repoLoadFailed": {
+    "message": "Error al cargar los repositorios."
+  },
+  "repoTokenPrivate": {
+    "message": "El token no es válido o no tiene derechos para repositorios privados."
+  },
+  "repoRefetchFailed": {
+    "message": "Error al recargar los repositorios."
+  },
+  "orgSetMessage": {
+    "message": "Organización establecida correctamente."
+  },
+  "orgClearedMessage": {
+    "message": "Organización eliminada. Haga clic en 'Generar informe' para obtener todas las actividades."
+  },
+  "orgNotFoundMessage": {
+    "message": "Organización no encontrada en GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Error al validar la organización."
+  },
+  "refreshingButton": {
+    "message": "Actualizando..."
+  },
+  "cacheClearFailed": {
+    "message": "Error al borrar el caché."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Generando..."
+  },
+  "copiedButton": {
+    "message": "¡Copiado!"
+  },
+  "orgChangedMessage": {
+    "message": "Organización cambiada. Haga clic en 'Generar informe' para obtener las actividades de GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Caché borrado con éxito. Haga clic en 'Generar informe' para obtener datos nuevos."
+  },
+  "cacheExpiredMessage": {
+    "message": "La caché ha expirado. Haga clic en \"Generar\" para obtener datos nuevos.",
+    "description": "Message shown when the cached data has expired and user needs to regenerate."
+  },
+  "cacheClearedButton": {
+    "message": "¡Caché borrado!"
+  },
+  "extensionDisabledMessage": {
+    "message": "La extensión está deshabilitada. Habilítela desde las opciones para generar informes de scrum."
+  },
+  "notePoint1": {
+    "message": "Las solicitudes de extracción se obtienen en función de la actividad de revisión más reciente de cualquier colaborador, no solo la suya. Revise y ajuste el informe SCRUM generado para asegurarse de que refleje con precisión su trabajo antes de compartirlo."
+  },
+  "noteSeeIssue": {
+    "message": "Ver este issue"
+  },
+  "platformLabel": {
+    "message": "Plataforma"
+  },
+  "usernameLabel": {
+    "message": "Su nombre de usuario"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Incluir solo PRs revisados en el informe"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Si está marcado, el informe solo incluirá PRs revisados por usted."
+  },
+  "usernameRequiredError": {
+    "message": "Por favor, introduzca su nombre de usuario para generar un informe."
+  },
+  "unknownPlatformError": {
+    "message": "Plataforma desconocida seleccionada."
+  },
+  "gitlabFetchingError": {
+    "message": "Se produjo un error al obtener los datos de GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Se produjo un error al generar el informe."
+  },
+  "githubUserNotFoundError": {
+    "message": "Usuario de GitHub \"$1\" no encontrado (404). Por favor, verifique el nombre de usuario e inténtelo de nuevo."
+  },
+  "githubUserValidationError": {
+    "message": "Error al validar el usuario de GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Consulta de búsqueda o rango de fechas no válido. Por favor, verifique el formato de su rango de fechas e inténtelo de nuevo."
+  },
+  "githubIssuesFetchError": {
+    "message": "Error al obtener los issues de GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Error al obtener los datos de revisión de PR de GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Error al obtener los datos del usuario de GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Token de GitHub no válido o caducado. Por favor, verifique su token en la configuración de Scrum Helper e inténtelo de nuevo."
+  },
+  "displayModeNotice": {
+    "message": "La extensión se abrirá en modo $1 en el próximo inicio."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "El filtrado de repositorios solo está disponible para GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "La carga de repositorios solo está disponible para GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "La obtención de repositorios solo está disponible para GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Cargando repositorios automáticamente.."
+  },
+  "gitlabUserFetchError": {
+    "message": "Error al obtener el usuario de GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Usuario de GitLab '$1' no encontrado"
+  },
+  "gitlabMembershipError": {
+    "message": "Error al obtener los proyectos de membresía de GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Error al obtener los proyectos a los que contribuyó en GitLab: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Nombre de usuario requerido."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Generando informe..."
+  },
+  "copyingReportNotification": {
+    "message": "Copiando informe..."
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Insertando informe en el correo..."
+  },
+  "insertedInEmailNotification": {
+    "message": "¡Informe insertado en el correo!"
+  },
+  "tokenSetupTitle": {
+    "message": "Agregar token de GitHub"
+  },
+  "tokenSetupDescription": {
+    "message": "Habilitar funciones avanzadas agregando su token de GitHub"
+  },
+  "tokenSetupBenefits": {
+    "message": "Beneficios"
+  },
+  "tokenSetupBenefit1": {
+    "message": "Límites de velocidad de API más altos"
+  },
+  "tokenSetupBenefit2": {
+    "message": "Acceso a repositorios privados"
+  },
+  "tokenSetupBenefit3": {
+    "message": "Mostrar commits en PRs"
+  },
+  "addTokenButton": {
+    "message": "Agregar token"
+  },
+  "learnMoreLink": {
+    "message": "Más información"
+  }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Rendez compte de votre progression en récupérant automatiquement votre activité Git pour une période sélectionnée."
-    },
-    "disableLabel": {
-        "message": "Désactiver"
-    },
-    "enableLabel": {
-        "message": "Activer"
-    },
-    "projectNameLabel": {
-        "message": "Nom du projet (utilisé dans l'objet de l'e-mail)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Entrez le nom de votre projet"
-    },
-    "githubUsernameLabel": {
-        "message": "Votre nom d'utilisateur GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Votre nom d'utilisateur GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Requis pour récupérer vos contributions"
-    },
-    "contributionsLabel": {
-        "message": "Récupérer vos contributions de :"
-    },
-    "last1DayLabel": {
-        "message": "Jour précédent"
-    },
-    "startDateLabel": {
-        "message": "De :"
-    },
-    "endDateLabel": {
-        "message": "À :"
-    },
-    "showOpenClosedLabel": {
-        "message": "Afficher le statut Ouvert/Fermé"
-    },
-    "blockersLabel": {
-        "message": "Qu'est-ce qui vous empêche de progresser ?"
-    },
-    "blockersPlaceholder": {
-        "message": "Entrez votre raison"
-    },
-    "scrumReportLabel": {
-        "message": "Rapport Scrum"
-    },
-    "generateReportButton": {
-        "message": "Générer"
-    },
-    "copyReportButton": {
-        "message": "Copier"
-    },
-    "insertInEmailButton": {
-        "message": "Insérer dans l’e-mail"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nom de l'organisation"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Entrez le nom de l'organisation"
-    },
-    "setButton": {
-        "message": "Définir"
-    },
-    "githubTokenLabel": {
-        "message": "Votre jeton GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Requis pour les requêtes authentifiées"
-    },
-    "githubTokenTooltip": {
-        "message": "Pourquoi est-il recommandé d'ajouter un jeton GitHub ? Scrum Helper fonctionne sans jeton GitHub, mais l'ajout d'un jeton d'accès personnel est recommandé pour une meilleure expérience."
-    },
-    "gitlabTokenLabel": {
-        "message": "Votre jeton GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Requis pour les dépôts privés"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Pourquoi est-il recommandé d'ajouter un jeton GitLab ? Scrum Helper fonctionne sans jeton GitLab pour les projets publics, mais l'ajout d'un jeton d'accès personnel est recommandé pour une meilleure expérience."
-    },
-    "showCommitsLabel": {
-        "message": "Afficher les commits sur les PRs ouverts/ brouillons de PRs"
-    },
-    "showCommitsTooltip": {
-        "message": "Jeton Github requis, ajoutez-le dans les paramètres."
-    },
-    "onlyIssuesLabel": {
-        "message": "Inclure uniquement les problèmes dans le rapport"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Si cette case est cochée, le rapport n'inclura que les problèmes créés par l'utilisateur ou qui lui sont assignés."
-    },
-    "onlyPRsLabel": {
-        "message": "Inclure uniquement les PRs dans le rapport"
-    },
-    "onlyPRsTooltip": {
-        "message": "Si coché, le rapport n'inclura que les pull requests créées par l'utilisateur ; les pull requests revues seront exclues."
-    },
-    "cacheTTLLabel": {
-        "message": "Entrez le TTL du cache",
-        "description": "Étiquette pour le champ de saisie de la durée de vie du cache."
-    },
-    "cacheTTLUnit": {
-        "message": "(en minutes)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Entrez le TTL du cache en minutes (Défaut : 10)"
-    },
-    "refreshDataButton": {
-        "message": "Actualiser les données (ignorer le cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Utilisez ce bouton pour récupérer des données fraîches immédiatement."
-    },
-    "noteTitle": {
-        "message": "Note :"
-    },
-    "viewCodeButton": {
-        "message": "Voir le code"
-    },
-    "reportIssueButton": {
-        "message": "Signaler un problème"
-    },
-    "repoFilterLabel": {
-        "message": "Filtrer par dépôts"
-    },
-    "enableFilteringLabel": {
-        "message": "Activer le filtrage"
-    },
-    "tokenRequiredWarning": {
-        "message": "Un jeton GitHub est requis pour filtrer les dépôts. Veuillez en ajouter un dans les paramètres."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Rechercher un dépôt à ajouter..."
-    },
-    "repoPlaceholder": {
-        "message": "Aucun dépôt sélectionné (tous seront inclus)"
-    },
-    "repoCountNone": {
-        "message": "0 dépôts sélectionnés"
-    },
-    "repoCount": {
-        "message": "$1 dépôts sélectionnés"
-    },
-    "repoLoading": {
-        "message": "Chargement des dépôts..."
-    },
-    "repoLoaded": {
-        "message": "$1 dépôts chargés."
-    },
-    "repoNotFound": {
-        "message": "Aucun dépôt trouvé"
-    },
-    "repoRefetching": {
-        "message": "Rechargement des dépôts..."
-    },
-    "repoLoadFailed": {
-        "message": "Échec du chargement des dépôts."
-    },
-    "repoTokenPrivate": {
-        "message": "Le jeton est invalide ou n'a pas les droits pour les dépôts privés."
-    },
-    "repoRefetchFailed": {
-        "message": "Échec du rechargement des dépôts."
-    },
-    "orgSetMessage": {
-        "message": "Organisation définie avec succès."
-    },
-    "orgClearedMessage": {
-        "message": "Organisation effacée. Cliquez sur 'Générer le rapport' pour récupérer toutes les activités."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organisation non trouvée sur GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Erreur lors de la validation de l'organisation."
-    },
-    "refreshingButton": {
-        "message": "Actualisation..."
-    },
-    "cacheClearFailed": {
-        "message": "Échec de la suppression du cache."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Génération..."
-    },
-    "copiedButton": {
-        "message": "Copié !"
-    },
-    "orgChangedMessage": {
-        "message": "Organisation modifiée. Cliquez sur 'Générer le rapport' pour récupérer les activités GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache vidé avec succès. Cliquez sur 'Générer le rapport' pour récupérer des données fraîches."
-    },
-    "cacheExpiredMessage": {
-        "message": "Le cache a expiré. Cliquez sur \"Générer\" pour récupérer des données fraîches.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Cache vidé !"
-    },
-    "extensionDisabledMessage": {
-        "message": "L'extension est désactivée. Activez-la depuis les paramètres pour générer des rapports Scrum."
-    },
-    "notePoint1": {
-        "message": "Les pull requests sont récupérées en fonction de l'activité de revue la plus récente de n'importe quel contributeur, pas seulement la vôtre. Veuillez examiner et ajuster le rapport SCRUM généré pour vous assurer qu'il reflète fidèlement votre travail avant de le partager."
-    },
-    "noteSeeIssue": {
-        "message": "Voir ce ticket"
-    },
-    "platformLabel": {
-        "message": "Plateforme"
-    },
-    "usernameLabel": {
-        "message": "Votre nom d'utilisateur"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Inclure uniquement les PRs revues dans le rapport"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Si coché, le rapport n'inclura que les PRs que vous avez revues."
-    },
-    	"usernameRequiredError": {
-		"message": "Veuillez saisir votre nom d'utilisateur pour générer un rapport."
-	},
-	"unknownPlatformError": {
-		"message": "Plateforme inconnue sélectionnée."
-	},
-	"gitlabFetchingError": {
-		"message": "Une erreur s'est produite lors de la récupération des données GitLab."
-	},
-	"reportGenerationError": {
-		"message": "Une erreur s'est produite lors de la génération du rapport."
-	},
-	"githubUserNotFoundError": {
-		"message": "Utilisateur GitHub \"$1\" introuvable (404). Veuillez vérifier le nom d'utilisateur et réessayer."
-	},
-	"githubUserValidationError": {
-		"message": "Erreur lors de la validation de l'utilisateur GitHub : $1 $2"
-	},
-	"invalidSearchQueryError": {
-		"message": "Requête de recherche ou plage de dates invalide. Veuillez vérifier le format de votre plage de dates et réessayer."
-	},
-	"githubIssuesFetchError": {
-		"message": "Erreur lors de la récupération des issues GitHub : $1 $2"
-	},
-	"githubPRReviewFetchError": {
-		"message": "Erreur lors de la récupération des données de révision de PR GitHub : $1 $2"
-	},
-	"githubUserFetchError": {
-		"message": "Erreur lors de la récupération des données utilisateur GitHub : $1 $2"
-	},
-	"invalidTokenError": {
-		"message": "Jeton GitHub invalide ou expiré. Veuillez vérifier votre jeton dans les paramètres de Scrum Helper et réessayer."
-	},
-	"displayModeNotice": {
-		"message": "L'extension s'ouvrira en mode $1 au prochain lancement."
-	},
-	"repoFilteringGithubOnly": {
-		"message": "Le filtrage des dépôts est uniquement disponible pour GitHub."
-	},
-	"repoLoadingGithubOnly": {
-		"message": "Le chargement des dépôts est uniquement disponible pour GitHub."
-	},
-	"repoFetchingGithubOnly": {
-		"message": "La récupération des dépôts est uniquement disponible pour GitHub."
-	},
-	"loadingReposAutomatically": {
-		"message": "Chargement automatique des dépôts.."
-	},
-	"gitlabUserFetchError": {
-		"message": "Erreur lors de la récupération de l'utilisateur GitLab : $1 $2"
-	},
-	"gitlabUserNotFoundError": {
-		"message": "Utilisateur GitLab '$1' introuvable"
-	},
-	"gitlabMembershipError": {
-		"message": "Erreur lors de la récupération des projets d'adhésion GitLab : $1 $2"
-	},
-	"gitlabContributedError": {
-		"message": "Erreur lors de la récupération des projets auxquels l'utilisateur a contribué sur GitLab : $1 $2"
-	},
-	"usernameMissingError": {
-		"message": "Nom d'utilisateur requis."
-	},
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Génération du rapport..."
-    },
-    "copyingReportNotification": {
-        "message": "Copie du rapport..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Insertion du rapport dans l'e-mail..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Rapport inséré dans l'e-mail !"
-   }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Rendez compte de votre progression en récupérant automatiquement votre activité Git pour une période sélectionnée."
+  },
+  "disableLabel": {
+    "message": "Désactiver"
+  },
+  "enableLabel": {
+    "message": "Activer"
+  },
+  "projectNameLabel": {
+    "message": "Nom du projet (utilisé dans l'objet de l'e-mail)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Entrez le nom de votre projet"
+  },
+  "githubUsernameLabel": {
+    "message": "Votre nom d'utilisateur GitHub"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Votre nom d'utilisateur GitLab"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Requis pour récupérer vos contributions"
+  },
+  "contributionsLabel": {
+    "message": "Récupérer vos contributions de :"
+  },
+  "last1DayLabel": {
+    "message": "Jour précédent"
+  },
+  "startDateLabel": {
+    "message": "De :"
+  },
+  "endDateLabel": {
+    "message": "À :"
+  },
+  "showOpenClosedLabel": {
+    "message": "Afficher le statut Ouvert/Fermé"
+  },
+  "blockersLabel": {
+    "message": "Qu'est-ce qui vous empêche de progresser ?"
+  },
+  "blockersPlaceholder": {
+    "message": "Entrez votre raison"
+  },
+  "scrumReportLabel": {
+    "message": "Rapport Scrum"
+  },
+  "generateReportButton": {
+    "message": "Générer"
+  },
+  "copyReportButton": {
+    "message": "Copier"
+  },
+  "insertInEmailButton": {
+    "message": "Insérer dans l’e-mail"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Nom de l'organisation"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Entrez le nom de l'organisation"
+  },
+  "setButton": {
+    "message": "Définir"
+  },
+  "githubTokenLabel": {
+    "message": "Votre jeton GitHub"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Requis pour les requêtes authentifiées"
+  },
+  "githubTokenTooltip": {
+    "message": "Pourquoi est-il recommandé d'ajouter un jeton GitHub ? Scrum Helper fonctionne sans jeton GitHub, mais l'ajout d'un jeton d'accès personnel est recommandé pour une meilleure expérience."
+  },
+  "gitlabTokenLabel": {
+    "message": "Votre jeton GitLab"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Requis pour les dépôts privés"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Pourquoi est-il recommandé d'ajouter un jeton GitLab ? Scrum Helper fonctionne sans jeton GitLab pour les projets publics, mais l'ajout d'un jeton d'accès personnel est recommandé pour une meilleure expérience."
+  },
+  "showCommitsLabel": {
+    "message": "Afficher les commits sur les PRs ouverts/ brouillons de PRs"
+  },
+  "showCommitsTooltip": {
+    "message": "Jeton Github requis, ajoutez-le dans les paramètres."
+  },
+  "onlyIssuesLabel": {
+    "message": "Inclure uniquement les problèmes dans le rapport"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Si cette case est cochée, le rapport n'inclura que les problèmes créés par l'utilisateur ou qui lui sont assignés."
+  },
+  "onlyPRsLabel": {
+    "message": "Inclure uniquement les PRs dans le rapport"
+  },
+  "onlyPRsTooltip": {
+    "message": "Si coché, le rapport n'inclura que les pull requests créées par l'utilisateur ; les pull requests revues seront exclues."
+  },
+  "cacheTTLLabel": {
+    "message": "Entrez le TTL du cache",
+    "description": "Étiquette pour le champ de saisie de la durée de vie du cache."
+  },
+  "cacheTTLUnit": {
+    "message": "(en minutes)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Entrez le TTL du cache en minutes (Défaut : 10)"
+  },
+  "refreshDataButton": {
+    "message": "Actualiser les données (ignorer le cache)"
+  },
+  "refreshDataInfo": {
+    "message": "Utilisez ce bouton pour récupérer des données fraîches immédiatement."
+  },
+  "noteTitle": {
+    "message": "Note :"
+  },
+  "viewCodeButton": {
+    "message": "Voir le code"
+  },
+  "reportIssueButton": {
+    "message": "Signaler un problème"
+  },
+  "repoFilterLabel": {
+    "message": "Filtrer par dépôts"
+  },
+  "enableFilteringLabel": {
+    "message": "Activer le filtrage"
+  },
+  "tokenRequiredWarning": {
+    "message": "Un jeton GitHub est requis pour filtrer les dépôts. Veuillez en ajouter un dans les paramètres."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Rechercher un dépôt à ajouter..."
+  },
+  "repoPlaceholder": {
+    "message": "Aucun dépôt sélectionné (tous seront inclus)"
+  },
+  "repoCountNone": {
+    "message": "0 dépôts sélectionnés"
+  },
+  "repoCount": {
+    "message": "$1 dépôts sélectionnés"
+  },
+  "repoLoading": {
+    "message": "Chargement des dépôts..."
+  },
+  "repoLoaded": {
+    "message": "$1 dépôts chargés."
+  },
+  "repoNotFound": {
+    "message": "Aucun dépôt trouvé"
+  },
+  "repoRefetching": {
+    "message": "Rechargement des dépôts..."
+  },
+  "repoLoadFailed": {
+    "message": "Échec du chargement des dépôts."
+  },
+  "repoTokenPrivate": {
+    "message": "Le jeton est invalide ou n'a pas les droits pour les dépôts privés."
+  },
+  "repoRefetchFailed": {
+    "message": "Échec du rechargement des dépôts."
+  },
+  "orgSetMessage": {
+    "message": "Organisation définie avec succès."
+  },
+  "orgClearedMessage": {
+    "message": "Organisation effacée. Cliquez sur 'Générer le rapport' pour récupérer toutes les activités."
+  },
+  "orgNotFoundMessage": {
+    "message": "Organisation non trouvée sur GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Erreur lors de la validation de l'organisation."
+  },
+  "refreshingButton": {
+    "message": "Actualisation..."
+  },
+  "cacheClearFailed": {
+    "message": "Échec de la suppression du cache."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Génération..."
+  },
+  "copiedButton": {
+    "message": "Copié !"
+  },
+  "orgChangedMessage": {
+    "message": "Organisation modifiée. Cliquez sur 'Générer le rapport' pour récupérer les activités GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Cache vidé avec succès. Cliquez sur 'Générer le rapport' pour récupérer des données fraîches."
+  },
+  "cacheExpiredMessage": {
+    "message": "Le cache a expiré. Cliquez sur \"Générer\" pour récupérer des données fraîches.",
+    "description": "Message shown when the cached data has expired and user needs to regenerate."
+  },
+  "cacheClearedButton": {
+    "message": "Cache vidé !"
+  },
+  "extensionDisabledMessage": {
+    "message": "L'extension est désactivée. Activez-la depuis les paramètres pour générer des rapports Scrum."
+  },
+  "notePoint1": {
+    "message": "Les pull requests sont récupérées en fonction de l'activité de revue la plus récente de n'importe quel contributeur, pas seulement la vôtre. Veuillez examiner et ajuster le rapport SCRUM généré pour vous assurer qu'il reflète fidèlement votre travail avant de le partager."
+  },
+  "noteSeeIssue": {
+    "message": "Voir ce ticket"
+  },
+  "platformLabel": {
+    "message": "Plateforme"
+  },
+  "usernameLabel": {
+    "message": "Votre nom d'utilisateur"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Inclure uniquement les PRs revues dans le rapport"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Si coché, le rapport n'inclura que les PRs que vous avez revues."
+  },
+  "usernameRequiredError": {
+    "message": "Veuillez saisir votre nom d'utilisateur pour générer un rapport."
+  },
+  "unknownPlatformError": {
+    "message": "Plateforme inconnue sélectionnée."
+  },
+  "gitlabFetchingError": {
+    "message": "Une erreur s'est produite lors de la récupération des données GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Une erreur s'est produite lors de la génération du rapport."
+  },
+  "githubUserNotFoundError": {
+    "message": "Utilisateur GitHub \"$1\" introuvable (404). Veuillez vérifier le nom d'utilisateur et réessayer."
+  },
+  "githubUserValidationError": {
+    "message": "Erreur lors de la validation de l'utilisateur GitHub : $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Requête de recherche ou plage de dates invalide. Veuillez vérifier le format de votre plage de dates et réessayer."
+  },
+  "githubIssuesFetchError": {
+    "message": "Erreur lors de la récupération des issues GitHub : $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Erreur lors de la récupération des données de révision de PR GitHub : $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Erreur lors de la récupération des données utilisateur GitHub : $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Jeton GitHub invalide ou expiré. Veuillez vérifier votre jeton dans les paramètres de Scrum Helper et réessayer."
+  },
+  "displayModeNotice": {
+    "message": "L'extension s'ouvrira en mode $1 au prochain lancement."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Le filtrage des dépôts est uniquement disponible pour GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Le chargement des dépôts est uniquement disponible pour GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "La récupération des dépôts est uniquement disponible pour GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Chargement automatique des dépôts.."
+  },
+  "gitlabUserFetchError": {
+    "message": "Erreur lors de la récupération de l'utilisateur GitLab : $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Utilisateur GitLab '$1' introuvable"
+  },
+  "gitlabMembershipError": {
+    "message": "Erreur lors de la récupération des projets d'adhésion GitLab : $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Erreur lors de la récupération des projets auxquels l'utilisateur a contribué sur GitLab : $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Nom d'utilisateur requis."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Génération du rapport..."
+  },
+  "copyingReportNotification": {
+    "message": "Copie du rapport..."
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Insertion du rapport dans l'e-mail..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Rapport inséré dans l'e-mail !"
+  },
+  "tokenSetupTitle": {
+    "message": "Ajouter un jeton GitHub"
+  },
+  "tokenSetupDescription": {
+    "message": "Activez les fonctionnalités avancées en ajoutant votre jeton GitHub"
+  },
+  "tokenSetupBenefits": {
+    "message": "Avantages"
+  },
+  "tokenSetupBenefit1": {
+    "message": "Limites de débit API plus élevées"
+  },
+  "tokenSetupBenefit2": {
+    "message": "Accès aux référentiels privés"
+  },
+  "tokenSetupBenefit3": {
+    "message": "Afficher les commits sur les PRs"
+  },
+  "addTokenButton": {
+    "message": "Ajouter un jeton"
+  },
+  "learnMoreLink": {
+    "message": "En savoir plus"
+  }
 }

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "דווח על התקדמות הפיתוח שלך על ידי שליפה אוטומטית של פעילות ה-Git שלך לתקופה נבחרת."
-    },
-    "disableLabel": {
-        "message": "השבת"
-    },
-    "enableLabel": {
-        "message": "הפעל"
-    },
-    "projectNameLabel": {
-        "message": "שם פרויקט (משמש בנושא האימייל)"
-    },
-    "projectNamePlaceholder": {
-        "message": "הזן את שם הפרויקט שלך"
-    },
-    "githubUsernameLabel": {
-        "message": "שם המשתמש שלך ב-GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "שם המשתמש שלך ב-GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "נדרש כדי להביא את התרומות שלך"
-    },
-    "contributionsLabel": {
-        "message": "הבא את התרומות שלך עבור:"
-    },
-    "last1DayLabel": {
-        "message": "היום הקודם"
-    },
-    "startDateLabel": {
-        "message": "מ:"
-    },
-    "endDateLabel": {
-        "message": "עד:"
-    },
-    "showOpenClosedLabel": {
-        "message": "הצג סטטוס פתוח/סגור"
-    },
-    "blockersLabel": {
-        "message": "מה מונע ממך להתקדם?"
-    },
-    "blockersPlaceholder": {
-        "message": "הזן את הסיבה שלך"
-    },
-    "scrumReportLabel": {
-        "message": "דוח סקראם"
-    },
-    "generateReportButton": {
-        "message": "צור דוח"
-    },
-    "copyReportButton": {
-        "message": "העתק דוח"
-    },
-    "insertInEmailButton": {
-        "message": "הוסף לאימייל",
-        "description": "Text for the 'Insert to Email' button."
-    },
-    "settingsOrgNameLabel": {
-        "message": "שם הארגון"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "הזן את שם הארגון"
-    },
-    "setButton": {
-        "message": "הגדר"
-    },
-    "githubTokenLabel": {
-        "message": "אסימון ה-GitHub שלך"
-    },
-    "githubTokenPlaceholder": {
-        "message": "נדרש לבקשות מאומתות"
-    },
-    "githubTokenTooltip": {
-        "message": "למה מומלץ להוסיף אסימון GitHub? Scrum Helper עובד ללא אסימון GitHub, אך הוספת אסימון גישה אישי מומלצת לחוויה טובה יותר."
-    },
-    "gitlabTokenLabel": {
-        "message": "אסימון ה-GitLab שלך"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "נדרש למאגרים פרטיים"
-    },
-    "gitlabTokenTooltip": {
-        "message": "למה מומלץ להוסיף אסימון GitLab? Scrum Helper עובד ללא אסימון GitLab לפרויקטים ציבוריים, אך הוספת אסימון גישה אישי מומלצת לחוויה טובה יותר."
-    },
-    "showCommitsLabel": {
-        "message": "הצג קומיטים ב-PR פתוחים/טיוטות PR"
-    },
-    "showCommitsTooltip": {
-        "message": "נדרש אסימון GitHub, הוסף אותו בהגדרות."
-    },
-    "onlyIssuesLabel": {
-        "message": "הכלל רק בעיות בדוח"
-    },
-    "onlyIssuesTooltip": {
-        "message": "אם מסומן, הדוח יכיל רק בעיות שנוצרו או הוקצו למשתמש."
-    },
-    "onlyPRsLabel": {
-        "message": "הכלל רק PR בדוח"
-    },
-    "onlyPRsTooltip": {
-        "message": "אם מסומן, הדוח יכיל רק pull requests שנוצרו על ידי המשתמש; PR שנסקרו יוחרגו."
-    },
-    "cacheTTLLabel": {
-        "message": "הזן TTL למטמון"
-    },
-    "cacheTTLUnit": {
-        "message": "(בדקות)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "כתוב את ה-TTL של המטמון בדקות (ברירת מחדל: 10)"
-    },
-    "refreshDataButton": {
-        "message": "רענן נתונים (עקוף מטמון)"
-    },
-    "refreshDataInfo": {
-        "message": "השתמש בכפתור זה כדי להביא נתונים טריים באופן מיידי."
-    },
-    "noteTitle": {
-        "message": "הערה:"
-    },
-    "viewCodeButton": {
-        "message": "הצג קוד"
-    },
-    "reportIssueButton": {
-        "message": "דווח על בעיה"
-    },
-    "repoFilterLabel": {
-        "message": "סנן לפי מאגרים"
-    },
-    "enableFilteringLabel": {
-        "message": "הפעל סינון"
-    },
-    "tokenRequiredWarning": {
-        "message": "נדרש אסימון GitHub לסינון מאגרים. אנא הוסף אחד בהגדרות."
-    },
-    "repoSearchPlaceholder": {
-        "message": "חפש מאגר להוספה..."
-    },
-    "repoPlaceholder": {
-        "message": "לא נבחרו מאגרים (כולם ייכללו)"
-    },
-    "repoCountNone": {
-        "message": "נבחרו 0 מאגרים"
-    },
-    "repoCount": {
-        "message": "נבחרו $1 מאגרים"
-    },
-    "repoLoading": {
-        "message": "טוען מאגרים..."
-    },
-    "repoLoaded": {
-        "message": "נטענו $1 מאגרים."
-    },
-    "repoNotFound": {
-        "message": "לא נמצאו מאגרים"
-    },
-    "repoRefetching": {
-        "message": "מביא מחדש מאגרים..."
-    },
-    "repoLoadFailed": {
-        "message": "נכשל בטעינת מאגרים."
-    },
-    "repoTokenPrivate": {
-        "message": "האסימון אינו חוקי או שאין לו הרשאות למאגרים פרטיים."
-    },
-    "repoRefetchFailed": {
-        "message": "נכשל בהבאה מחדש של מאגרים."
-    },
-    "orgSetMessage": {
-        "message": "הארגון הוגדר בהצלחה."
-    },
-    "orgClearedMessage": {
-        "message": "הארגון נוקה. לחץ על 'צור דוח' כדי להביא את כל הפעילויות."
-    },
-    "orgNotFoundMessage": {
-        "message": "הארגון לא נמצא ב-GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "שגיאה באימות הארגון."
-    },
-    "refreshingButton": {
-        "message": "מרענן..."
-    },
-    "cacheClearFailed": {
-        "message": "ניקוי המטמון נכשל."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "יוצר..."
-    },
-    "copiedButton": {
-        "message": "הועתק!"
-    },
-    "orgChangedMessage": {
-        "message": "הארגון השתנה. לחץ על 'צור דוח' כדי להביא פעילויות GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "המטמון נוקה בהצלחה. לחץ על 'צור דוח' כדי להביא נתונים טריים."
-    },
-    "cacheExpiredMessage": {
-        "message": "המטמון פג תוקף. לחץ על \"צור\" כדי להביא נתונים חדשים.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "המטמון נוקה!"
-    },
-    "extensionDisabledMessage": {
-        "message": "ההרחבה מושבתת. הפעל אותה מההגדרות כדי ליצור דוחות סקראם."
-    },
-    "notePoint1": {
-        "message": "בקשות משיכה (Pull requests) מאוחזרות על סמך פעילות הסקירה האחרונה של כל תורם, לא רק שלך. אנא בדוק והתאם את דוח ה-SCRUM שנוצר כדי לוודא שהוא משקף במדויק את עבודתך לפני השיתוף."
-    },
-    "noteSeeIssue": {
-        "message": "ראה בעיה זו"
-    },
-    "platformLabel": {
-        "message": "פלטפורמה"
-    },
-    "usernameLabel": {
-        "message": "שם המשתמש שלך"
-    },
-    "onlyRevPRsLabel": {
-        "message": "כלול בדוח רק PR שנבדקו על ידך"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "אם מסומן, הדוח יכלול רק PR שנבדקו על ידך."
-    },
-    "usernameRequiredError": {
-		"message": "אנא הזן את שם המשתמש שלך כדי ליצור דוח."
-	},
-	"unknownPlatformError": {
-		"message": "נבחרה פלטפורמה לא מוכרת."
-	},
-	"gitlabFetchingError": {
-		"message": "אירעה שגיאה בעת אחזור נתוני GitLab."
-	},
-	"reportGenerationError": {
-		"message": "אירעה שגיאה בעת יצירת הדוח."
-	},
-	"githubUserNotFoundError": {
-		"message": "משתמש GitHub \"$1\" לא נמצא (404). אנא בדוק את שם המשתמש ונסה שוב."
-	},
-	"githubUserValidationError": {
-		"message": "שגיאה באימות משתמש GitHub: $1 $2"
-	},
-	"invalidSearchQueryError": {
-		"message": "שאילתת חיפוש או טווח תאריכים לא תקינים. אנא בדוק את פורמט טווח התאריכים ונסה שוב."
-	},
-	"githubIssuesFetchError": {
-		"message": "שגיאה באחזור Issues מ-GitHub: $1 $2"
-	},
-	"githubPRReviewFetchError": {
-		"message": "שגיאה באחזור נתוני סקירת PR מ-GitHub: $1 $2"
-	},
-	"githubUserFetchError": {
-		"message": "שגיאה באחזור נתוני משתמש GitHub: $1 $2"
-	},
-	"invalidTokenError": {
-		"message": "טוקן GitHub לא תקין או שפג תוקפו. אנא בדוק את הטוקן שלך בהגדרות Scrum Helper ונסה שוב."
-	},
-	"displayModeNotice": {
-		"message": "ההרחבה תיפתח במצב $1 בהפעלה הבאה."
-	},
-	"repoFilteringGithubOnly": {
-		"message": "סינון מאגרים זמין רק עבור GitHub."
-	},
-	"repoLoadingGithubOnly": {
-		"message": "טעינת מאגרים זמינה רק עבור GitHub."
-	},
-	"repoFetchingGithubOnly": {
-		"message": "אחזור מאגרים זמין רק עבור GitHub."
-	},
-	"loadingReposAutomatically": {
-		"message": "טוען מאגרים באופן אוטומטי.."
-	},
-	"gitlabUserFetchError": {
-		"message": "שגיאה באחזור משתמש GitLab: $1 $2"
-	},
-	"gitlabUserNotFoundError": {
-		"message": "משתמש GitLab '$1' לא נמצא"
-	},
-	"gitlabMembershipError": {
-		"message": "שגיאה באחזור פרויקטי חברות ב-GitLab: $1 $2"
-	},
-	"gitlabContributedError": {
-		"message": "שגיאה באחזור פרויקטים שאליהם המשתמש תרם ב-GitLab: $1 $2"
-    },
-    "usernameMissingError": {
-		"message": "שם משתמש נדרש."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "מייצר דוח..."
-    },
-    "copyingReportNotification": {
-        "message": "מעתיק דוח..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "מוסיף דוח לאימייל..."
-    },
-    "insertedInEmailNotification": {
-        "message": "הדוח הוכנס לאימייל!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "דווח על התקדמות הפיתוח שלך על ידי שליפה אוטומטית של פעילות ה-Git שלך לתקופה נבחרת."
+  },
+  "disableLabel": {
+    "message": "השבת"
+  },
+  "enableLabel": {
+    "message": "הפעל"
+  },
+  "projectNameLabel": {
+    "message": "שם פרויקט (משמש בנושא האימייל)"
+  },
+  "projectNamePlaceholder": {
+    "message": "הזן את שם הפרויקט שלך"
+  },
+  "githubUsernameLabel": {
+    "message": "שם המשתמש שלך ב-GitHub"
+  },
+  "gitlabUsernameLabel": {
+    "message": "שם המשתמש שלך ב-GitLab"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "נדרש כדי להביא את התרומות שלך"
+  },
+  "contributionsLabel": {
+    "message": "הבא את התרומות שלך עבור:"
+  },
+  "last1DayLabel": {
+    "message": "היום הקודם"
+  },
+  "startDateLabel": {
+    "message": "מ:"
+  },
+  "endDateLabel": {
+    "message": "עד:"
+  },
+  "showOpenClosedLabel": {
+    "message": "הצג סטטוס פתוח/סגור"
+  },
+  "blockersLabel": {
+    "message": "מה מונע ממך להתקדם?"
+  },
+  "blockersPlaceholder": {
+    "message": "הזן את הסיבה שלך"
+  },
+  "scrumReportLabel": {
+    "message": "דוח סקראם"
+  },
+  "generateReportButton": {
+    "message": "צור דוח"
+  },
+  "copyReportButton": {
+    "message": "העתק דוח"
+  },
+  "insertInEmailButton": {
+    "message": "הוסף לאימייל",
+    "description": "Text for the 'Insert to Email' button."
+  },
+  "settingsOrgNameLabel": {
+    "message": "שם הארגון"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "הזן את שם הארגון"
+  },
+  "setButton": {
+    "message": "הגדר"
+  },
+  "githubTokenLabel": {
+    "message": "אסימון ה-GitHub שלך"
+  },
+  "githubTokenPlaceholder": {
+    "message": "נדרש לבקשות מאומתות"
+  },
+  "githubTokenTooltip": {
+    "message": "למה מומלץ להוסיף אסימון GitHub? Scrum Helper עובד ללא אסימון GitHub, אך הוספת אסימון גישה אישי מומלצת לחוויה טובה יותר."
+  },
+  "gitlabTokenLabel": {
+    "message": "אסימון ה-GitLab שלך"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "נדרש למאגרים פרטיים"
+  },
+  "gitlabTokenTooltip": {
+    "message": "למה מומלץ להוסיף אסימון GitLab? Scrum Helper עובד ללא אסימון GitLab לפרויקטים ציבוריים, אך הוספת אסימון גישה אישי מומלצת לחוויה טובה יותר."
+  },
+  "showCommitsLabel": {
+    "message": "הצג קומיטים ב-PR פתוחים/טיוטות PR"
+  },
+  "showCommitsTooltip": {
+    "message": "נדרש אסימון GitHub, הוסף אותו בהגדרות."
+  },
+  "onlyIssuesLabel": {
+    "message": "הכלל רק בעיות בדוח"
+  },
+  "onlyIssuesTooltip": {
+    "message": "אם מסומן, הדוח יכיל רק בעיות שנוצרו או הוקצו למשתמש."
+  },
+  "onlyPRsLabel": {
+    "message": "הכלל רק PR בדוח"
+  },
+  "onlyPRsTooltip": {
+    "message": "אם מסומן, הדוח יכיל רק pull requests שנוצרו על ידי המשתמש; PR שנסקרו יוחרגו."
+  },
+  "cacheTTLLabel": {
+    "message": "הזן TTL למטמון"
+  },
+  "cacheTTLUnit": {
+    "message": "(בדקות)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "כתוב את ה-TTL של המטמון בדקות (ברירת מחדל: 10)"
+  },
+  "refreshDataButton": {
+    "message": "רענן נתונים (עקוף מטמון)"
+  },
+  "refreshDataInfo": {
+    "message": "השתמש בכפתור זה כדי להביא נתונים טריים באופן מיידי."
+  },
+  "noteTitle": {
+    "message": "הערה:"
+  },
+  "viewCodeButton": {
+    "message": "הצג קוד"
+  },
+  "reportIssueButton": {
+    "message": "דווח על בעיה"
+  },
+  "repoFilterLabel": {
+    "message": "סנן לפי מאגרים"
+  },
+  "enableFilteringLabel": {
+    "message": "הפעל סינון"
+  },
+  "tokenRequiredWarning": {
+    "message": "נדרש אסימון GitHub לסינון מאגרים. אנא הוסף אחד בהגדרות."
+  },
+  "repoSearchPlaceholder": {
+    "message": "חפש מאגר להוספה..."
+  },
+  "repoPlaceholder": {
+    "message": "לא נבחרו מאגרים (כולם ייכללו)"
+  },
+  "repoCountNone": {
+    "message": "נבחרו 0 מאגרים"
+  },
+  "repoCount": {
+    "message": "נבחרו $1 מאגרים"
+  },
+  "repoLoading": {
+    "message": "טוען מאגרים..."
+  },
+  "repoLoaded": {
+    "message": "נטענו $1 מאגרים."
+  },
+  "repoNotFound": {
+    "message": "לא נמצאו מאגרים"
+  },
+  "repoRefetching": {
+    "message": "מביא מחדש מאגרים..."
+  },
+  "repoLoadFailed": {
+    "message": "נכשל בטעינת מאגרים."
+  },
+  "repoTokenPrivate": {
+    "message": "האסימון אינו חוקי או שאין לו הרשאות למאגרים פרטיים."
+  },
+  "repoRefetchFailed": {
+    "message": "נכשל בהבאה מחדש של מאגרים."
+  },
+  "orgSetMessage": {
+    "message": "הארגון הוגדר בהצלחה."
+  },
+  "orgClearedMessage": {
+    "message": "הארגון נוקה. לחץ על 'צור דוח' כדי להביא את כל הפעילויות."
+  },
+  "orgNotFoundMessage": {
+    "message": "הארגון לא נמצא ב-GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "שגיאה באימות הארגון."
+  },
+  "refreshingButton": {
+    "message": "מרענן..."
+  },
+  "cacheClearFailed": {
+    "message": "ניקוי המטמון נכשל."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "יוצר..."
+  },
+  "copiedButton": {
+    "message": "הועתק!"
+  },
+  "orgChangedMessage": {
+    "message": "הארגון השתנה. לחץ על 'צור דוח' כדי להביא פעילויות GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "המטמון נוקה בהצלחה. לחץ על 'צור דוח' כדי להביא נתונים טריים."
+  },
+  "cacheExpiredMessage": {
+    "message": "המטמון פג תוקף. לחץ על \"צור\" כדי להביא נתונים חדשים.",
+    "description": "Message shown when the cached data has expired and user needs to regenerate."
+  },
+  "cacheClearedButton": {
+    "message": "המטמון נוקה!"
+  },
+  "extensionDisabledMessage": {
+    "message": "ההרחבה מושבתת. הפעל אותה מההגדרות כדי ליצור דוחות סקראם."
+  },
+  "notePoint1": {
+    "message": "בקשות משיכה (Pull requests) מאוחזרות על סמך פעילות הסקירה האחרונה של כל תורם, לא רק שלך. אנא בדוק והתאם את דוח ה-SCRUM שנוצר כדי לוודא שהוא משקף במדויק את עבודתך לפני השיתוף."
+  },
+  "noteSeeIssue": {
+    "message": "ראה בעיה זו"
+  },
+  "platformLabel": {
+    "message": "פלטפורמה"
+  },
+  "usernameLabel": {
+    "message": "שם המשתמש שלך"
+  },
+  "onlyRevPRsLabel": {
+    "message": "כלול בדוח רק PR שנבדקו על ידך"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "אם מסומן, הדוח יכלול רק PR שנבדקו על ידך."
+  },
+  "usernameRequiredError": {
+    "message": "אנא הזן את שם המשתמש שלך כדי ליצור דוח."
+  },
+  "unknownPlatformError": {
+    "message": "נבחרה פלטפורמה לא מוכרת."
+  },
+  "gitlabFetchingError": {
+    "message": "אירעה שגיאה בעת אחזור נתוני GitLab."
+  },
+  "reportGenerationError": {
+    "message": "אירעה שגיאה בעת יצירת הדוח."
+  },
+  "githubUserNotFoundError": {
+    "message": "משתמש GitHub \"$1\" לא נמצא (404). אנא בדוק את שם המשתמש ונסה שוב."
+  },
+  "githubUserValidationError": {
+    "message": "שגיאה באימות משתמש GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "שאילתת חיפוש או טווח תאריכים לא תקינים. אנא בדוק את פורמט טווח התאריכים ונסה שוב."
+  },
+  "githubIssuesFetchError": {
+    "message": "שגיאה באחזור Issues מ-GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "שגיאה באחזור נתוני סקירת PR מ-GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "שגיאה באחזור נתוני משתמש GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "טוקן GitHub לא תקין או שפג תוקפו. אנא בדוק את הטוקן שלך בהגדרות Scrum Helper ונסה שוב."
+  },
+  "displayModeNotice": {
+    "message": "ההרחבה תיפתח במצב $1 בהפעלה הבאה."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "סינון מאגרים זמין רק עבור GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "טעינת מאגרים זמינה רק עבור GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "אחזור מאגרים זמין רק עבור GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "טוען מאגרים באופן אוטומטי.."
+  },
+  "gitlabUserFetchError": {
+    "message": "שגיאה באחזור משתמש GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "משתמש GitLab '$1' לא נמצא"
+  },
+  "gitlabMembershipError": {
+    "message": "שגיאה באחזור פרויקטי חברות ב-GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "שגיאה באחזור פרויקטים שאליהם המשתמש תרם ב-GitLab: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "שם משתמש נדרש."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "מייצר דוח..."
+  },
+  "copyingReportNotification": {
+    "message": "מעתיק דוח..."
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "מוסיף דוח לאימייל..."
+  },
+  "insertedInEmailNotification": {
+    "message": "הדוח הוכנס לאימייל!"
+  },
+  "tokenSetupTitle": {
+    "message": "הוסף טוקן GitHub"
+  },
+  "tokenSetupDescription": {
+    "message": "הפוך תכונות מתקדמות על ידי הוספת טוקן GitHub שלך"
+  },
+  "tokenSetupBenefits": {
+    "message": "יתרונות"
+  },
+  "tokenSetupBenefit1": {
+    "message": "מגבלות קצב API גבוהות יותר"
+  },
+  "tokenSetupBenefit2": {
+    "message": "גישה למאגרים פרטיים"
+  },
+  "tokenSetupBenefit3": {
+    "message": "הצג commits ב-PRs"
+  },
+  "addTokenButton": {
+    "message": "הוסף טוקן"
+  },
+  "learnMoreLink": {
+    "message": "למד עוד"
+  }
 }

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Laporkan kemajuan pengembangan Anda dengan mengambil aktivitas Git Anda secara otomatis untuk periode yang dipilih."
-    },
-    "disableLabel": {
-        "message": "Nonaktifkan"
-    },
-    "enableLabel": {
-        "message": "Aktifkan"
-    },
-    "projectNameLabel": {
-        "message": "Nama Proyek (digunakan di subjek email)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Masukkan nama proyek Anda"
-    },
-    "githubUsernameLabel": {
-        "message": "Nama Pengguna GitHub Anda"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Nama Pengguna GitLab Anda"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Diperlukan untuk mengambil kontribusi Anda"
-    },
-    "contributionsLabel": {
-        "message": "Ambil kontribusi Anda untuk:"
-    },
-    "last1DayLabel": {
-        "message": "Hari sebelumnya"
-    },
-    "startDateLabel": {
-        "message": "Dari:"
-    },
-    "endDateLabel": {
-        "message": "Hingga:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Tampilkan status Buka/Tutup"
-    },
-    "blockersLabel": {
-        "message": "Apa yang menghalangi kemajuan Anda?"
-    },
-    "blockersPlaceholder": {
-        "message": "Masukkan alasan Anda"
-    },
-    "scrumReportLabel": {
-        "message": "Laporan Scrum"
-    },
-    "generateReportButton": {
-        "message": "Buat"
-    },
-    "copyReportButton": {
-        "message": "Salin"
-    },
-    "insertInEmailButton": {
-        "message": "Sisipkan ke Email"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nama Organisasi"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Masukkan nama organisasi"
-    },
-    "setButton": {
-        "message": "Atur"
-    },
-    "githubTokenLabel": {
-        "message": "Token GitHub Anda"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Diperlukan untuk permintaan terotentikasi"
-    },
-    "githubTokenTooltip": {
-        "message": "Mengapa disarankan untuk menambahkan token GitHub? Scrum Helper berfungsi tanpa token GitHub, tetapi menambahkan token akses pribadi disarankan untuk pengalaman yang lebih baik."
-    },
-    "gitlabTokenLabel": {
-        "message": "Token GitLab Anda"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Diperlukan untuk repo pribadi"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Mengapa disarankan untuk menambahkan token GitLab? Scrum Helper berfungsi tanpa token GitLab untuk proyek publik, tetapi menambahkan token akses pribadi disarankan untuk pengalaman yang lebih baik."
-    },
-    "showCommitsLabel": {
-        "message": "Tampilkan commit pada PR terbuka/ draf PR"
-    },
-    "showCommitsTooltip": {
-        "message": "Token Github diperlukan, tambahkan di pengaturan."
-    },
-    "onlyIssuesLabel": {
-        "message": "Hanya sertakan masalah dalam laporan"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Jika dicentang, laporan hanya akan menyertakan masalah yang dibuat atau ditugaskan kepada pengguna."
-    },
-    "onlyPRsLabel": {
-        "message": "Hanya sertakan PR dalam laporan"
-    },
-    "onlyPRsTooltip": {
-        "message": "Jika dicentang, laporan hanya akan menyertakan PR yang dibuat oleh pengguna; PR yang telah ditinjau akan dikecualikan."
-    },
-    "cacheTTLLabel": {
-        "message": "Masukkan TTL cache",
-        "description": "Label untuk masukan time-to-live cache."
-    },
-    "cacheTTLUnit": {
-        "message": "(dalam menit)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Tulis TTL Cache dalam menit (Default: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Segarkan Data (abaikan cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Gunakan tombol ini untuk mengambil data baru segera."
-    },
-    "noteTitle": {
-        "message": "Catatan:"
-    },
-    "viewCodeButton": {
-        "message": "Lihat Kode"
-    },
-    "reportIssueButton": {
-        "message": "Laporkan Masalah"
-    },
-    "repoFilterLabel": {
-        "message": "Filter berdasarkan repositori"
-    },
-    "enableFilteringLabel": {
-        "message": "Aktifkan pemfilteran"
-    },
-    "tokenRequiredWarning": {
-        "message": "Token GitHub diperlukan untuk pemfilteran repositori. Harap tambahkan di pengaturan."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Cari repositori untuk ditambahkan..."
-    },
-    "repoPlaceholder": {
-        "message": "Tidak ada repositori yang dipilih (semua akan disertakan)"
-    },
-    "repoCountNone": {
-        "message": "0 repositori dipilih"
-    },
-    "repoCount": {
-        "message": "$1 repositori dipilih"
-    },
-    "repoLoading": {
-        "message": "Memuat repositori..."
-    },
-    "repoLoaded": {
-        "message": "$1 repositori dimuat."
-    },
-    "repoNotFound": {
-        "message": "Tidak ada repositori ditemukan"
-    },
-    "repoRefetching": {
-        "message": "Memuat ulang repositori..."
-    },
-    "repoLoadFailed": {
-        "message": "Gagal memuat repositori."
-    },
-    "repoTokenPrivate": {
-        "message": "Token tidak valid atau tidak memiliki hak untuk repo pribadi."
-    },
-    "repoRefetchFailed": {
-        "message": "Gagal memuat ulang repositori."
-    },
-    "orgSetMessage": {
-        "message": "Organisasi berhasil diatur."
-    },
-    "orgClearedMessage": {
-        "message": "Organisasi dihapus. Klik 'Buat Laporan' untuk mengambil semua aktivitas."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organisasi tidak ditemukan di GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Gagal memvalidasi organisasi."
-    },
-    "refreshingButton": {
-        "message": "Menyegarkan..."
-    },
-    "cacheClearFailed": {
-        "message": "Gagal membersihkan cache."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Membuat..."
-    },
-    "copiedButton": {
-        "message": "Tersalin!"
-    },
-    "orgChangedMessage": {
-        "message": "Organisasi diubah. Klik tombol 'Buat Laporan' untuk mengambil aktivitas GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache berhasil dihapus. Klik 'Buat Laporan' untuk mengambil data baru."
-    },
-    "cacheExpiredMessage": {
-        "message": "Cache telah kedaluwarsa. Klik \"Buat\" untuk mengambil data baru.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Cache Dihapus!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Ekstensi dinonaktifkan. Aktifkan dari opsi untuk membuat laporan scrum."
-    },
-    "notePoint1": {
-        "message": "Pull request diambil berdasarkan aktivitas review terbaru oleh kontributor mana pun, bukan hanya milik Anda. Harap tinjau dan sesuaikan laporan SCRUM yang dihasilkan untuk memastikan laporan tersebut secara akurat mencerminkan pekerjaan Anda sebelum dibagikan."
-    },
-    "noteSeeIssue": {
-        "message": "Lihat masalah ini"
-    },
-    "platformLabel": {
-        "message": "Platform"
-    },
-    "usernameLabel": {
-        "message": "Nama pengguna Anda"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Hanya sertakan PR yang ditinjau dalam laporan"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Jika dicentang, laporan hanya akan menyertakan PR yang ditinjau oleh Anda."
-    },
-    	"usernameRequiredError": {
-		"message": "Silakan masukkan nama pengguna Anda untuk membuat laporan."
-	},
-	"unknownPlatformError": {
-		"message": "Platform yang dipilih tidak dikenal."
-	},
-	"gitlabFetchingError": {
-		"message": "Terjadi kesalahan saat mengambil data GitLab."
-	},
-	"reportGenerationError": {
-		"message": "Terjadi kesalahan saat membuat laporan."
-	},
-	"githubUserNotFoundError": {
-		"message": "Pengguna GitHub \"$1\" tidak ditemukan (404). Silakan periksa nama pengguna dan coba lagi."
-	},
-	"githubUserValidationError": {
-		"message": "Kesalahan saat memvalidasi pengguna GitHub: $1 $2"
-	},
-	"invalidSearchQueryError": {
-		"message": "Kueri pencarian atau rentang tanggal tidak valid. Silakan periksa format rentang tanggal Anda dan coba lagi."
-	},
-	"githubIssuesFetchError": {
-		"message": "Kesalahan saat mengambil issue GitHub: $1 $2"
-	},
-	"githubPRReviewFetchError": {
-		"message": "Kesalahan saat mengambil data ulasan PR GitHub: $1 $2"
-	},
-	"githubUserFetchError": {
-		"message": "Kesalahan saat mengambil data pengguna GitHub: $1 $2"
-	},
-	"invalidTokenError": {
-		"message": "Token GitHub tidak valid atau telah kedaluwarsa. Silakan periksa token Anda di pengaturan Scrum Helper dan coba lagi."
-	},
-	"displayModeNotice": {
-		"message": "Ekstensi akan terbuka dalam mode $1 pada peluncuran berikutnya."
-	},
-	"repoFilteringGithubOnly": {
-		"message": "Pemfilteran repositori hanya tersedia untuk GitHub."
-	},
-	"repoLoadingGithubOnly": {
-		"message": "Pemuatan repositori hanya tersedia untuk GitHub."
-	},
-	"repoFetchingGithubOnly": {
-		"message": "Pengambilan repositori hanya tersedia untuk GitHub."
-	},
-	"loadingReposAutomatically": {
-		"message": "Memuat repositori secara otomatis.."
-	},
-	"gitlabUserFetchError": {
-		"message": "Kesalahan saat mengambil pengguna GitLab: $1 $2"
-	},
-	"gitlabUserNotFoundError": {
-		"message": "Pengguna GitLab '$1' tidak ditemukan"
-	},
-	"gitlabMembershipError": {
-		"message": "Kesalahan saat mengambil proyek keanggotaan GitLab: $1 $2"
-	},
-	"gitlabContributedError": {
-		"message": "Kesalahan saat mengambil proyek kontribusi GitLab: $1 $2"
-	},
-	"usernameMissingError": {
-		"message": "Nama pengguna diperlukan."
-	},
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Membuat laporan..."
-    },
-    "copyingReportNotification": {
-        "message": "Menyalin laporan..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Menyisipkan laporan ke email..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Laporan disisipkan ke email!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Laporkan kemajuan pengembangan Anda dengan mengambil aktivitas Git Anda secara otomatis untuk periode yang dipilih."
+  },
+  "disableLabel": {
+    "message": "Nonaktifkan"
+  },
+  "enableLabel": {
+    "message": "Aktifkan"
+  },
+  "projectNameLabel": {
+    "message": "Nama Proyek (digunakan di subjek email)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Masukkan nama proyek Anda"
+  },
+  "githubUsernameLabel": {
+    "message": "Nama Pengguna GitHub Anda"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Nama Pengguna GitLab Anda"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Diperlukan untuk mengambil kontribusi Anda"
+  },
+  "contributionsLabel": {
+    "message": "Ambil kontribusi Anda untuk:"
+  },
+  "last1DayLabel": {
+    "message": "Hari sebelumnya"
+  },
+  "startDateLabel": {
+    "message": "Dari:"
+  },
+  "endDateLabel": {
+    "message": "Hingga:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Tampilkan status Buka/Tutup"
+  },
+  "blockersLabel": {
+    "message": "Apa yang menghalangi kemajuan Anda?"
+  },
+  "blockersPlaceholder": {
+    "message": "Masukkan alasan Anda"
+  },
+  "scrumReportLabel": {
+    "message": "Laporan Scrum"
+  },
+  "generateReportButton": {
+    "message": "Buat"
+  },
+  "copyReportButton": {
+    "message": "Salin"
+  },
+  "insertInEmailButton": {
+    "message": "Sisipkan ke Email"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Nama Organisasi"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Masukkan nama organisasi"
+  },
+  "setButton": {
+    "message": "Atur"
+  },
+  "githubTokenLabel": {
+    "message": "Token GitHub Anda"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Diperlukan untuk permintaan terotentikasi"
+  },
+  "githubTokenTooltip": {
+    "message": "Mengapa disarankan untuk menambahkan token GitHub? Scrum Helper berfungsi tanpa token GitHub, tetapi menambahkan token akses pribadi disarankan untuk pengalaman yang lebih baik."
+  },
+  "gitlabTokenLabel": {
+    "message": "Token GitLab Anda"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Diperlukan untuk repo pribadi"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Mengapa disarankan untuk menambahkan token GitLab? Scrum Helper berfungsi tanpa token GitLab untuk proyek publik, tetapi menambahkan token akses pribadi disarankan untuk pengalaman yang lebih baik."
+  },
+  "showCommitsLabel": {
+    "message": "Tampilkan commit pada PR terbuka/ draf PR"
+  },
+  "showCommitsTooltip": {
+    "message": "Token Github diperlukan, tambahkan di pengaturan."
+  },
+  "onlyIssuesLabel": {
+    "message": "Hanya sertakan masalah dalam laporan"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Jika dicentang, laporan hanya akan menyertakan masalah yang dibuat atau ditugaskan kepada pengguna."
+  },
+  "onlyPRsLabel": {
+    "message": "Hanya sertakan PR dalam laporan"
+  },
+  "onlyPRsTooltip": {
+    "message": "Jika dicentang, laporan hanya akan menyertakan PR yang dibuat oleh pengguna; PR yang telah ditinjau akan dikecualikan."
+  },
+  "cacheTTLLabel": {
+    "message": "Masukkan TTL cache",
+    "description": "Label untuk masukan time-to-live cache."
+  },
+  "cacheTTLUnit": {
+    "message": "(dalam menit)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Tulis TTL Cache dalam menit (Default: 10)"
+  },
+  "refreshDataButton": {
+    "message": "Segarkan Data (abaikan cache)"
+  },
+  "refreshDataInfo": {
+    "message": "Gunakan tombol ini untuk mengambil data baru segera."
+  },
+  "noteTitle": {
+    "message": "Catatan:"
+  },
+  "viewCodeButton": {
+    "message": "Lihat Kode"
+  },
+  "reportIssueButton": {
+    "message": "Laporkan Masalah"
+  },
+  "repoFilterLabel": {
+    "message": "Filter berdasarkan repositori"
+  },
+  "enableFilteringLabel": {
+    "message": "Aktifkan pemfilteran"
+  },
+  "tokenRequiredWarning": {
+    "message": "Token GitHub diperlukan untuk pemfilteran repositori. Harap tambahkan di pengaturan."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Cari repositori untuk ditambahkan..."
+  },
+  "repoPlaceholder": {
+    "message": "Tidak ada repositori yang dipilih (semua akan disertakan)"
+  },
+  "repoCountNone": {
+    "message": "0 repositori dipilih"
+  },
+  "repoCount": {
+    "message": "$1 repositori dipilih"
+  },
+  "repoLoading": {
+    "message": "Memuat repositori..."
+  },
+  "repoLoaded": {
+    "message": "$1 repositori dimuat."
+  },
+  "repoNotFound": {
+    "message": "Tidak ada repositori ditemukan"
+  },
+  "repoRefetching": {
+    "message": "Memuat ulang repositori..."
+  },
+  "repoLoadFailed": {
+    "message": "Gagal memuat repositori."
+  },
+  "repoTokenPrivate": {
+    "message": "Token tidak valid atau tidak memiliki hak untuk repo pribadi."
+  },
+  "repoRefetchFailed": {
+    "message": "Gagal memuat ulang repositori."
+  },
+  "orgSetMessage": {
+    "message": "Organisasi berhasil diatur."
+  },
+  "orgClearedMessage": {
+    "message": "Organisasi dihapus. Klik 'Buat Laporan' untuk mengambil semua aktivitas."
+  },
+  "orgNotFoundMessage": {
+    "message": "Organisasi tidak ditemukan di GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Gagal memvalidasi organisasi."
+  },
+  "refreshingButton": {
+    "message": "Menyegarkan..."
+  },
+  "cacheClearFailed": {
+    "message": "Gagal membersihkan cache."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Membuat..."
+  },
+  "copiedButton": {
+    "message": "Tersalin!"
+  },
+  "orgChangedMessage": {
+    "message": "Organisasi diubah. Klik tombol 'Buat Laporan' untuk mengambil aktivitas GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Cache berhasil dihapus. Klik 'Buat Laporan' untuk mengambil data baru."
+  },
+  "cacheExpiredMessage": {
+    "message": "Cache telah kedaluwarsa. Klik \"Buat\" untuk mengambil data baru.",
+    "description": "Message shown when the cached data has expired and user needs to regenerate."
+  },
+  "cacheClearedButton": {
+    "message": "Cache Dihapus!"
+  },
+  "extensionDisabledMessage": {
+    "message": "Ekstensi dinonaktifkan. Aktifkan dari opsi untuk membuat laporan scrum."
+  },
+  "notePoint1": {
+    "message": "Pull request diambil berdasarkan aktivitas review terbaru oleh kontributor mana pun, bukan hanya milik Anda. Harap tinjau dan sesuaikan laporan SCRUM yang dihasilkan untuk memastikan laporan tersebut secara akurat mencerminkan pekerjaan Anda sebelum dibagikan."
+  },
+  "noteSeeIssue": {
+    "message": "Lihat masalah ini"
+  },
+  "platformLabel": {
+    "message": "Platform"
+  },
+  "usernameLabel": {
+    "message": "Nama pengguna Anda"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Hanya sertakan PR yang ditinjau dalam laporan"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Jika dicentang, laporan hanya akan menyertakan PR yang ditinjau oleh Anda."
+  },
+  "usernameRequiredError": {
+    "message": "Silakan masukkan nama pengguna Anda untuk membuat laporan."
+  },
+  "unknownPlatformError": {
+    "message": "Platform yang dipilih tidak dikenal."
+  },
+  "gitlabFetchingError": {
+    "message": "Terjadi kesalahan saat mengambil data GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Terjadi kesalahan saat membuat laporan."
+  },
+  "githubUserNotFoundError": {
+    "message": "Pengguna GitHub \"$1\" tidak ditemukan (404). Silakan periksa nama pengguna dan coba lagi."
+  },
+  "githubUserValidationError": {
+    "message": "Kesalahan saat memvalidasi pengguna GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Kueri pencarian atau rentang tanggal tidak valid. Silakan periksa format rentang tanggal Anda dan coba lagi."
+  },
+  "githubIssuesFetchError": {
+    "message": "Kesalahan saat mengambil issue GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Kesalahan saat mengambil data ulasan PR GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Kesalahan saat mengambil data pengguna GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Token GitHub tidak valid atau telah kedaluwarsa. Silakan periksa token Anda di pengaturan Scrum Helper dan coba lagi."
+  },
+  "displayModeNotice": {
+    "message": "Ekstensi akan terbuka dalam mode $1 pada peluncuran berikutnya."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Pemfilteran repositori hanya tersedia untuk GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Pemuatan repositori hanya tersedia untuk GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Pengambilan repositori hanya tersedia untuk GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Memuat repositori secara otomatis.."
+  },
+  "gitlabUserFetchError": {
+    "message": "Kesalahan saat mengambil pengguna GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Pengguna GitLab '$1' tidak ditemukan"
+  },
+  "gitlabMembershipError": {
+    "message": "Kesalahan saat mengambil proyek keanggotaan GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Kesalahan saat mengambil proyek kontribusi GitLab: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Nama pengguna diperlukan."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Membuat laporan..."
+  },
+  "copyingReportNotification": {
+    "message": "Menyalin laporan..."
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Menyisipkan laporan ke email..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Laporan disisipkan ke email!"
+  },
+  "tokenSetupTitle": {
+    "message": "Tambahkan Token GitHub"
+  },
+  "tokenSetupDescription": {
+    "message": "Aktifkan fitur lanjutan dengan menambahkan token GitHub Anda"
+  },
+  "tokenSetupBenefits": {
+    "message": "Manfaat"
+  },
+  "tokenSetupBenefit1": {
+    "message": "Batas laju API yang lebih tinggi"
+  },
+  "tokenSetupBenefit2": {
+    "message": "Akses ke repositori pribadi"
+  },
+  "tokenSetupBenefit3": {
+    "message": "Tampilkan komit di PR"
+  },
+  "addTokenButton": {
+    "message": "Tambahkan Token"
+  },
+  "learnMoreLink": {
+    "message": "Pelajari Lebih Lanjut"
+  }
 }

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Segnala i tuoi progressi di sviluppo recuperando automaticamente la tua attività Git per un periodo selezionato."
-    },
-    "disableLabel": {
-        "message": "Disabilita"
-    },
-    "enableLabel": {
-        "message": "Abilita"
-    },
-    "projectNameLabel": {
-        "message": "Nome del progetto (usato nell'oggetto dell'email)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Inserisci il nome del tuo progetto"
-    },
-    "githubUsernameLabel": {
-        "message": "Il tuo nome utente GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Il tuo nome utente GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Richiesto per recuperare i tuoi contributi"
-    },
-    "contributionsLabel": {
-        "message": "Recupera i tuoi contributi per:"
-    },
-    "last1DayLabel": {
-        "message": "Giorno precedente"
-    },
-    "startDateLabel": {
-        "message": "Da:"
-    },
-    "endDateLabel": {
-        "message": "A:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Mostra stato Aperto/Chiuso"
-    },
-    "blockersLabel": {
-        "message": "Cosa ti impedisce di progredire?"
-    },
-    "blockersPlaceholder": {
-        "message": "Inserisci il motivo"
-    },
-    "scrumReportLabel": {
-        "message": "Rapporto Scrum"
-    },
-    "generateReportButton": {
-        "message": "Genera Rapporto"
-    },
-    "copyReportButton": {
-        "message": "Copia Rapporto"
-    },
-    "insertInEmailButton": {
-        "message": "Inserisci nell'email",
-        "description": "Text for the 'Insert to Email' button."
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nome dell'organizzazione"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Inserisci il nome dell'organizzazione"
-    },
-    "setButton": {
-        "message": "Imposta"
-    },
-    "githubTokenLabel": {
-        "message": "Il tuo token GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Richiesto per richieste autenticate"
-    },
-    "githubTokenTooltip": {
-        "message": "Perché è consigliato aggiungere un token GitHub? Scrum Helper funziona senza un token GitHub, ma aggiungere un token di accesso personale è consigliato per un'esperienza migliore."
-    },
-    "gitlabTokenLabel": {
-        "message": "Il tuo token GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Richiesto per repo privati"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Perché è consigliato aggiungere un token GitLab? Scrum Helper funziona senza un token GitLab per progetti pubblici, ma aggiungere un token di accesso personale è consigliato per un'esperienza migliore."
-    },
-    "showCommitsLabel": {
-        "message": "Mostra commit su PR aperti/ bozze di PR"
-    },
-    "showCommitsTooltip": {
-        "message": "Token GitHub richiesto, aggiungilo nelle impostazioni."
-    },
-    "onlyIssuesLabel": {
-        "message": "Includi solo i problemi nel report"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Se selezionato, il report includerà solo i problemi creati o assegnati all'utente."
-    },
-    "onlyPRsLabel": {
-        "message": "Includi solo le PR nel report"
-    },
-    "onlyPRsTooltip": {
-        "message": "Se selezionato, il report includerà solo le pull request create dall'utente; le PR revisionate saranno escluse."
-    },
-    "cacheTTLLabel": {
-        "message": "Inserisci TTL della cache"
-    },
-    "cacheTTLUnit": {
-        "message": "(in minuti)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Scrivi il TTL della cache in minuti (Predefinito: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Aggiorna dati (ignora cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Usa questo pulsante per recuperare immediatamente dati aggiornati."
-    },
-    "noteTitle": {
-        "message": "Nota:"
-    },
-    "viewCodeButton": {
-        "message": "Visualizza Codice"
-    },
-    "reportIssueButton": {
-        "message": "Segnala un problema"
-    },
-    "repoFilterLabel": {
-        "message": "Filtra per repository"
-    },
-    "enableFilteringLabel": {
-        "message": "Abilita filtro"
-    },
-    "tokenRequiredWarning": {
-        "message": "È richiesto un token GitHub per filtrare i repository. Aggiungine uno nelle impostazioni."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Cerca un repository da aggiungere..."
-    },
-    "repoPlaceholder": {
-        "message": "Nessun repository selezionato (tutti saranno inclusi)"
-    },
-    "repoCountNone": {
-        "message": "0 repository selezionati"
-    },
-    "repoCount": {
-        "message": "$1 repository selezionati"
-    },
-    "repoLoading": {
-        "message": "Caricamento repository..."
-    },
-    "repoLoaded": {
-        "message": "Caricati $1 repository."
-    },
-    "repoNotFound": {
-        "message": "Nessun repository trovato"
-    },
-    "repoRefetching": {
-        "message": "Recupero repository in corso..."
-    },
-    "repoLoadFailed": {
-        "message": "Caricamento repository fallito."
-    },
-    "repoTokenPrivate": {
-        "message": "Il token non è valido o non ha i permessi per i repository privati."
-    },
-    "repoRefetchFailed": {
-        "message": "Recupero repository fallito."
-    },
-    "orgSetMessage": {
-        "message": "Organizzazione impostata con successo."
-    },
-    "orgClearedMessage": {
-        "message": "Organizzazione rimossa. Clicca 'Genera Rapporto' per recuperare tutte le attività."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organizzazione non trovata su GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Errore durante la convalida dell'organizzazione."
-    },
-    "refreshingButton": {
-        "message": "Aggiornamento..."
-    },
-    "cacheClearFailed": {
-        "message": "Pulizia della cache fallita."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Generazione in corso..."
-    },
-    "copiedButton": {
-        "message": "Copiato!"
-    },
-    "orgChangedMessage": {
-        "message": "Organizzazione modificata. Clicca 'Genera Rapporto' per recuperare le attività di GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache svuotata con successo. Clicca 'Genera Rapporto' per recuperare dati aggiornati."
-    },
-    "cacheExpiredMessage": {
-        "message": "Cache scaduta. Clicca \"Genera\" per recuperare dati aggiornati.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Cache Svuotata!"
-    },
-    "extensionDisabledMessage": {
-        "message": "L'estensione è disabilitata. Abilitala dalle impostazioni per generare rapporti scrum."
-    },
-    "notePoint1": {
-        "message": "Le pull request vengono recuperate in base all'attività di revisione più recente di qualsiasi contributore, non solo la tua. Si prega di rivedere e modificare il rapporto SCRUM generato per assicurarsi che rifletta accuratamente il proprio lavoro prima di condividerlo."
-    },
-    "noteSeeIssue": {
-        "message": "Vedi questo problema"
-    },
-    "platformLabel": {
-        "message": "Piattaforma"
-    },
-    "usernameLabel": {
-        "message": "Il tuo nome utente"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Includi solo le PR revisionate nel report"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Se selezionato, il report includerà solo le PR revisionate da te."
-    },
-    	"usernameRequiredError": {
-		"message": "Inserisci il tuo nome utente per generare un report."
-	},
-	"unknownPlatformError": {
-		"message": "Piattaforma selezionata sconosciuta."
-	},
-	"gitlabFetchingError": {
-		"message": "Si è verificato un errore durante il recupero dei dati di GitLab."
-	},
-	"reportGenerationError": {
-		"message": "Si è verificato un errore durante la generazione del report."
-	},
-	"githubUserNotFoundError": {
-		"message": "Utente GitHub \"$1\" non trovato (404). Verifica il nome utente e riprova."
-	},
-	"githubUserValidationError": {
-		"message": "Errore durante la convalida dell'utente GitHub: $1 $2"
-	},
-	"invalidSearchQueryError": {
-		"message": "Query di ricerca o intervallo di date non valido. Verifica il formato dell'intervallo di date e riprova."
-	},
-	"githubIssuesFetchError": {
-		"message": "Errore durante il recupero delle issue di GitHub: $1 $2"
-	},
-	"githubPRReviewFetchError": {
-		"message": "Errore durante il recupero dei dati di revisione PR di GitHub: $1 $2"
-	},
-	"githubUserFetchError": {
-		"message": "Errore durante il recupero dei dati dell'utente GitHub: $1 $2"
-	},
-	"invalidTokenError": {
-		"message": "Token GitHub non valido o scaduto. Verifica il tuo token nelle impostazioni di Scrum Helper e riprova."
-	},
-	"displayModeNotice": {
-		"message": "L'estensione si aprirà in modalità $1 al prossimo avvio."
-	},
-	"repoFilteringGithubOnly": {
-		"message": "Il filtro dei repository è disponibile solo per GitHub."
-	},
-	"repoLoadingGithubOnly": {
-		"message": "Il caricamento dei repository è disponibile solo per GitHub."
-	},
-	"repoFetchingGithubOnly": {
-		"message": "Il recupero dei repository è disponibile solo per GitHub."
-	},
-	"loadingReposAutomatically": {
-		"message": "Caricamento automatico dei repository.."
-	},
-	"gitlabUserFetchError": {
-		"message": "Errore durante il recupero dell'utente GitLab: $1 $2"
-	},
-	"gitlabUserNotFoundError": {
-		"message": "Utente GitLab '$1' non trovato"
-	},
-	"gitlabMembershipError": {
-		"message": "Errore durante il recupero dei progetti di appartenenza GitLab: $1 $2"
-	},
-	"gitlabContributedError": {
-		"message": "Errore durante il recupero dei progetti a cui l'utente ha contribuito su GitLab: $1 $2"
-	},
-	"usernameMissingError": {
-		"message": "Nome utente richiesto."
-	},
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Generazione del report..."
-    },
-    "copyingReportNotification": {
-        "message": "Copia del report..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Inserimento del report nell'email..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Report inserito nell'email!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Segnala i tuoi progressi di sviluppo recuperando automaticamente la tua attività Git per un periodo selezionato."
+  },
+  "disableLabel": {
+    "message": "Disabilita"
+  },
+  "enableLabel": {
+    "message": "Abilita"
+  },
+  "projectNameLabel": {
+    "message": "Nome del progetto (usato nell'oggetto dell'email)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Inserisci il nome del tuo progetto"
+  },
+  "githubUsernameLabel": {
+    "message": "Il tuo nome utente GitHub"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Il tuo nome utente GitLab"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Richiesto per recuperare i tuoi contributi"
+  },
+  "contributionsLabel": {
+    "message": "Recupera i tuoi contributi per:"
+  },
+  "last1DayLabel": {
+    "message": "Giorno precedente"
+  },
+  "startDateLabel": {
+    "message": "Da:"
+  },
+  "endDateLabel": {
+    "message": "A:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Mostra stato Aperto/Chiuso"
+  },
+  "blockersLabel": {
+    "message": "Cosa ti impedisce di progredire?"
+  },
+  "blockersPlaceholder": {
+    "message": "Inserisci il motivo"
+  },
+  "scrumReportLabel": {
+    "message": "Rapporto Scrum"
+  },
+  "generateReportButton": {
+    "message": "Genera Rapporto"
+  },
+  "copyReportButton": {
+    "message": "Copia Rapporto"
+  },
+  "insertInEmailButton": {
+    "message": "Inserisci nell'email",
+    "description": "Text for the 'Insert to Email' button."
+  },
+  "settingsOrgNameLabel": {
+    "message": "Nome dell'organizzazione"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Inserisci il nome dell'organizzazione"
+  },
+  "setButton": {
+    "message": "Imposta"
+  },
+  "githubTokenLabel": {
+    "message": "Il tuo token GitHub"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Richiesto per richieste autenticate"
+  },
+  "githubTokenTooltip": {
+    "message": "Perché è consigliato aggiungere un token GitHub? Scrum Helper funziona senza un token GitHub, ma aggiungere un token di accesso personale è consigliato per un'esperienza migliore."
+  },
+  "gitlabTokenLabel": {
+    "message": "Il tuo token GitLab"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Richiesto per repo privati"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Perché è consigliato aggiungere un token GitLab? Scrum Helper funziona senza un token GitLab per progetti pubblici, ma aggiungere un token di accesso personale è consigliato per un'esperienza migliore."
+  },
+  "showCommitsLabel": {
+    "message": "Mostra commit su PR aperti/ bozze di PR"
+  },
+  "showCommitsTooltip": {
+    "message": "Token GitHub richiesto, aggiungilo nelle impostazioni."
+  },
+  "onlyIssuesLabel": {
+    "message": "Includi solo i problemi nel report"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Se selezionato, il report includerà solo i problemi creati o assegnati all'utente."
+  },
+  "onlyPRsLabel": {
+    "message": "Includi solo le PR nel report"
+  },
+  "onlyPRsTooltip": {
+    "message": "Se selezionato, il report includerà solo le pull request create dall'utente; le PR revisionate saranno escluse."
+  },
+  "cacheTTLLabel": {
+    "message": "Inserisci TTL della cache"
+  },
+  "cacheTTLUnit": {
+    "message": "(in minuti)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Scrivi il TTL della cache in minuti (Predefinito: 10)"
+  },
+  "refreshDataButton": {
+    "message": "Aggiorna dati (ignora cache)"
+  },
+  "refreshDataInfo": {
+    "message": "Usa questo pulsante per recuperare immediatamente dati aggiornati."
+  },
+  "noteTitle": {
+    "message": "Nota:"
+  },
+  "viewCodeButton": {
+    "message": "Visualizza Codice"
+  },
+  "reportIssueButton": {
+    "message": "Segnala un problema"
+  },
+  "repoFilterLabel": {
+    "message": "Filtra per repository"
+  },
+  "enableFilteringLabel": {
+    "message": "Abilita filtro"
+  },
+  "tokenRequiredWarning": {
+    "message": "È richiesto un token GitHub per filtrare i repository. Aggiungine uno nelle impostazioni."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Cerca un repository da aggiungere..."
+  },
+  "repoPlaceholder": {
+    "message": "Nessun repository selezionato (tutti saranno inclusi)"
+  },
+  "repoCountNone": {
+    "message": "0 repository selezionati"
+  },
+  "repoCount": {
+    "message": "$1 repository selezionati"
+  },
+  "repoLoading": {
+    "message": "Caricamento repository..."
+  },
+  "repoLoaded": {
+    "message": "Caricati $1 repository."
+  },
+  "repoNotFound": {
+    "message": "Nessun repository trovato"
+  },
+  "repoRefetching": {
+    "message": "Recupero repository in corso..."
+  },
+  "repoLoadFailed": {
+    "message": "Caricamento repository fallito."
+  },
+  "repoTokenPrivate": {
+    "message": "Il token non è valido o non ha i permessi per i repository privati."
+  },
+  "repoRefetchFailed": {
+    "message": "Recupero repository fallito."
+  },
+  "orgSetMessage": {
+    "message": "Organizzazione impostata con successo."
+  },
+  "orgClearedMessage": {
+    "message": "Organizzazione rimossa. Clicca 'Genera Rapporto' per recuperare tutte le attività."
+  },
+  "orgNotFoundMessage": {
+    "message": "Organizzazione non trovata su GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Errore durante la convalida dell'organizzazione."
+  },
+  "refreshingButton": {
+    "message": "Aggiornamento..."
+  },
+  "cacheClearFailed": {
+    "message": "Pulizia della cache fallita."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Generazione in corso..."
+  },
+  "copiedButton": {
+    "message": "Copiato!"
+  },
+  "orgChangedMessage": {
+    "message": "Organizzazione modificata. Clicca 'Genera Rapporto' per recuperare le attività di GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Cache svuotata con successo. Clicca 'Genera Rapporto' per recuperare dati aggiornati."
+  },
+  "cacheExpiredMessage": {
+    "message": "Cache scaduta. Clicca \"Genera\" per recuperare dati aggiornati.",
+    "description": "Message shown when the cached data has expired and user needs to regenerate."
+  },
+  "cacheClearedButton": {
+    "message": "Cache Svuotata!"
+  },
+  "extensionDisabledMessage": {
+    "message": "L'estensione è disabilitata. Abilitala dalle impostazioni per generare rapporti scrum."
+  },
+  "notePoint1": {
+    "message": "Le pull request vengono recuperate in base all'attività di revisione più recente di qualsiasi contributore, non solo la tua. Si prega di rivedere e modificare il rapporto SCRUM generato per assicurarsi che rifletta accuratamente il proprio lavoro prima di condividerlo."
+  },
+  "noteSeeIssue": {
+    "message": "Vedi questo problema"
+  },
+  "platformLabel": {
+    "message": "Piattaforma"
+  },
+  "usernameLabel": {
+    "message": "Il tuo nome utente"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Includi solo le PR revisionate nel report"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Se selezionato, il report includerà solo le PR revisionate da te."
+  },
+  "usernameRequiredError": {
+    "message": "Inserisci il tuo nome utente per generare un report."
+  },
+  "unknownPlatformError": {
+    "message": "Piattaforma selezionata sconosciuta."
+  },
+  "gitlabFetchingError": {
+    "message": "Si è verificato un errore durante il recupero dei dati di GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Si è verificato un errore durante la generazione del report."
+  },
+  "githubUserNotFoundError": {
+    "message": "Utente GitHub \"$1\" non trovato (404). Verifica il nome utente e riprova."
+  },
+  "githubUserValidationError": {
+    "message": "Errore durante la convalida dell'utente GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Query di ricerca o intervallo di date non valido. Verifica il formato dell'intervallo di date e riprova."
+  },
+  "githubIssuesFetchError": {
+    "message": "Errore durante il recupero delle issue di GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Errore durante il recupero dei dati di revisione PR di GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Errore durante il recupero dei dati dell'utente GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Token GitHub non valido o scaduto. Verifica il tuo token nelle impostazioni di Scrum Helper e riprova."
+  },
+  "displayModeNotice": {
+    "message": "L'estensione si aprirà in modalità $1 al prossimo avvio."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Il filtro dei repository è disponibile solo per GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Il caricamento dei repository è disponibile solo per GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Il recupero dei repository è disponibile solo per GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Caricamento automatico dei repository.."
+  },
+  "gitlabUserFetchError": {
+    "message": "Errore durante il recupero dell'utente GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Utente GitLab '$1' non trovato"
+  },
+  "gitlabMembershipError": {
+    "message": "Errore durante il recupero dei progetti di appartenenza GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Errore durante il recupero dei progetti a cui l'utente ha contribuito su GitLab: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Nome utente richiesto."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Generazione del report..."
+  },
+  "copyingReportNotification": {
+    "message": "Copia del report..."
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Inserimento del report nell'email..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Report inserito nell'email!"
+  },
+  "tokenSetupTitle": {
+    "message": "Aggiungi token GitHub"
+  },
+  "tokenSetupDescription": {
+    "message": "Abilita funzionalità avanzate aggiungendo il tuo token GitHub"
+  },
+  "tokenSetupBenefits": {
+    "message": "Vantaggi"
+  },
+  "tokenSetupBenefit1": {
+    "message": "Limiti di velocità API più elevati"
+  },
+  "tokenSetupBenefit2": {
+    "message": "Accesso ai repository privati"
+  },
+  "tokenSetupBenefit3": {
+    "message": "Mostra commit su PR"
+  },
+  "addTokenButton": {
+    "message": "Aggiungi token"
+  },
+  "learnMoreLink": {
+    "message": "Ulteriori informazioni"
+  }
 }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -1,320 +1,344 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "選択した期間のGitアクティビティを自動的に取得して、開発の進捗を報告します。"
-    },
-    "disableLabel": {
-        "message": "無効にする"
-    },
-    "enableLabel": {
-        "message": "有効にする"
-    },
-    "projectNameLabel": {
-        "message": "プロジェクト名（メールの件名に使用）"
-    },
-    "projectNamePlaceholder": {
-        "message": "メール件名"
-    },
-    "githubUsernameLabel": {
-        "message": "GitHubユーザー名"
-    },
-    "gitlabUsernameLabel": {
-        "message": "GitLabユーザー名"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "コントリビューションの取得に必要です"
-    },
-    "contributionsLabel": {
-        "message": "取得するコントリビューションの期間："
-    },
-    "last1DayLabel": {
-        "message": "前日"
-    },
-    "startDateLabel": {
-        "message": "開始:"
-    },
-    "endDateLabel": {
-        "message": "終了:"
-    },
-    "showOpenClosedLabel": {
-        "message": "オープン/クローズ状態を表示"
-    },
-    "blockersLabel": {
-        "message": "進捗の妨げになっているものは何ですか？"
-    },
-    "blockersPlaceholder": {
-        "message": "理由を入力してください"
-    },
-    "scrumReportLabel": {
-        "message": "スクラムレポート"
-    },
-    "generateReportButton": {
-        "message": "レポートを生成"
-    },
-    "copyReportButton": {
-        "message": "レポートをコピー"
-    },
-    "insertInEmailButton": {
-        "message": "メールに挿入",
-        "description": "Text for the 'Insert to Email' button."
-    },
-    "settingsOrgNameLabel": {
-        "message": "組織名"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "組織名を入力してください"
-    },
-    "setButton": {
-        "message": "設定"
-    },
-    "githubTokenLabel": {
-        "message": "GitHubトークン"
-    },
-    "githubTokenPlaceholder": {
-        "message": "認証済みリクエストに必要です"
-    },
-    "githubTokenTooltip": {
-        "message": "GitHubトークンを追加することをお勧めするのはなぜですか？Scrum HelperはGitHubトークンなしで機能しますが、より良いエクスペリエンスのためにパーソナルアクセストークンを追加することをお勧めします。"
-    },
-    "gitlabTokenLabel": {
-        "message": "GitLabトークン"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "プライベートプロジェクトへのアクセスに必要です"
-    },
-    "gitlabTokenTooltip": {
-        "message": "GitLabトークンを追加することをお勧めするのはなぜですか？Scrum HelperはパブリックプロジェクトのGitLabトークンなしで機能しますが、より良いエクスペリエンスのためにパーソナルアクセストークンを追加することをお勧めします。"
-    },
-    "showCommitsLabel": {
-        "message": "オープンなPR/ドラフトPRのコミットを表示"
-    },
-    "showCommitsTooltip": {
-        "message": "GitHubトークンが必要です。設定で追加してください。"
-    },
-    "onlyIssuesLabel": {
-        "message": "レポートに課題のみを含める"
-    },
-    "onlyIssuesTooltip": {
-        "message": "チェックした場合、レポートにはユーザーが作成または割り当てられた課題のみが含まれます。"
-    },
-    "onlyPRsLabel": {
-        "message": "レポートにPRのみを含める"
-    },
-    "onlyPRsTooltip": {
-        "message": "チェックすると、レポートにはユーザーが作成したPRのみが含まれ、レビュー済みのPRは除外されます。"
-    },
-    "cacheTTLLabel": {
-        "message": "キャッシュTTLを入力",
-        "description": "キャッシュの有効期間入力のラベル。"
-    },
-    "cacheTTLUnit": {
-        "message": "（分）"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "キャッシュTTLを分単位で入力 (デフォルト: 10)"
-    },
-    "refreshDataButton": {
-        "message": "データを更新 (キャッシュを無視)"
-    },
-    "refreshDataInfo": {
-        "message": "このボタンで最新のデータをすぐに取得します。"
-    },
-    "noteTitle": {
-        "message": "注："
-    },
-    "viewCodeButton": {
-        "message": "コードを見る"
-    },
-    "reportIssueButton": {
-        "message": "問題を報告"
-    },
-    "repoFilterLabel": {
-        "message": "リポジトリでフィルタリング"
-    },
-    "enableFilteringLabel": {
-        "message": "フィルタリングを有効にする"
-    },
-    "tokenRequiredWarning": {
-        "message": "リポジトリのフィルタリングにはGitHubトークンが必要です。設定で追加してください。"
-    },
-    "repoSearchPlaceholder": {
-        "message": "追加するリポジトリを検索..."
-    },
-    "repoPlaceholder": {
-        "message": "リポジトリが選択されていません（すべて含まれます）"
-    },
-    "repoCountNone": {
-        "message": "0件のリポジトリが選択されています"
-    },
-    "repoCount": {
-        "message": "$1件のリポジトリが選択されています"
-    },
-    "repoLoading": {
-        "message": "リポジトリを読み込み中..."
-    },
-    "repoLoaded": {
-        "message": "$1件のリポジトリを読み込みました。"
-    },
-    "repoNotFound": {
-        "message": "リポジトリが見つかりません"
-    },
-    "repoRefetching": {
-        "message": "リポジトリを再読み込み中..."
-    },
-    "repoLoadFailed": {
-        "message": "リポジトリの読み込みに失敗しました。"
-    },
-    "repoTokenPrivate": {
-        "message": "トークンが無効か、プライベートリポジトリへの権限がありません。"
-    },
-    "repoRefetchFailed": {
-        "message": "リポジトリの再読み込みに失敗しました。"
-    },
-    "orgSetMessage": {
-        "message": "組織が正常に設定されました。"
-    },
-    "orgClearedMessage": {
-        "message": "組織がクリアされました。「レポートを生成」をクリックしてすべてのアクティビティを取得してください。"
-    },
-    "orgNotFoundMessage": {
-        "message": "GitHubで組織が見つかりません。"
-    },
-    "orgValidationErrorMessage": {
-        "message": "組織の検証中にエラーが発生しました。"
-    },
-    "refreshingButton": {
-        "message": "更新中..."
-    },
-    "cacheClearFailed": {
-        "message": "キャッシュのクリアに失敗しました。"
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "生成中..."
-    },
-    "copiedButton": {
-        "message": "コピーしました！"
-    },
-    "orgChangedMessage": {
-        "message": "組織が変更されました。「レポートを生成」ボタンをクリックしてGitHubアクティビティを取得してください。"
-    },
-    "cacheClearedMessage": {
-        "message": "キャッシュが正常にクリアされました。「レポートを生成」をクリックして新しいデータを取得してください。"
-    },
-    "cacheExpiredMessage": {
-        "message": "キャッシュの有効期限が切れました。「生成」をクリックして最新のデータを取得してください。",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "キャッシュクリア！"
-    },
-    "extensionDisabledMessage": {
-        "message": "拡張機能が無効です。スクラムレポートを生成するには、オプションから有効にしてください。"
-    },
-    "notePoint1": {
-        "message": "プルリクエストは、自分だけでなく、任意のコントリビューターによる最新のレビューアクティビティに基づいて取得されます。共有する前に、生成されたSCRUMレポートを確認および調整して、作業が正確に反映されていることを確認してください。"
-    },
-    "noteSeeIssue": {
-        "message": "このIssueを参照"
-    },
-    "platformLabel": {
-        "message": "プラットフォーム"
-    },
-    "usernameLabel": {
-        "message": "あなたのユーザー名"
-    },
-    "onlyRevPRsLabel": {
-        "message": "レポートにレビュー済みのPRのみを含める"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "チェックした場合、レポートにはあなたがレビューしたPRのみが含まれます。"
-    },
-    "usernameRequiredError": {
-		"message": "レポートを生成するには、ユーザー名を入力してください。"
-	},
-	"unknownPlatformError": {
-		"message": "不明なプラットフォームが選択されました。"
-	},
-	"gitlabFetchingError": {
-		"message": "GitLabデータの取得中にエラーが発生しました。"
-	},
-	"reportGenerationError": {
-		"message": "レポートの生成中にエラーが発生しました。"
-	},
-	"githubUserNotFoundError": {
-		"message": "GitHubユーザー \"$1\" が見つかりませんでした (404)。ユーザー名を確認して再試行してください。"
-	},
-	"githubUserValidationError": {
-		"message": "GitHubユーザーの検証中にエラーが発生しました: $1 $2"
-	},
-	"invalidSearchQueryError": {
-		"message": "無効な検索クエリまたは日付範囲です。日付範囲の形式を確認して再試行してください。"
-	},
-	"githubIssuesFetchError": {
-		"message": "GitHubのIssue取得中にエラーが発生しました: $1 $2"
-	},
-	"githubPRReviewFetchError": {
-		"message": "GitHubのPRレビュー データ取得中にエラーが発生しました: $1 $2"
-	},
-	"githubUserFetchError": {
-		"message": "GitHubユーザーデータ取得中にエラーが発生しました: $1 $2"
-	},
-	"invalidTokenError": {
-		"message": "GitHubトークンが無効または期限切れです。Scrum Helperの設定でトークンを確認し、再試行してください。"
-	},
-	"displayModeNotice": {
-		"message": "拡張機能は次回起動時に $1 モードで開きます。"
-	},
-	"repoFilteringGithubOnly": {
-		"message": "リポジトリのフィルタリングはGitHubでのみ利用可能です。"
-	},
-	"repoLoadingGithubOnly": {
-		"message": "リポジトリの読み込みはGitHubでのみ利用可能です。"
-	},
-	"repoFetchingGithubOnly": {
-		"message": "リポジトリの取得はGitHubでのみ利用可能です。"
-	},
-	"loadingReposAutomatically": {
-		"message": "リポジトリを自動的に読み込み中.."
-	},
-	"gitlabUserFetchError": {
-		"message": "GitLabユーザー取得中にエラーが発生しました: $1 $2"
-	},
-	"gitlabUserNotFoundError": {
-		"message": "GitLabユーザー '$1' が見つかりませんでした"
-	},
-	"gitlabMembershipError": {
-		"message": "GitLabのメンバーシッププロジェクト取得中にエラーが発生しました: $1 $2"
-	},
-	"gitlabContributedError": {
-		"message": "GitLabの貢献プロジェクト取得中にエラーが発生しました: $1 $2"
-	},
-	"usernameMissingError": {
-		"message": "ユーザー名が必要です。"
-	},
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "レポートを生成中..."
-    },
-    "copyingReportNotification": {
-        "message": "レポートをコピー中..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "レポートをメールに挿入中..."
-    },
-    "insertedInEmailNotification": {
-        "message": "レポートをメールに挿入しました！"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "選択した期間のGitアクティビティを自動的に取得して、開発の進捗を報告します。"
+  },
+  "disableLabel": {
+    "message": "無効にする"
+  },
+  "enableLabel": {
+    "message": "有効にする"
+  },
+  "projectNameLabel": {
+    "message": "プロジェクト名（メールの件名に使用）"
+  },
+  "projectNamePlaceholder": {
+    "message": "メール件名"
+  },
+  "githubUsernameLabel": {
+    "message": "GitHubユーザー名"
+  },
+  "gitlabUsernameLabel": {
+    "message": "GitLabユーザー名"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "コントリビューションの取得に必要です"
+  },
+  "contributionsLabel": {
+    "message": "取得するコントリビューションの期間："
+  },
+  "last1DayLabel": {
+    "message": "前日"
+  },
+  "startDateLabel": {
+    "message": "開始:"
+  },
+  "endDateLabel": {
+    "message": "終了:"
+  },
+  "showOpenClosedLabel": {
+    "message": "オープン/クローズ状態を表示"
+  },
+  "blockersLabel": {
+    "message": "進捗の妨げになっているものは何ですか？"
+  },
+  "blockersPlaceholder": {
+    "message": "理由を入力してください"
+  },
+  "scrumReportLabel": {
+    "message": "スクラムレポート"
+  },
+  "generateReportButton": {
+    "message": "レポートを生成"
+  },
+  "copyReportButton": {
+    "message": "レポートをコピー"
+  },
+  "insertInEmailButton": {
+    "message": "メールに挿入",
+    "description": "Text for the 'Insert to Email' button."
+  },
+  "settingsOrgNameLabel": {
+    "message": "組織名"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "組織名を入力してください"
+  },
+  "setButton": {
+    "message": "設定"
+  },
+  "githubTokenLabel": {
+    "message": "GitHubトークン"
+  },
+  "githubTokenPlaceholder": {
+    "message": "認証済みリクエストに必要です"
+  },
+  "githubTokenTooltip": {
+    "message": "GitHubトークンを追加することをお勧めするのはなぜですか？Scrum HelperはGitHubトークンなしで機能しますが、より良いエクスペリエンスのためにパーソナルアクセストークンを追加することをお勧めします。"
+  },
+  "gitlabTokenLabel": {
+    "message": "GitLabトークン"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "プライベートプロジェクトへのアクセスに必要です"
+  },
+  "gitlabTokenTooltip": {
+    "message": "GitLabトークンを追加することをお勧めするのはなぜですか？Scrum HelperはパブリックプロジェクトのGitLabトークンなしで機能しますが、より良いエクスペリエンスのためにパーソナルアクセストークンを追加することをお勧めします。"
+  },
+  "showCommitsLabel": {
+    "message": "オープンなPR/ドラフトPRのコミットを表示"
+  },
+  "showCommitsTooltip": {
+    "message": "GitHubトークンが必要です。設定で追加してください。"
+  },
+  "onlyIssuesLabel": {
+    "message": "レポートに課題のみを含める"
+  },
+  "onlyIssuesTooltip": {
+    "message": "チェックした場合、レポートにはユーザーが作成または割り当てられた課題のみが含まれます。"
+  },
+  "onlyPRsLabel": {
+    "message": "レポートにPRのみを含める"
+  },
+  "onlyPRsTooltip": {
+    "message": "チェックすると、レポートにはユーザーが作成したPRのみが含まれ、レビュー済みのPRは除外されます。"
+  },
+  "cacheTTLLabel": {
+    "message": "キャッシュTTLを入力",
+    "description": "キャッシュの有効期間入力のラベル。"
+  },
+  "cacheTTLUnit": {
+    "message": "（分）"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "キャッシュTTLを分単位で入力 (デフォルト: 10)"
+  },
+  "refreshDataButton": {
+    "message": "データを更新 (キャッシュを無視)"
+  },
+  "refreshDataInfo": {
+    "message": "このボタンで最新のデータをすぐに取得します。"
+  },
+  "noteTitle": {
+    "message": "注："
+  },
+  "viewCodeButton": {
+    "message": "コードを見る"
+  },
+  "reportIssueButton": {
+    "message": "問題を報告"
+  },
+  "repoFilterLabel": {
+    "message": "リポジトリでフィルタリング"
+  },
+  "enableFilteringLabel": {
+    "message": "フィルタリングを有効にする"
+  },
+  "tokenRequiredWarning": {
+    "message": "リポジトリのフィルタリングにはGitHubトークンが必要です。設定で追加してください。"
+  },
+  "repoSearchPlaceholder": {
+    "message": "追加するリポジトリを検索..."
+  },
+  "repoPlaceholder": {
+    "message": "リポジトリが選択されていません（すべて含まれます）"
+  },
+  "repoCountNone": {
+    "message": "0件のリポジトリが選択されています"
+  },
+  "repoCount": {
+    "message": "$1件のリポジトリが選択されています"
+  },
+  "repoLoading": {
+    "message": "リポジトリを読み込み中..."
+  },
+  "repoLoaded": {
+    "message": "$1件のリポジトリを読み込みました。"
+  },
+  "repoNotFound": {
+    "message": "リポジトリが見つかりません"
+  },
+  "repoRefetching": {
+    "message": "リポジトリを再読み込み中..."
+  },
+  "repoLoadFailed": {
+    "message": "リポジトリの読み込みに失敗しました。"
+  },
+  "repoTokenPrivate": {
+    "message": "トークンが無効か、プライベートリポジトリへの権限がありません。"
+  },
+  "repoRefetchFailed": {
+    "message": "リポジトリの再読み込みに失敗しました。"
+  },
+  "orgSetMessage": {
+    "message": "組織が正常に設定されました。"
+  },
+  "orgClearedMessage": {
+    "message": "組織がクリアされました。「レポートを生成」をクリックしてすべてのアクティビティを取得してください。"
+  },
+  "orgNotFoundMessage": {
+    "message": "GitHubで組織が見つかりません。"
+  },
+  "orgValidationErrorMessage": {
+    "message": "組織の検証中にエラーが発生しました。"
+  },
+  "refreshingButton": {
+    "message": "更新中..."
+  },
+  "cacheClearFailed": {
+    "message": "キャッシュのクリアに失敗しました。"
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "生成中..."
+  },
+  "copiedButton": {
+    "message": "コピーしました！"
+  },
+  "orgChangedMessage": {
+    "message": "組織が変更されました。「レポートを生成」ボタンをクリックしてGitHubアクティビティを取得してください。"
+  },
+  "cacheClearedMessage": {
+    "message": "キャッシュが正常にクリアされました。「レポートを生成」をクリックして新しいデータを取得してください。"
+  },
+  "cacheExpiredMessage": {
+    "message": "キャッシュの有効期限が切れました。「生成」をクリックして最新のデータを取得してください。",
+    "description": "Message shown when the cached data has expired and user needs to regenerate."
+  },
+  "cacheClearedButton": {
+    "message": "キャッシュクリア！"
+  },
+  "extensionDisabledMessage": {
+    "message": "拡張機能が無効です。スクラムレポートを生成するには、オプションから有効にしてください。"
+  },
+  "notePoint1": {
+    "message": "プルリクエストは、自分だけでなく、任意のコントリビューターによる最新のレビューアクティビティに基づいて取得されます。共有する前に、生成されたSCRUMレポートを確認および調整して、作業が正確に反映されていることを確認してください。"
+  },
+  "noteSeeIssue": {
+    "message": "このIssueを参照"
+  },
+  "platformLabel": {
+    "message": "プラットフォーム"
+  },
+  "usernameLabel": {
+    "message": "あなたのユーザー名"
+  },
+  "onlyRevPRsLabel": {
+    "message": "レポートにレビュー済みのPRのみを含める"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "チェックした場合、レポートにはあなたがレビューしたPRのみが含まれます。"
+  },
+  "usernameRequiredError": {
+    "message": "レポートを生成するには、ユーザー名を入力してください。"
+  },
+  "unknownPlatformError": {
+    "message": "不明なプラットフォームが選択されました。"
+  },
+  "gitlabFetchingError": {
+    "message": "GitLabデータの取得中にエラーが発生しました。"
+  },
+  "reportGenerationError": {
+    "message": "レポートの生成中にエラーが発生しました。"
+  },
+  "githubUserNotFoundError": {
+    "message": "GitHubユーザー \"$1\" が見つかりませんでした (404)。ユーザー名を確認して再試行してください。"
+  },
+  "githubUserValidationError": {
+    "message": "GitHubユーザーの検証中にエラーが発生しました: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "無効な検索クエリまたは日付範囲です。日付範囲の形式を確認して再試行してください。"
+  },
+  "githubIssuesFetchError": {
+    "message": "GitHubのIssue取得中にエラーが発生しました: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "GitHubのPRレビュー データ取得中にエラーが発生しました: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "GitHubユーザーデータ取得中にエラーが発生しました: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "GitHubトークンが無効または期限切れです。Scrum Helperの設定でトークンを確認し、再試行してください。"
+  },
+  "displayModeNotice": {
+    "message": "拡張機能は次回起動時に $1 モードで開きます。"
+  },
+  "repoFilteringGithubOnly": {
+    "message": "リポジトリのフィルタリングはGitHubでのみ利用可能です。"
+  },
+  "repoLoadingGithubOnly": {
+    "message": "リポジトリの読み込みはGitHubでのみ利用可能です。"
+  },
+  "repoFetchingGithubOnly": {
+    "message": "リポジトリの取得はGitHubでのみ利用可能です。"
+  },
+  "loadingReposAutomatically": {
+    "message": "リポジトリを自動的に読み込み中.."
+  },
+  "gitlabUserFetchError": {
+    "message": "GitLabユーザー取得中にエラーが発生しました: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "GitLabユーザー '$1' が見つかりませんでした"
+  },
+  "gitlabMembershipError": {
+    "message": "GitLabのメンバーシッププロジェクト取得中にエラーが発生しました: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "GitLabの貢献プロジェクト取得中にエラーが発生しました: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "ユーザー名が必要です。"
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "レポートを生成中..."
+  },
+  "copyingReportNotification": {
+    "message": "レポートをコピー中..."
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "レポートをメールに挧入中..."
+  },
+  "insertedInEmailNotification": {
+    "message": "レポートをメールに挧入しました！"
+  },
+  "tokenSetupTitle": {
+    "message": "GitHubトークンを追加"
+  },
+  "tokenSetupDescription": {
+    "message": "GitHubトークンを追加して高度な機能を有効にします"
+  },
+  "tokenSetupBenefits": {
+    "message": "利点"
+  },
+  "tokenSetupBenefit1": {
+    "message": "高いAPIレート制限"
+  },
+  "tokenSetupBenefit2": {
+    "message": "プライベートリポジトリへのアクセス"
+  },
+  "tokenSetupBenefit3": {
+    "message": "PRのコミットを表示"
+  },
+  "addTokenButton": {
+    "message": "トークンを追加"
+  },
+  "learnMoreLink": {
+    "message": "詳細はこちら"
+  }
 }

--- a/src/_locales/nb/messages.json
+++ b/src/_locales/nb/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Rapporter utviklingsfremgangen din ved å automatisk hente Git-aktiviteten din for en valgt periode."
-    },
-    "disableLabel": {
-        "message": "Deaktiver"
-    },
-    "enableLabel": {
-        "message": "Aktiver"
-    },
-    "projectNameLabel": {
-        "message": "Prosjektnavn (brukes i e-postemne)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Skriv inn prosjektnavnet ditt"
-    },
-    "githubUsernameLabel": {
-        "message": "Ditt GitHub-brukernavn"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Ditt GitLab-brukernavn"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Påkrevd for å hente bidragene dine"
-    },
-    "contributionsLabel": {
-        "message": "Hent dine bidrag for:"
-    },
-    "last1DayLabel": {
-        "message": "Forrige dag"
-    },
-    "startDateLabel": {
-        "message": "Fra:"
-    },
-    "endDateLabel": {
-        "message": "Til:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Vis Åpen/Lukket-status"
-    },
-    "blockersLabel": {
-        "message": "Hva hindrer deg i å gjøre fremgang?"
-    },
-    "blockersPlaceholder": {
-        "message": "Skriv inn din grunn"
-    },
-    "scrumReportLabel": {
-        "message": "Scrum-rapport"
-    },
-    "generateReportButton": {
-        "message": "Generer rapport"
-    },
-    "copyReportButton": {
-        "message": "Kopier rapport"
-    },
-    "insertInEmailButton": {
-        "message": "Sett inn i e-post",
-        "description": "Text for the 'Insert to Email' button."
-    },
-    "settingsOrgNameLabel": {
-        "message": "Organisasjonsnavn"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Skriv inn organisasjonsnavn"
-    },
-    "setButton": {
-        "message": "Angi"
-    },
-    "githubTokenLabel": {
-        "message": "Ditt GitHub-token"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Påkrevd for autentiserte forespørsler"
-    },
-    "githubTokenTooltip": {
-        "message": "Hvorfor anbefales det å legge til et GitHub-token? Scrum Helper fungerer uten et GitHub-token, men det anbefales å legge til et personlig tilgangstoken for en bedre opplevelse."
-    },
-    "gitlabTokenLabel": {
-        "message": "Ditt GitLab-token"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Påkrevd for private repositorier"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Hvorfor anbefales det å legge til et GitLab-token? Scrum Helper fungerer uten et GitLab-token for offentlige prosjekter, men det anbefales å legge til et personlig tilgangstoken for en bedre opplevelse."
-    },
-    "showCommitsLabel": {
-        "message": "Vis commits på åpne PR-er/utkast til PR-er"
-    },
-    "showCommitsTooltip": {
-        "message": "GitHub-token kreves. Legg det til i innstillingene."
-    },
-    "onlyIssuesLabel": {
-        "message": "Inkluder kun problemer i rapporten"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Hvis valgt, vil rapporten kun inkludere problemer opprettet eller tildelt brukeren."
-    },
-    "onlyPRsLabel": {
-        "message": "Inkluder kun PR-er i rapporten"
-    },
-    "onlyPRsTooltip": {
-        "message": "Hvis valgt, vil rapporten kun inkludere PR-er opprettet av brukeren; gjennomgåtte PR-er vil utelates."
-    },
-    "cacheTTLLabel": {
-        "message": "Angi cache-TTL"
-    },
-    "cacheTTLUnit": {
-        "message": "(i minutter)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Skriv inn cache-TTL i minutter (Standard: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Oppdater data (omgå cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Bruk denne knappen for å hente ferske data umiddelbart."
-    },
-    "noteTitle": {
-        "message": "Merk:"
-    },
-    "viewCodeButton": {
-        "message": "Se kode"
-    },
-    "reportIssueButton": {
-        "message": "Rapporter et problem"
-    },
-    "repoFilterLabel": {
-        "message": "Filtrer etter repositorier"
-    },
-    "enableFilteringLabel": {
-        "message": "Aktiver filtrering"
-    },
-    "tokenRequiredWarning": {
-        "message": "Et GitHub-token er påkrevd for repositoriefiltrering. Vennligst legg til ett i innstillingene."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Søk etter et repositorium for å legge til..."
-    },
-    "repoPlaceholder": {
-        "message": "Ingen repositorier valgt (alle vil bli inkludert)"
-    },
-    "repoCountNone": {
-        "message": "0 repositorier valgt"
-    },
-    "repoCount": {
-        "message": "$1 repositorier valgt"
-    },
-    "repoLoading": {
-        "message": "Laster repositorier..."
-    },
-    "repoLoaded": {
-        "message": "Lastet $1 repositorier."
-    },
-    "repoNotFound": {
-        "message": "Ingen repositorier funnet"
-    },
-    "repoRefetching": {
-        "message": "Henter repositorier på nytt..."
-    },
-    "repoLoadFailed": {
-        "message": "Kunne ikke laste repositorier."
-    },
-    "repoTokenPrivate": {
-        "message": "Tokenet er ugyldig eller har ikke rettigheter for private repositorier."
-    },
-    "repoRefetchFailed": {
-        "message": "Kunne ikke hente repositorier på nytt."
-    },
-    "orgSetMessage": {
-        "message": "Organisasjon satt."
-    },
-    "orgClearedMessage": {
-        "message": "Organisasjon fjernet. Klikk 'Generer rapport' for å hente alle aktiviteter."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organisasjon ikke funnet på GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Feil ved validering av organisasjon."
-    },
-    "refreshingButton": {
-        "message": "Oppdaterer..."
-    },
-    "cacheClearFailed": {
-        "message": "Tømming av cache mislyktes."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Genererer..."
-    },
-    "copiedButton": {
-        "message": "Kopiert!"
-    },
-    "orgChangedMessage": {
-        "message": "Organisasjon endret. Klikk 'Generer rapport' for å hente GitHub-aktiviteter."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache tømt. Klikk 'Generer rapport' for å hente ferske data."
-    },
-    "cacheExpiredMessage": {
-        "message": "Hurtigbufferen har utløpt. Klikk \"Generer\" for å hente nye data.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Cache tømt!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Utvidelsen er deaktivert. Aktiver den fra innstillingene for å generere scrum-rapporter."
-    },
-    "notePoint1": {
-        "message": "Pull-forespørsler hentes basert på den siste gjennomgangsaktiviteten til enhver bidragsyter, ikke bare din egen. Vennligst gjennomgå og juster den genererte SCRUM-rapporten for å sikre at den nøyaktig gjenspeiler arbeidet ditt før du deler den."
-    },
-    "noteSeeIssue": {
-        "message": "Se dette problemet"
-    },
-    "platformLabel": {
-        "message": "Plattform"
-    },
-    "usernameLabel": {
-        "message": "Ditt brukernavn"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Inkluder kun gjennomgåtte PR-er i rapporten"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Hvis valgt, vil rapporten kun inkludere PR-er gjennomgått av deg."
-    },
-    "usernameRequiredError": {
-        "message": "Vennligst skriv inn brukernavn for å generere rapport."
-    },
-    "unknownPlatformError": {
-        "message": "Ukjent plattform valgt."
-    },
-    "gitlabFetchingError": {
-        "message": "En feil oppstod under henting av GitLab-data."
-    },
-    "reportGenerationError": {
-        "message": "En feil oppstod under generering av rapporten."
-    },
-    "githubUserNotFoundError": {
-        "message": "GitHub-bruker \"$1\" ikke funnet (404). Sjekk brukernavnet og prøv igjen."
-    },
-    "githubUserValidationError": {
-        "message": "Feil ved validering av GitHub-bruker: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Ugyldig søkespørring eller datoperiode. Sjekk formatet og prøv igjen."
-    },
-    "githubIssuesFetchError": {
-        "message": "Feil ved henting av GitHub-issues: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Feil ved henting av GitHub PR-review-data: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Feil ved henting av GitHub-brukerdata: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Ugyldig eller utløpt GitHub-token. Sjekk tokenet i Scrum Helper-innstillingene og prøv igjen."
-    },
-    "displayModeNotice": {
-        "message": "Utvidelsen åpnes i $1-modus ved neste oppstart."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Repositoriefiltrering er kun tilgjengelig for GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Repositorielasting er kun tilgjengelig for GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Repositoriehenting er kun tilgjengelig for GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Laster repositorier automatisk..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Feil ved henting av GitLab-bruker: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "GitLab-bruker '$1' ikke funnet"
-    },
-    "gitlabMembershipError": {
-        "message": "Feil ved henting av GitLab-medlemskapsprosjekter: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Feil ved henting av GitLab-bidragsprosjekter: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Brukernavn påkrevd."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Genererer rapport..."
-    },
-    "copyingReportNotification": {
-        "message": "Kopierer rapport..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Setter inn rapport i e-post..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Rapport satt inn i e-post!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Rapporter utviklingsfremgangen din ved å automatisk hente Git-aktiviteten din for en valgt periode."
+  },
+  "disableLabel": {
+    "message": "Deaktiver"
+  },
+  "enableLabel": {
+    "message": "Aktiver"
+  },
+  "projectNameLabel": {
+    "message": "Prosjektnavn (brukes i e-postemne)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Skriv inn prosjektnavnet ditt"
+  },
+  "githubUsernameLabel": {
+    "message": "Ditt GitHub-brukernavn"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Ditt GitLab-brukernavn"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Påkrevd for å hente bidragene dine"
+  },
+  "contributionsLabel": {
+    "message": "Hent dine bidrag for:"
+  },
+  "last1DayLabel": {
+    "message": "Forrige dag"
+  },
+  "startDateLabel": {
+    "message": "Fra:"
+  },
+  "endDateLabel": {
+    "message": "Til:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Vis Åpen/Lukket-status"
+  },
+  "blockersLabel": {
+    "message": "Hva hindrer deg i å gjøre fremgang?"
+  },
+  "blockersPlaceholder": {
+    "message": "Skriv inn din grunn"
+  },
+  "scrumReportLabel": {
+    "message": "Scrum-rapport"
+  },
+  "generateReportButton": {
+    "message": "Generer rapport"
+  },
+  "copyReportButton": {
+    "message": "Kopier rapport"
+  },
+  "insertInEmailButton": {
+    "message": "Sett inn i e-post",
+    "description": "Text for the 'Insert to Email' button."
+  },
+  "settingsOrgNameLabel": {
+    "message": "Organisasjonsnavn"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Skriv inn organisasjonsnavn"
+  },
+  "setButton": {
+    "message": "Angi"
+  },
+  "githubTokenLabel": {
+    "message": "Ditt GitHub-token"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Påkrevd for autentiserte forespørsler"
+  },
+  "githubTokenTooltip": {
+    "message": "Hvorfor anbefales det å legge til et GitHub-token? Scrum Helper fungerer uten et GitHub-token, men det anbefales å legge til et personlig tilgangstoken for en bedre opplevelse."
+  },
+  "gitlabTokenLabel": {
+    "message": "Ditt GitLab-token"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Påkrevd for private repositorier"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Hvorfor anbefales det å legge til et GitLab-token? Scrum Helper fungerer uten et GitLab-token for offentlige prosjekter, men det anbefales å legge til et personlig tilgangstoken for en bedre opplevelse."
+  },
+  "showCommitsLabel": {
+    "message": "Vis commits på åpne PR-er/utkast til PR-er"
+  },
+  "showCommitsTooltip": {
+    "message": "GitHub-token kreves. Legg det til i innstillingene."
+  },
+  "onlyIssuesLabel": {
+    "message": "Inkluder kun problemer i rapporten"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Hvis valgt, vil rapporten kun inkludere problemer opprettet eller tildelt brukeren."
+  },
+  "onlyPRsLabel": {
+    "message": "Inkluder kun PR-er i rapporten"
+  },
+  "onlyPRsTooltip": {
+    "message": "Hvis valgt, vil rapporten kun inkludere PR-er opprettet av brukeren; gjennomgåtte PR-er vil utelates."
+  },
+  "cacheTTLLabel": {
+    "message": "Angi cache-TTL"
+  },
+  "cacheTTLUnit": {
+    "message": "(i minutter)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Skriv inn cache-TTL i minutter (Standard: 10)"
+  },
+  "refreshDataButton": {
+    "message": "Oppdater data (omgå cache)"
+  },
+  "refreshDataInfo": {
+    "message": "Bruk denne knappen for å hente ferske data umiddelbart."
+  },
+  "noteTitle": {
+    "message": "Merk:"
+  },
+  "viewCodeButton": {
+    "message": "Se kode"
+  },
+  "reportIssueButton": {
+    "message": "Rapporter et problem"
+  },
+  "repoFilterLabel": {
+    "message": "Filtrer etter repositorier"
+  },
+  "enableFilteringLabel": {
+    "message": "Aktiver filtrering"
+  },
+  "tokenRequiredWarning": {
+    "message": "Et GitHub-token er påkrevd for repositoriefiltrering. Vennligst legg til ett i innstillingene."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Søk etter et repositorium for å legge til..."
+  },
+  "repoPlaceholder": {
+    "message": "Ingen repositorier valgt (alle vil bli inkludert)"
+  },
+  "repoCountNone": {
+    "message": "0 repositorier valgt"
+  },
+  "repoCount": {
+    "message": "$1 repositorier valgt"
+  },
+  "repoLoading": {
+    "message": "Laster repositorier..."
+  },
+  "repoLoaded": {
+    "message": "Lastet $1 repositorier."
+  },
+  "repoNotFound": {
+    "message": "Ingen repositorier funnet"
+  },
+  "repoRefetching": {
+    "message": "Henter repositorier på nytt..."
+  },
+  "repoLoadFailed": {
+    "message": "Kunne ikke laste repositorier."
+  },
+  "repoTokenPrivate": {
+    "message": "Tokenet er ugyldig eller har ikke rettigheter for private repositorier."
+  },
+  "repoRefetchFailed": {
+    "message": "Kunne ikke hente repositorier på nytt."
+  },
+  "orgSetMessage": {
+    "message": "Organisasjon satt."
+  },
+  "orgClearedMessage": {
+    "message": "Organisasjon fjernet. Klikk 'Generer rapport' for å hente alle aktiviteter."
+  },
+  "orgNotFoundMessage": {
+    "message": "Organisasjon ikke funnet på GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Feil ved validering av organisasjon."
+  },
+  "refreshingButton": {
+    "message": "Oppdaterer..."
+  },
+  "cacheClearFailed": {
+    "message": "Tømming av cache mislyktes."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Genererer..."
+  },
+  "copiedButton": {
+    "message": "Kopiert!"
+  },
+  "orgChangedMessage": {
+    "message": "Organisasjon endret. Klikk 'Generer rapport' for å hente GitHub-aktiviteter."
+  },
+  "cacheClearedMessage": {
+    "message": "Cache tømt. Klikk 'Generer rapport' for å hente ferske data."
+  },
+  "cacheExpiredMessage": {
+    "message": "Hurtigbufferen har utløpt. Klikk \"Generer\" for å hente nye data.",
+    "description": "Message shown when the cached data has expired and user needs to regenerate."
+  },
+  "cacheClearedButton": {
+    "message": "Cache tømt!"
+  },
+  "extensionDisabledMessage": {
+    "message": "Utvidelsen er deaktivert. Aktiver den fra innstillingene for å generere scrum-rapporter."
+  },
+  "notePoint1": {
+    "message": "Pull-forespørsler hentes basert på den siste gjennomgangsaktiviteten til enhver bidragsyter, ikke bare din egen. Vennligst gjennomgå og juster den genererte SCRUM-rapporten for å sikre at den nøyaktig gjenspeiler arbeidet ditt før du deler den."
+  },
+  "noteSeeIssue": {
+    "message": "Se dette problemet"
+  },
+  "platformLabel": {
+    "message": "Plattform"
+  },
+  "usernameLabel": {
+    "message": "Ditt brukernavn"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Inkluder kun gjennomgåtte PR-er i rapporten"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Hvis valgt, vil rapporten kun inkludere PR-er gjennomgått av deg."
+  },
+  "usernameRequiredError": {
+    "message": "Vennligst skriv inn brukernavn for å generere rapport."
+  },
+  "unknownPlatformError": {
+    "message": "Ukjent plattform valgt."
+  },
+  "gitlabFetchingError": {
+    "message": "En feil oppstod under henting av GitLab-data."
+  },
+  "reportGenerationError": {
+    "message": "En feil oppstod under generering av rapporten."
+  },
+  "githubUserNotFoundError": {
+    "message": "GitHub-bruker \"$1\" ikke funnet (404). Sjekk brukernavnet og prøv igjen."
+  },
+  "githubUserValidationError": {
+    "message": "Feil ved validering av GitHub-bruker: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Ugyldig søkespørring eller datoperiode. Sjekk formatet og prøv igjen."
+  },
+  "githubIssuesFetchError": {
+    "message": "Feil ved henting av GitHub-issues: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Feil ved henting av GitHub PR-review-data: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Feil ved henting av GitHub-brukerdata: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Ugyldig eller utløpt GitHub-token. Sjekk tokenet i Scrum Helper-innstillingene og prøv igjen."
+  },
+  "displayModeNotice": {
+    "message": "Utvidelsen åpnes i $1-modus ved neste oppstart."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Repositoriefiltrering er kun tilgjengelig for GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Repositorielasting er kun tilgjengelig for GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Repositoriehenting er kun tilgjengelig for GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Laster repositorier automatisk..."
+  },
+  "gitlabUserFetchError": {
+    "message": "Feil ved henting av GitLab-bruker: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "GitLab-bruker '$1' ikke funnet"
+  },
+  "gitlabMembershipError": {
+    "message": "Feil ved henting av GitLab-medlemskapsprosjekter: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Feil ved henting av GitLab-bidragsprosjekter: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Brukernavn påkrevd."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Genererer rapport..."
+  },
+  "copyingReportNotification": {
+    "message": "Kopierer rapport..."
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Setter inn rapport i e-post..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Rapport satt inn i e-post!"
+  },
+  "tokenSetupTitle": {
+    "message": "Legg til GitHub-token"
+  },
+  "tokenSetupDescription": {
+    "message": "Aktiver avanserte funksjoner ved \u00e5 legge til GitHub-tokenet ditt"
+  },
+  "tokenSetupBenefits": {
+    "message": "Fordeler"
+  },
+  "tokenSetupBenefit1": {
+    "message": "H\u00f8yere API-hastighetsbegr\u00e6nsninger"
+  },
+  "tokenSetupBenefit2": {
+    "message": "Tilgang til private repositories"
+  },
+  "tokenSetupBenefit3": {
+    "message": "Vis commits p\u00e5 PR-er"
+  },
+  "addTokenButton": {
+    "message": "Legg til token"
+  },
+  "learnMoreLink": {
+    "message": "L\u00e6r mer"
+  }
 }

--- a/src/_locales/pt/messages.json
+++ b/src/_locales/pt/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Relate o seu progresso de desenvolvimento buscando automaticamente a sua atividade no Git para um período selecionado"
-    },
-    "disableLabel": {
-        "message": "Desativar"
-    },
-    "enableLabel": {
-        "message": "Ativar"
-    },
-    "projectNameLabel": {
-        "message": "Nome do Projeto (usado no assunto do e-mail)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Digite o nome do seu projeto"
-    },
-    "githubUsernameLabel": {
-        "message": "Seu nome de usuário do GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Seu nome de usuário do GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Necessário para buscar suas contribuições"
-    },
-    "contributionsLabel": {
-        "message": "Buscar suas contribuições entre:"
-    },
-    "last1DayLabel": {
-        "message": "Dia anterior"
-    },
-    "startDateLabel": {
-        "message": "De:"
-    },
-    "endDateLabel": {
-        "message": "Até:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Mostrar Rótulo Aberto/Fechado"
-    },
-    "blockersLabel": {
-        "message": "O que está impedindo você de progredir?"
-    },
-    "blockersPlaceholder": {
-        "message": "Digite o seu motivo"
-    },
-    "scrumReportLabel": {
-        "message": "Relatório Scrum"
-    },
-    "generateReportButton": {
-        "message": "Gerar"
-    },
-    "copyReportButton": {
-        "message": "Copiar"
-    },
-    "insertInEmailButton": {
-        "message": "Inserir no email"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nome da Organização"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Digite o nome da organização"
-    },
-    "setButton": {
-        "message": "Definir"
-    },
-    "githubTokenLabel": {
-        "message": "Seu Token do GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Necessário para fazer solicitações autenticadas"
-    },
-    "githubTokenTooltip": {
-        "message": "Por que é recomendado adicionar um token do GitHub? O Scrum Helper funciona sem um token do GitHub, mas adicionar um token de acesso pessoal é recomendado para uma melhor experiência."
-    },
-    "gitlabTokenLabel": {
-        "message": "Seu Token GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Necessário para repos privados"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Por que é recomendado adicionar um token do GitLab? O Scrum Helper funciona sem um token do GitLab para projetos públicos, mas adicionar um token de acesso pessoal é recomendado para uma melhor experiência."
-    },
-    "showCommitsLabel": {
-        "message": "Mostrar commits em PRs abertos/ rascunhos de PRs"
-    },
-    "showCommitsTooltip": {
-        "message": "Token do GitHub necessário, adicione-o nas configurações."
-    },
-    "onlyIssuesLabel": {
-        "message": "Incluir apenas problemas no relatório"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas os problemas criados ou atribuídos ao usuário."
-    },
-    "onlyPRsLabel": {
-        "message": "Incluir apenas PRs no relatório"
-    },
-    "onlyPRsTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas PRs criadas pelo usuário; as PRs revisadas serão excluídas."
-    },
-    "cacheTTLLabel": {
-        "message": "Digite o TTL do cache",
-        "description": "Rótulo para a entrada de tempo de vida do cache."
-    },
-    "cacheTTLUnit": {
-        "message": "(em minutos)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Escreva o TTL do cache em minutos (Padrão 10 minutos)"
-    },
-    "refreshDataButton": {
-        "message": "Atualizar Dados (ignorar cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Use este botão para buscar dados novos imediatamente."
-    },
-    "noteTitle": {
-        "message": "Nota:"
-    },
-    "viewCodeButton": {
-        "message": "Ver Código"
-    },
-    "reportIssueButton": {
-        "message": "Relatar Problema"
-    },
-    "repoFilterLabel": {
-        "message": "Filtrar por repositórios"
-    },
-    "enableFilteringLabel": {
-        "message": "Ativar filtragem"
-    },
-    "tokenRequiredWarning": {
-        "message": "Um token do GitHub é necessário para filtragem de repositórios. Por favor, adicione um nas configurações."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Pesquisar um repositório para adicionar..."
-    },
-    "repoPlaceholder": {
-        "message": "Nenhum repositório selecionado (todos serão incluídos)"
-    },
-    "repoCountNone": {
-        "message": "0 repositórios selecionados"
-    },
-    "repoCount": {
-        "message": "$1 repositórios selecionados"
-    },
-    "repoLoading": {
-        "message": "Carregando repositórios..."
-    },
-    "repoLoaded": {
-        "message": "Carregados $1 repositórios."
-    },
-    "repoNotFound": {
-        "message": "Nenhum repositório encontrado"
-    },
-    "repoRefetching": {
-        "message": "Recarregando repositórios..."
-    },
-    "repoLoadFailed": {
-        "message": "Falha ao carregar repositórios."
-    },
-    "repoTokenPrivate": {
-        "message": "Token é inválido ou não tem direitos para repositórios privados."
-    },
-    "repoRefetchFailed": {
-        "message": "Falha ao recarregar repositórios."
-    },
-    "orgSetMessage": {
-        "message": "Organização configurada com sucesso."
-    },
-    "orgClearedMessage": {
-        "message": "Organização removida. Clique em 'Gerar Relatório' para buscar todas as atividades."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organização não encontrada no GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Erro ao validar a organização."
-    },
-    "refreshingButton": {
-        "message": "Atualizando..."
-    },
-    "cacheClearFailed": {
-        "message": "Falha ao limpar o cache."
-    },
-    "madeWithLoveBy": {
-        "message": "Feito com ❤️ por"
-    },
-    "generatingButton": {
-        "message": "Gerando..."
-    },
-    "copiedButton": {
-        "message": "Copiado!"
-    },
-    "orgChangedMessage": {
-        "message": "Organização alterada. Clique no botão Gerar para buscar as atividades do GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache limpo com sucesso. Clique em \"Gerar Relatório\" para buscar dados novos."
-    },
-    "cacheExpiredMessage": {
-        "message": "O cache expirou. Clique em \"Gerar\" para buscar dados novos.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Cache Limpo!"
-    },
-    "extensionDisabledMessage": {
-        "message": "A extensão está desativada. Ative-a nas opções para gerar relatórios scrum."
-    },
-    "notePoint1": {
-        "message": "As solicitações de pull são buscadas com base na atividade de revisão mais recente de qualquer contribuidor, não apenas na sua. Revise e ajuste o relatório SCRUM gerado para garantir que ele reflita com precisão o seu trabalho antes de compartilhá-lo."
-    },
-    "noteSeeIssue": {
-        "message": "Veja este problema"
-    },
-    "platformLabel": {
-        "message": "Plataforma"
-    },
-    "usernameLabel": {
-        "message": "Seu nome de usuário"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Incluir apenas PRs revisadas no relatório"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas PRs revisadas por você."
-    },
-    "usernameRequiredError": {
-        "message": "Por favor, digite seu nome de usuário para gerar o relatório."
-    },
-    "unknownPlatformError": {
-        "message": "Plataforma desconhecida selecionada."
-    },
-    "gitlabFetchingError": {
-        "message": "Ocorreu um erro ao buscar os dados do GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Ocorreu um erro ao gerar o relatório."
-    },
-    "githubUserNotFoundError": {
-        "message": "Usuário do GitHub \"$1\" não encontrado (404). Verifique o nome de usuário e tente novamente."
-    },
-    "githubUserValidationError": {
-        "message": "Erro ao validar o usuário do GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Consulta de busca ou intervalo de datas inválido. Verifique o formato e tente novamente."
-    },
-    "githubIssuesFetchError": {
-        "message": "Erro ao buscar issues do GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Erro ao buscar dados de revisão de PR do GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Erro ao buscar dados do usuário do GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Token do GitHub inválido ou expirado. Verifique seu token nas configurações do Scrum Helper e tente novamente."
-    },
-    "displayModeNotice": {
-        "message": "A extensão será aberta no modo $1 no próximo lançamento."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Filtragem de repositórios disponível apenas para o GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Carregamento de repositórios disponível apenas para o GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Busca de repositórios disponível apenas para o GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Carregando repositórios automaticamente..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Erro ao buscar usuário do GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Usuário do GitLab '$1' não encontrado"
-    },
-    "gitlabMembershipError": {
-        "message": "Erro ao buscar projetos de associação do GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Erro ao buscar projetos contribuídos do GitLab: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Nome de usuário obrigatório."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Gerando relatório..."
-    },
-    "copyingReportNotification": {
-        "message": "Copiando relatório..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Inserindo relatório no e-mail..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Relatório inserido no e-mail!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Relate o seu progresso de desenvolvimento buscando automaticamente a sua atividade no Git para um período selecionado"
+  },
+  "disableLabel": {
+    "message": "Desativar"
+  },
+  "enableLabel": {
+    "message": "Ativar"
+  },
+  "projectNameLabel": {
+    "message": "Nome do Projeto (usado no assunto do e-mail)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Digite o nome do seu projeto"
+  },
+  "githubUsernameLabel": {
+    "message": "Seu nome de usuário do GitHub"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Seu nome de usuário do GitLab"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Necessário para buscar suas contribuições"
+  },
+  "contributionsLabel": {
+    "message": "Buscar suas contribuições entre:"
+  },
+  "last1DayLabel": {
+    "message": "Dia anterior"
+  },
+  "startDateLabel": {
+    "message": "De:"
+  },
+  "endDateLabel": {
+    "message": "Até:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Mostrar Rótulo Aberto/Fechado"
+  },
+  "blockersLabel": {
+    "message": "O que está impedindo você de progredir?"
+  },
+  "blockersPlaceholder": {
+    "message": "Digite o seu motivo"
+  },
+  "scrumReportLabel": {
+    "message": "Relatório Scrum"
+  },
+  "generateReportButton": {
+    "message": "Gerar"
+  },
+  "copyReportButton": {
+    "message": "Copiar"
+  },
+  "insertInEmailButton": {
+    "message": "Inserir no email"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Nome da Organização"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Digite o nome da organização"
+  },
+  "setButton": {
+    "message": "Definir"
+  },
+  "githubTokenLabel": {
+    "message": "Seu Token do GitHub"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Necessário para fazer solicitações autenticadas"
+  },
+  "githubTokenTooltip": {
+    "message": "Por que é recomendado adicionar um token do GitHub? O Scrum Helper funciona sem um token do GitHub, mas adicionar um token de acesso pessoal é recomendado para uma melhor experiência."
+  },
+  "gitlabTokenLabel": {
+    "message": "Seu Token GitLab"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Necessário para repos privados"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Por que é recomendado adicionar um token do GitLab? O Scrum Helper funciona sem um token do GitLab para projetos públicos, mas adicionar um token de acesso pessoal é recomendado para uma melhor experiência."
+  },
+  "showCommitsLabel": {
+    "message": "Mostrar commits em PRs abertos/ rascunhos de PRs"
+  },
+  "showCommitsTooltip": {
+    "message": "Token do GitHub necessário, adicione-o nas configurações."
+  },
+  "onlyIssuesLabel": {
+    "message": "Incluir apenas problemas no relatório"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Se marcado, o relatório incluirá apenas os problemas criados ou atribuídos ao usuário."
+  },
+  "onlyPRsLabel": {
+    "message": "Incluir apenas PRs no relatório"
+  },
+  "onlyPRsTooltip": {
+    "message": "Se marcado, o relatório incluirá apenas PRs criadas pelo usuário; as PRs revisadas serão excluídas."
+  },
+  "cacheTTLLabel": {
+    "message": "Digite o TTL do cache",
+    "description": "Rótulo para a entrada de tempo de vida do cache."
+  },
+  "cacheTTLUnit": {
+    "message": "(em minutos)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Escreva o TTL do cache em minutos (Padrão 10 minutos)"
+  },
+  "refreshDataButton": {
+    "message": "Atualizar Dados (ignorar cache)"
+  },
+  "refreshDataInfo": {
+    "message": "Use este botão para buscar dados novos imediatamente."
+  },
+  "noteTitle": {
+    "message": "Nota:"
+  },
+  "viewCodeButton": {
+    "message": "Ver Código"
+  },
+  "reportIssueButton": {
+    "message": "Relatar Problema"
+  },
+  "repoFilterLabel": {
+    "message": "Filtrar por repositórios"
+  },
+  "enableFilteringLabel": {
+    "message": "Ativar filtragem"
+  },
+  "tokenRequiredWarning": {
+    "message": "Um token do GitHub é necessário para filtragem de repositórios. Por favor, adicione um nas configurações."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Pesquisar um repositório para adicionar..."
+  },
+  "repoPlaceholder": {
+    "message": "Nenhum repositório selecionado (todos serão incluídos)"
+  },
+  "repoCountNone": {
+    "message": "0 repositórios selecionados"
+  },
+  "repoCount": {
+    "message": "$1 repositórios selecionados"
+  },
+  "repoLoading": {
+    "message": "Carregando repositórios..."
+  },
+  "repoLoaded": {
+    "message": "Carregados $1 repositórios."
+  },
+  "repoNotFound": {
+    "message": "Nenhum repositório encontrado"
+  },
+  "repoRefetching": {
+    "message": "Recarregando repositórios..."
+  },
+  "repoLoadFailed": {
+    "message": "Falha ao carregar repositórios."
+  },
+  "repoTokenPrivate": {
+    "message": "Token é inválido ou não tem direitos para repositórios privados."
+  },
+  "repoRefetchFailed": {
+    "message": "Falha ao recarregar repositórios."
+  },
+  "orgSetMessage": {
+    "message": "Organização configurada com sucesso."
+  },
+  "orgClearedMessage": {
+    "message": "Organização removida. Clique em 'Gerar Relatório' para buscar todas as atividades."
+  },
+  "orgNotFoundMessage": {
+    "message": "Organização não encontrada no GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Erro ao validar a organização."
+  },
+  "refreshingButton": {
+    "message": "Atualizando..."
+  },
+  "cacheClearFailed": {
+    "message": "Falha ao limpar o cache."
+  },
+  "madeWithLoveBy": {
+    "message": "Feito com ❤️ por"
+  },
+  "generatingButton": {
+    "message": "Gerando..."
+  },
+  "copiedButton": {
+    "message": "Copiado!"
+  },
+  "orgChangedMessage": {
+    "message": "Organização alterada. Clique no botão Gerar para buscar as atividades do GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Cache limpo com sucesso. Clique em \"Gerar Relatório\" para buscar dados novos."
+  },
+  "cacheExpiredMessage": {
+    "message": "O cache expirou. Clique em \"Gerar\" para buscar dados novos.",
+    "description": "Message shown when the cached data has expired and user needs to regenerate."
+  },
+  "cacheClearedButton": {
+    "message": "Cache Limpo!"
+  },
+  "extensionDisabledMessage": {
+    "message": "A extensão está desativada. Ative-a nas opções para gerar relatórios scrum."
+  },
+  "notePoint1": {
+    "message": "As solicitações de pull são buscadas com base na atividade de revisão mais recente de qualquer contribuidor, não apenas na sua. Revise e ajuste o relatório SCRUM gerado para garantir que ele reflita com precisão o seu trabalho antes de compartilhá-lo."
+  },
+  "noteSeeIssue": {
+    "message": "Veja este problema"
+  },
+  "platformLabel": {
+    "message": "Plataforma"
+  },
+  "usernameLabel": {
+    "message": "Seu nome de usuário"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Incluir apenas PRs revisadas no relatório"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Se marcado, o relatório incluirá apenas PRs revisadas por você."
+  },
+  "usernameRequiredError": {
+    "message": "Por favor, digite seu nome de usuário para gerar o relatório."
+  },
+  "unknownPlatformError": {
+    "message": "Plataforma desconhecida selecionada."
+  },
+  "gitlabFetchingError": {
+    "message": "Ocorreu um erro ao buscar os dados do GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Ocorreu um erro ao gerar o relatório."
+  },
+  "githubUserNotFoundError": {
+    "message": "Usuário do GitHub \"$1\" não encontrado (404). Verifique o nome de usuário e tente novamente."
+  },
+  "githubUserValidationError": {
+    "message": "Erro ao validar o usuário do GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Consulta de busca ou intervalo de datas inválido. Verifique o formato e tente novamente."
+  },
+  "githubIssuesFetchError": {
+    "message": "Erro ao buscar issues do GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Erro ao buscar dados de revisão de PR do GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Erro ao buscar dados do usuário do GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Token do GitHub inválido ou expirado. Verifique seu token nas configurações do Scrum Helper e tente novamente."
+  },
+  "displayModeNotice": {
+    "message": "A extensão será aberta no modo $1 no próximo lançamento."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Filtragem de repositórios disponível apenas para o GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Carregamento de repositórios disponível apenas para o GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Busca de repositórios disponível apenas para o GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Carregando repositórios automaticamente..."
+  },
+  "gitlabUserFetchError": {
+    "message": "Erro ao buscar usuário do GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Usuário do GitLab '$1' não encontrado"
+  },
+  "gitlabMembershipError": {
+    "message": "Erro ao buscar projetos de associação do GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Erro ao buscar projetos contribuídos do GitLab: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Nome de usuário obrigatório."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Gerando relatório..."
+  },
+  "copyingReportNotification": {
+    "message": "Copiando relatório..."
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Inserindo relatório no e-mail..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Relatório inserido no e-mail!"
+  },
+  "tokenSetupTitle": {
+    "message": "Adicionar token do GitHub"
+  },
+  "tokenSetupDescription": {
+    "message": "Ative recursos avançados adicionando seu token do GitHub"
+  },
+  "tokenSetupBenefits": {
+    "message": "Benefícios"
+  },
+  "tokenSetupBenefit1": {
+    "message": "Limites de taxa de API mais altos"
+  },
+  "tokenSetupBenefit2": {
+    "message": "Acesso a repositórios privados"
+  },
+  "tokenSetupBenefit3": {
+    "message": "Mostrar commits em PRs"
+  },
+  "addTokenButton": {
+    "message": "Adicionar token"
+  },
+  "learnMoreLink": {
+    "message": "Saiba mais"
+  }
 }

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Relate seu progresso de desenvolvimento buscando automaticamente sua atividade no Git para um período selecionado."
-    },
-    "disableLabel": {
-        "message": "Desativar"
-    },
-    "enableLabel": {
-        "message": "Ativar"
-    },
-    "projectNameLabel": {
-        "message": "Nome do Projeto (usado no assunto do e-mail)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Digite o nome do seu projeto"
-    },
-    "githubUsernameLabel": {
-        "message": "Seu nome de usuário do GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Seu nome de usuário do GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Necessário para buscar suas contribuições"
-    },
-    "contributionsLabel": {
-        "message": "Buscar suas contribuições de:"
-    },
-    "last1DayLabel": {
-        "message": "Dia anterior"
-    },
-    "startDateLabel": {
-        "message": "De:"
-    },
-    "endDateLabel": {
-        "message": "Até:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Mostrar status Aberto/Fechado"
-    },
-    "blockersLabel": {
-        "message": "O que está impedindo seu progresso?"
-    },
-    "blockersPlaceholder": {
-        "message": "Digite o motivo"
-    },
-    "scrumReportLabel": {
-        "message": "Relatório Scrum"
-    },
-    "generateReportButton": {
-        "message": "Gerar"
-    },
-    "copyReportButton": {
-        "message": "Copiar"
-    },
-    "insertInEmailButton": {
-        "message": "Inserir no e-mail"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nome da Organização"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Digite o nome da organização"
-    },
-    "setButton": {
-        "message": "Definir"
-    },
-    "githubTokenLabel": {
-        "message": "Seu Token do GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Necessário para solicitações autenticadas"
-    },
-    "githubTokenTooltip": {
-        "message": "Por que é recomendado adicionar um token do GitHub? O Scrum Helper funciona sem um token do GitHub, mas é recomendado adicionar um token de acesso pessoal para uma melhor experiência."
-    },
-    "gitlabTokenLabel": {
-        "message": "Seu Token GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Necessário para repos privados"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Por que é recomendado adicionar um token do GitLab? O Scrum Helper funciona sem um token do GitLab para projetos públicos, mas é recomendado adicionar um token de acesso pessoal para uma melhor experiência."
-    },
-    "showCommitsLabel": {
-        "message": "Mostrar commits em PRs abertos/ rascunhos de PRs"
-    },
-    "showCommitsTooltip": {
-        "message": "Token do Github necessário, adicione-o nas configurações."
-    },
-    "onlyIssuesLabel": {
-        "message": "Incluir apenas issues no relatório"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas as issues criadas ou atribuídas ao usuário."
-    },
-    "onlyPRsLabel": {
-        "message": "Incluir apenas PRs no relatório"
-    },
-    "onlyPRsTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas PRs criadas pelo usuário; as PRs revisadas serão excluídas."
-    },
-    "cacheTTLLabel": {
-        "message": "Digite o TTL do cache",
-        "description": "Rótulo para a entrada de tempo de vida do cache."
-    },
-    "cacheTTLUnit": {
-        "message": "(em minutos)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Digite o TTL do cache em minutos (Padrão: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Atualizar Dados (ignorar cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Use este botão para buscar dados novos imediatamente."
-    },
-    "noteTitle": {
-        "message": "Nota:"
-    },
-    "viewCodeButton": {
-        "message": "Ver código"
-    },
-    "reportIssueButton": {
-        "message": "Relatar um problema"
-    },
-    "repoFilterLabel": {
-        "message": "Filtrar por repositórios"
-    },
-    "enableFilteringLabel": {
-        "message": "Ativar filtragem"
-    },
-    "tokenRequiredWarning": {
-        "message": "Um token do GitHub é necessário para filtrar repositórios. Adicione um nas configurações."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Buscar um repositório para adicionar..."
-    },
-    "repoPlaceholder": {
-        "message": "Nenhum repositório selecionado (todos serão incluídos)"
-    },
-    "repoCountNone": {
-        "message": "0 repositórios selecionados"
-    },
-    "repoCount": {
-        "message": "$1 repositórios selecionados"
-    },
-    "repoLoading": {
-        "message": "Carregando repositórios..."
-    },
-    "repoLoaded": {
-        "message": "$1 repositórios carregados."
-    },
-    "repoNotFound": {
-        "message": "Nenhum repositório encontrado"
-    },
-    "repoRefetching": {
-        "message": "Recarregando repositórios..."
-    },
-    "repoLoadFailed": {
-        "message": "Falha ao carregar repositórios."
-    },
-    "repoTokenPrivate": {
-        "message": "O token é inválido ou não tem permissão para repositórios privados."
-    },
-    "repoRefetchFailed": {
-        "message": "Falha ao recarregar repositórios."
-    },
-    "orgSetMessage": {
-        "message": "Organização definida com sucesso."
-    },
-    "orgClearedMessage": {
-        "message": "Organização removida. Clique em 'Gerar Relatório' para buscar todas as atividades."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organização não encontrada no GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Erro ao validar a organização."
-    },
-    "refreshingButton": {
-        "message": "Atualizando..."
-    },
-    "cacheClearFailed": {
-        "message": "Falha ao limpar o cache."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Gerando..."
-    },
-    "copiedButton": {
-        "message": "Copiado!"
-    },
-    "orgChangedMessage": {
-        "message": "Organização alterada. Clique em 'Gerar Relatório' para buscar as atividades do GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache limpo com sucesso. Clique em 'Gerar Relatório' para buscar dados novos."
-    },
-    "cacheExpiredMessage": {
-        "message": "O cache expirou. Clique em \"Gerar\" para buscar dados novos.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Cache Limpo!"
-    },
-    "extensionDisabledMessage": {
-        "message": "A extensão está desativada. Ative-a nos ajustes para gerar relatórios scrum."
-    },
-    "notePoint1": {
-        "message": "As solicitações de pull são buscadas com base na atividade de revisão mais recente de qualquer contribuidor, não apenas na sua. Revise e ajuste o relatório SCRUM gerado para garantir que ele reflita com precisão o seu trabalho antes de compartilhá-lo."
-    },
-    "noteSeeIssue": {
-        "message": "Veja este issue"
-    },
-    "platformLabel": {
-        "message": "Plataforma"
-    },
-    "usernameLabel": {
-        "message": "Seu nome de usuário"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Incluir apenas PRs revisadas no relatório"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas PRs revisadas por você."
-    },
-    "usernameRequiredError": {
-        "message": "Por favor, digite seu nome de usuário para gerar o relatório."
-    },
-    "unknownPlatformError": {
-        "message": "Plataforma desconhecida selecionada."
-    },
-    "gitlabFetchingError": {
-        "message": "Ocorreu um erro ao buscar os dados do GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Ocorreu um erro ao gerar o relatório."
-    },
-    "githubUserNotFoundError": {
-        "message": "Usuário do GitHub \"$1\" não encontrado (404). Verifique o nome de usuário e tente novamente."
-    },
-    "githubUserValidationError": {
-        "message": "Erro ao validar o usuário do GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Consulta de busca ou intervalo de datas inválido. Verifique o formato e tente novamente."
-    },
-    "githubIssuesFetchError": {
-        "message": "Erro ao buscar issues do GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Erro ao buscar dados de revisão de PR do GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Erro ao buscar dados do usuário do GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Token do GitHub inválido ou expirado. Verifique seu token nas configurações do Scrum Helper e tente novamente."
-    },
-    "displayModeNotice": {
-        "message": "A extensão será aberta no modo $1 no próximo lançamento."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Filtragem de repositórios disponível apenas para o GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Carregamento de repositórios disponível apenas para o GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Busca de repositórios disponível apenas para o GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Carregando repositórios automaticamente..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Erro ao buscar usuário do GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Usuário do GitLab '$1' não encontrado"
-    },
-    "gitlabMembershipError": {
-        "message": "Erro ao buscar projetos de associação do GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Erro ao buscar projetos contribuídos do GitLab: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Nome de usuário obrigatório."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Gerando relatório..."
-    },
-    "copyingReportNotification": {
-        "message": "Copiando relatório..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Inserindo relatório no e-mail..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Relatório inserido no e-mail!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Relate seu progresso de desenvolvimento buscando automaticamente sua atividade no Git para um período selecionado."
+  },
+  "disableLabel": {
+    "message": "Desativar"
+  },
+  "enableLabel": {
+    "message": "Ativar"
+  },
+  "projectNameLabel": {
+    "message": "Nome do Projeto (usado no assunto do e-mail)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Digite o nome do seu projeto"
+  },
+  "githubUsernameLabel": {
+    "message": "Seu nome de usuário do GitHub"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Seu nome de usuário do GitLab"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Necessário para buscar suas contribuições"
+  },
+  "contributionsLabel": {
+    "message": "Buscar suas contribuições de:"
+  },
+  "last1DayLabel": {
+    "message": "Dia anterior"
+  },
+  "startDateLabel": {
+    "message": "De:"
+  },
+  "endDateLabel": {
+    "message": "Até:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Mostrar status Aberto/Fechado"
+  },
+  "blockersLabel": {
+    "message": "O que está impedindo seu progresso?"
+  },
+  "blockersPlaceholder": {
+    "message": "Digite o motivo"
+  },
+  "scrumReportLabel": {
+    "message": "Relatório Scrum"
+  },
+  "generateReportButton": {
+    "message": "Gerar"
+  },
+  "copyReportButton": {
+    "message": "Copiar"
+  },
+  "insertInEmailButton": {
+    "message": "Inserir no e-mail"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Nome da Organização"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Digite o nome da organização"
+  },
+  "setButton": {
+    "message": "Definir"
+  },
+  "githubTokenLabel": {
+    "message": "Seu Token do GitHub"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Necessário para solicitações autenticadas"
+  },
+  "githubTokenTooltip": {
+    "message": "Por que é recomendado adicionar um token do GitHub? O Scrum Helper funciona sem um token do GitHub, mas é recomendado adicionar um token de acesso pessoal para uma melhor experiência."
+  },
+  "gitlabTokenLabel": {
+    "message": "Seu Token GitLab"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Necessário para repos privados"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Por que é recomendado adicionar um token do GitLab? O Scrum Helper funciona sem um token do GitLab para projetos públicos, mas é recomendado adicionar um token de acesso pessoal para uma melhor experiência."
+  },
+  "showCommitsLabel": {
+    "message": "Mostrar commits em PRs abertos/ rascunhos de PRs"
+  },
+  "showCommitsTooltip": {
+    "message": "Token do Github necessário, adicione-o nas configurações."
+  },
+  "onlyIssuesLabel": {
+    "message": "Incluir apenas issues no relatório"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Se marcado, o relatório incluirá apenas as issues criadas ou atribuídas ao usuário."
+  },
+  "onlyPRsLabel": {
+    "message": "Incluir apenas PRs no relatório"
+  },
+  "onlyPRsTooltip": {
+    "message": "Se marcado, o relatório incluirá apenas PRs criadas pelo usuário; as PRs revisadas serão excluídas."
+  },
+  "cacheTTLLabel": {
+    "message": "Digite o TTL do cache",
+    "description": "Rótulo para a entrada de tempo de vida do cache."
+  },
+  "cacheTTLUnit": {
+    "message": "(em minutos)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Digite o TTL do cache em minutos (Padrão: 10)"
+  },
+  "refreshDataButton": {
+    "message": "Atualizar Dados (ignorar cache)"
+  },
+  "refreshDataInfo": {
+    "message": "Use este botão para buscar dados novos imediatamente."
+  },
+  "noteTitle": {
+    "message": "Nota:"
+  },
+  "viewCodeButton": {
+    "message": "Ver código"
+  },
+  "reportIssueButton": {
+    "message": "Relatar um problema"
+  },
+  "repoFilterLabel": {
+    "message": "Filtrar por repositórios"
+  },
+  "enableFilteringLabel": {
+    "message": "Ativar filtragem"
+  },
+  "tokenRequiredWarning": {
+    "message": "Um token do GitHub é necessário para filtrar repositórios. Adicione um nas configurações."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Buscar um repositório para adicionar..."
+  },
+  "repoPlaceholder": {
+    "message": "Nenhum repositório selecionado (todos serão incluídos)"
+  },
+  "repoCountNone": {
+    "message": "0 repositórios selecionados"
+  },
+  "repoCount": {
+    "message": "$1 repositórios selecionados"
+  },
+  "repoLoading": {
+    "message": "Carregando repositórios..."
+  },
+  "repoLoaded": {
+    "message": "$1 repositórios carregados."
+  },
+  "repoNotFound": {
+    "message": "Nenhum repositório encontrado"
+  },
+  "repoRefetching": {
+    "message": "Recarregando repositórios..."
+  },
+  "repoLoadFailed": {
+    "message": "Falha ao carregar repositórios."
+  },
+  "repoTokenPrivate": {
+    "message": "O token é inválido ou não tem permissão para repositórios privados."
+  },
+  "repoRefetchFailed": {
+    "message": "Falha ao recarregar repositórios."
+  },
+  "orgSetMessage": {
+    "message": "Organização definida com sucesso."
+  },
+  "orgClearedMessage": {
+    "message": "Organização removida. Clique em 'Gerar Relatório' para buscar todas as atividades."
+  },
+  "orgNotFoundMessage": {
+    "message": "Organização não encontrada no GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Erro ao validar a organização."
+  },
+  "refreshingButton": {
+    "message": "Atualizando..."
+  },
+  "cacheClearFailed": {
+    "message": "Falha ao limpar o cache."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Gerando..."
+  },
+  "copiedButton": {
+    "message": "Copiado!"
+  },
+  "orgChangedMessage": {
+    "message": "Organização alterada. Clique em 'Gerar Relatório' para buscar as atividades do GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Cache limpo com sucesso. Clique em 'Gerar Relatório' para buscar dados novos."
+  },
+  "cacheExpiredMessage": {
+    "message": "O cache expirou. Clique em \"Gerar\" para buscar dados novos.",
+    "description": "Message shown when the cached data has expired and user needs to regenerate."
+  },
+  "cacheClearedButton": {
+    "message": "Cache Limpo!"
+  },
+  "extensionDisabledMessage": {
+    "message": "A extensão está desativada. Ative-a nos ajustes para gerar relatórios scrum."
+  },
+  "notePoint1": {
+    "message": "As solicitações de pull são buscadas com base na atividade de revisão mais recente de qualquer contribuidor, não apenas na sua. Revise e ajuste o relatório SCRUM gerado para garantir que ele reflita com precisão o seu trabalho antes de compartilhá-lo."
+  },
+  "noteSeeIssue": {
+    "message": "Veja este issue"
+  },
+  "platformLabel": {
+    "message": "Plataforma"
+  },
+  "usernameLabel": {
+    "message": "Seu nome de usuário"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Incluir apenas PRs revisadas no relatório"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Se marcado, o relatório incluirá apenas PRs revisadas por você."
+  },
+  "usernameRequiredError": {
+    "message": "Por favor, digite seu nome de usuário para gerar o relatório."
+  },
+  "unknownPlatformError": {
+    "message": "Plataforma desconhecida selecionada."
+  },
+  "gitlabFetchingError": {
+    "message": "Ocorreu um erro ao buscar os dados do GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Ocorreu um erro ao gerar o relatório."
+  },
+  "githubUserNotFoundError": {
+    "message": "Usuário do GitHub \"$1\" não encontrado (404). Verifique o nome de usuário e tente novamente."
+  },
+  "githubUserValidationError": {
+    "message": "Erro ao validar o usuário do GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Consulta de busca ou intervalo de datas inválido. Verifique o formato e tente novamente."
+  },
+  "githubIssuesFetchError": {
+    "message": "Erro ao buscar issues do GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Erro ao buscar dados de revisão de PR do GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Erro ao buscar dados do usuário do GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Token do GitHub inválido ou expirado. Verifique seu token nas configurações do Scrum Helper e tente novamente."
+  },
+  "displayModeNotice": {
+    "message": "A extensão será aberta no modo $1 no próximo lançamento."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Filtragem de repositórios disponível apenas para o GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Carregamento de repositórios disponível apenas para o GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Busca de repositórios disponível apenas para o GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Carregando repositórios automaticamente..."
+  },
+  "gitlabUserFetchError": {
+    "message": "Erro ao buscar usuário do GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Usuário do GitLab '$1' não encontrado"
+  },
+  "gitlabMembershipError": {
+    "message": "Erro ao buscar projetos de associação do GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Erro ao buscar projetos contribuídos do GitLab: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Nome de usuário obrigatório."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Gerando relatório..."
+  },
+  "copyingReportNotification": {
+    "message": "Copiando relatório..."
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Inserindo relatório no e-mail..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Relatório inserido no e-mail!"
+  },
+  "tokenSetupTitle": {
+    "message": "Adicionar token do GitHub"
+  },
+  "tokenSetupDescription": {
+    "message": "Habilite recursos avançados adicionando seu token do GitHub"
+  },
+  "tokenSetupBenefits": {
+    "message": "Benefícios"
+  },
+  "tokenSetupBenefit1": {
+    "message": "Limites de taxa de API mais altos"
+  },
+  "tokenSetupBenefit2": {
+    "message": "Acesso a repositórios privados"
+  },
+  "tokenSetupBenefit3": {
+    "message": "Mostrar commits em PRs"
+  },
+  "addTokenButton": {
+    "message": "Adicionar token"
+  },
+  "learnMoreLink": {
+    "message": "Saiba mais"
+  }
 }

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Сообщайте о своем прогрессе в разработке, автоматически получая данные о вашей активности в Git за выбранный период."
-    },
-    "disableLabel": {
-        "message": "Отключить"
-    },
-    "enableLabel": {
-        "message": "Включить"
-    },
-    "projectNameLabel": {
-        "message": "Название проекта (используется в теме письма)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Введите название вашего проекта"
-    },
-    "githubUsernameLabel": {
-        "message": "Ваше имя пользователя GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Ваше имя пользователя GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Требуется для получения ваших вкладов"
-    },
-    "contributionsLabel": {
-        "message": "Получить ваши вклады за:"
-    },
-    "last1DayLabel": {
-        "message": "Предыдущий день"
-    },
-    "startDateLabel": {
-        "message": "С:"
-    },
-    "endDateLabel": {
-        "message": "До:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Показывать статус Открыто/Закрыто"
-    },
-    "blockersLabel": {
-        "message": "Что мешает вашему прогрессу?"
-    },
-    "blockersPlaceholder": {
-        "message": "Введите причину"
-    },
-    "scrumReportLabel": {
-        "message": "Scrum-отчет"
-    },
-    "generateReportButton": {
-        "message": "Создать"
-    },
-    "copyReportButton": {
-        "message": "Копировать"
-    },
-    "insertInEmailButton": {
-        "message": "Вставить в письмо"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Название организации"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Введите название организации"
-    },
-    "setButton": {
-        "message": "Установить"
-    },
-    "githubTokenLabel": {
-        "message": "Ваш токен GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Требуется для аутентифицированных запросов"
-    },
-    "githubTokenTooltip": {
-        "message": "Зачем рекомендуется добавлять токен GitHub? Scrum Helper работает без токена GitHub, но для лучшего опыта рекомендуется добавить токен личного доступа."
-    },
-    "gitlabTokenLabel": {
-        "message": "Ваш токен GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Требуется для приватных репо"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Зачем рекомендуется добавлять токен GitLab? Scrum Helper работает без токена GitLab для публичных проектов, но для лучшего опыта рекомендуется добавить токен личного доступа."
-    },
-    "showCommitsLabel": {
-        "message": "Показывать коммиты в открытых PR/ черновиках PR"
-    },
-    "showCommitsTooltip": {
-        "message": "Требуется токен Github, добавьте его в настройках."
-    },
-    "onlyIssuesLabel": {
-        "message": "Включить в отчет только задачи"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Если флажок установлен, в отчет будут включены только задачи, созданные пользователем или назначенные ему."
-    },
-    "onlyPRsLabel": {
-        "message": "Включать в отчёт только PR"
-    },
-    "onlyPRsTooltip": {
-        "message": "Если отмечено, отчёт будет включать только pull request'ы, созданные пользователем; проверенные PR будут исключены."
-    },
-    "cacheTTLLabel": {
-        "message": "Введите TTL кеша",
-        "description": "Метка для ввода времени жизни кеша."
-    },
-    "cacheTTLUnit": {
-        "message": "(в минутах)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Укажите TTL кэша в минутах (по умолчанию: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Обновить данные (в обход кэша)"
-    },
-    "refreshDataInfo": {
-        "message": "Используйте эту кнопку для немедленного получения свежих данных."
-    },
-    "noteTitle": {
-        "message": "Примечание:"
-    },
-    "viewCodeButton": {
-        "message": "Посмотреть код"
-    },
-    "reportIssueButton": {
-        "message": "Сообщить о проблеме"
-    },
-    "repoFilterLabel": {
-        "message": "Фильтровать по репозиториям"
-    },
-    "enableFilteringLabel": {
-        "message": "Включить фильтрацию"
-    },
-    "tokenRequiredWarning": {
-        "message": "Для фильтрации репозиториев требуется токен GitHub. Пожалуйста, добавьте его в настройках."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Найти репозиторий для добавления..."
-    },
-    "repoPlaceholder": {
-        "message": "Репозитории не выбраны (будут включены все)"
-    },
-    "repoCountNone": {
-        "message": "0 репозиториев выбрано"
-    },
-    "repoCount": {
-        "message": "$1 репозиториев выбрано"
-    },
-    "repoLoading": {
-        "message": "Загрузка репозиториев..."
-    },
-    "repoLoaded": {
-        "message": "Загружено $1 репозиториев."
-    },
-    "repoNotFound": {
-        "message": "Репозитории не найдены"
-    },
-    "repoRefetching": {
-        "message": "Перезагрузка репозиториев..."
-    },
-    "repoLoadFailed": {
-        "message": "Не удалось загрузить репозитории."
-    },
-    "repoTokenPrivate": {
-        "message": "Токен недействителен или не имеет прав для частных репозиториев."
-    },
-    "repoRefetchFailed": {
-        "message": "Не удалось перезагрузить репозитории."
-    },
-    "orgSetMessage": {
-        "message": "Организация успешно установлена."
-    },
-    "orgClearedMessage": {
-        "message": "Организация удалена. Нажмите 'Создать отчет', чтобы получить все действия."
-    },
-    "orgNotFoundMessage": {
-        "message": "Организация не найдена на GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Ошибка при проверке организации."
-    },
-    "refreshingButton": {
-        "message": "Обновление..."
-    },
-    "cacheClearFailed": {
-        "message": "Не удалось очистить кэш."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Создание..."
-    },
-    "copiedButton": {
-        "message": "Скопировано!"
-    },
-    "orgChangedMessage": {
-        "message": "Организация изменена. Нажмите 'Создать отчет', чтобы получить данные о действиях в GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Кэш успешно очищен. Нажмите 'Создать отчет', чтобы получить свежие данные."
-    },
-    "cacheExpiredMessage": {
-        "message": "Кэш истёк. Нажмите \"Создать\", чтобы получить новые данные.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Кэш очищен!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Расширение отключено. Включите его в настройках, чтобы создавать scrum-отчеты."
-    },
-    "notePoint1": {
-        "message": "Pull-реквесты извлекаются на основе последней активности по проверке любого участника, а не только вашей. Пожалуйста, просмотрите и скорректируйте сгенерированный отчет SCRUM, чтобы убедиться, что он точно отражает вашу работу, прежде чем делиться им."
-    },
-    "noteSeeIssue": {
-        "message": "Смотрите эту проблему"
-    },
-    "platformLabel": {
-        "message": "Платформа"
-    },
-    "usernameLabel": {
-        "message": "Ваше имя пользователя"
-    },
-    "usernameRequiredError": {
-        "message": "Пожалуйста, введите имя пользователя для создания отчета."
-    },
-    "unknownPlatformError": {
-        "message": "Выбрана неизвестная платформа."
-    },
-    "gitlabFetchingError": {
-        "message": "Произошла ошибка при получении данных GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Произошла ошибка при создании отчета."
-    },
-    "githubUserNotFoundError": {
-        "message": "Пользователь GitHub \"$1\" не найден (404). Проверьте имя пользователя и попробуйте снова."
-    },
-    "githubUserValidationError": {
-        "message": "Ошибка при проверке пользователя GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Недопустимый поисковый запрос или диапазон дат. Проверьте формат и попробуйте снова."
-    },
-    "githubIssuesFetchError": {
-        "message": "Ошибка при получении задач GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Ошибка при получении данных проверки PR GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Ошибка при получении данных пользователя GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Недействительный или истекший токен GitHub. Проверьте токен в настройках Scrum Helper и попробуйте снова."
-    },
-    "displayModeNotice": {
-        "message": "Расширение откроется в режиме $1 при следующем запуске."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Фильтрация репозиториев доступна только для GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Загрузка репозиториев доступна только для GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Получение репозиториев доступно только для GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Репозитории загружаются автоматически..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Ошибка при получении пользователя GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Пользователь GitLab '$1' не найден"
-    },
-    "gitlabMembershipError": {
-        "message": "Ошибка при получении проектов членства GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Ошибка при получении проектов с вкладом GitLab: $1 $2"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Включить в отчет только проверенные PR"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Если отмечено, отчёт будет включать только PR, проверенные вами."
-    },
-    "usernameMissingError": {
-        "message": "Требуется имя пользователя."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Создание отчёта..."
-    },
-    "copyingReportNotification": {
-        "message": "Копирование отчёта..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Вставка отчёта в письмо..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Отчёт вставлен в письмо!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Сообщайте о своем прогрессе в разработке, автоматически получая данные о вашей активности в Git за выбранный период."
+  },
+  "disableLabel": {
+    "message": "Отключить"
+  },
+  "enableLabel": {
+    "message": "Включить"
+  },
+  "projectNameLabel": {
+    "message": "Название проекта (используется в теме письма)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Введите название вашего проекта"
+  },
+  "githubUsernameLabel": {
+    "message": "Ваше имя пользователя GitHub"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Ваше имя пользователя GitLab"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Требуется для получения ваших вкладов"
+  },
+  "contributionsLabel": {
+    "message": "Получить ваши вклады за:"
+  },
+  "last1DayLabel": {
+    "message": "Предыдущий день"
+  },
+  "startDateLabel": {
+    "message": "С:"
+  },
+  "endDateLabel": {
+    "message": "До:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Показывать статус Открыто/Закрыто"
+  },
+  "blockersLabel": {
+    "message": "Что мешает вашему прогрессу?"
+  },
+  "blockersPlaceholder": {
+    "message": "Введите причину"
+  },
+  "scrumReportLabel": {
+    "message": "Scrum-отчет"
+  },
+  "generateReportButton": {
+    "message": "Создать"
+  },
+  "copyReportButton": {
+    "message": "Копировать"
+  },
+  "insertInEmailButton": {
+    "message": "Вставить в письмо"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Название организации"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Введите название организации"
+  },
+  "setButton": {
+    "message": "Установить"
+  },
+  "githubTokenLabel": {
+    "message": "Ваш токен GitHub"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Требуется для аутентифицированных запросов"
+  },
+  "githubTokenTooltip": {
+    "message": "Зачем рекомендуется добавлять токен GitHub? Scrum Helper работает без токена GitHub, но для лучшего опыта рекомендуется добавить токен личного доступа."
+  },
+  "gitlabTokenLabel": {
+    "message": "Ваш токен GitLab"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Требуется для приватных репо"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Зачем рекомендуется добавлять токен GitLab? Scrum Helper работает без токена GitLab для публичных проектов, но для лучшего опыта рекомендуется добавить токен личного доступа."
+  },
+  "showCommitsLabel": {
+    "message": "Показывать коммиты в открытых PR/ черновиках PR"
+  },
+  "showCommitsTooltip": {
+    "message": "Требуется токен Github, добавьте его в настройках."
+  },
+  "onlyIssuesLabel": {
+    "message": "Включить в отчет только задачи"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Если флажок установлен, в отчет будут включены только задачи, созданные пользователем или назначенные ему."
+  },
+  "onlyPRsLabel": {
+    "message": "Включать в отчёт только PR"
+  },
+  "onlyPRsTooltip": {
+    "message": "Если отмечено, отчёт будет включать только pull request'ы, созданные пользователем; проверенные PR будут исключены."
+  },
+  "cacheTTLLabel": {
+    "message": "Введите TTL кеша",
+    "description": "Метка для ввода времени жизни кеша."
+  },
+  "cacheTTLUnit": {
+    "message": "(в минутах)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Укажите TTL кэша в минутах (по умолчанию: 10)"
+  },
+  "refreshDataButton": {
+    "message": "Обновить данные (в обход кэша)"
+  },
+  "refreshDataInfo": {
+    "message": "Используйте эту кнопку для немедленного получения свежих данных."
+  },
+  "noteTitle": {
+    "message": "Примечание:"
+  },
+  "viewCodeButton": {
+    "message": "Посмотреть код"
+  },
+  "reportIssueButton": {
+    "message": "Сообщить о проблеме"
+  },
+  "repoFilterLabel": {
+    "message": "Фильтровать по репозиториям"
+  },
+  "enableFilteringLabel": {
+    "message": "Включить фильтрацию"
+  },
+  "tokenRequiredWarning": {
+    "message": "Для фильтрации репозиториев требуется токен GitHub. Пожалуйста, добавьте его в настройках."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Найти репозиторий для добавления..."
+  },
+  "repoPlaceholder": {
+    "message": "Репозитории не выбраны (будут включены все)"
+  },
+  "repoCountNone": {
+    "message": "0 репозиториев выбрано"
+  },
+  "repoCount": {
+    "message": "$1 репозиториев выбрано"
+  },
+  "repoLoading": {
+    "message": "Загрузка репозиториев..."
+  },
+  "repoLoaded": {
+    "message": "Загружено $1 репозиториев."
+  },
+  "repoNotFound": {
+    "message": "Репозитории не найдены"
+  },
+  "repoRefetching": {
+    "message": "Перезагрузка репозиториев..."
+  },
+  "repoLoadFailed": {
+    "message": "Не удалось загрузить репозитории."
+  },
+  "repoTokenPrivate": {
+    "message": "Токен недействителен или не имеет прав для частных репозиториев."
+  },
+  "repoRefetchFailed": {
+    "message": "Не удалось перезагрузить репозитории."
+  },
+  "orgSetMessage": {
+    "message": "Организация успешно установлена."
+  },
+  "orgClearedMessage": {
+    "message": "Организация удалена. Нажмите 'Создать отчет', чтобы получить все действия."
+  },
+  "orgNotFoundMessage": {
+    "message": "Организация не найдена на GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Ошибка при проверке организации."
+  },
+  "refreshingButton": {
+    "message": "Обновление..."
+  },
+  "cacheClearFailed": {
+    "message": "Не удалось очистить кэш."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Создание..."
+  },
+  "copiedButton": {
+    "message": "Скопировано!"
+  },
+  "orgChangedMessage": {
+    "message": "Организация изменена. Нажмите 'Создать отчет', чтобы получить данные о действиях в GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Кэш успешно очищен. Нажмите 'Создать отчет', чтобы получить свежие данные."
+  },
+  "cacheExpiredMessage": {
+    "message": "Кэш истёк. Нажмите \"Создать\", чтобы получить новые данные.",
+    "description": "Message shown when the cached data has expired and user needs to regenerate."
+  },
+  "cacheClearedButton": {
+    "message": "Кэш очищен!"
+  },
+  "extensionDisabledMessage": {
+    "message": "Расширение отключено. Включите его в настройках, чтобы создавать scrum-отчеты."
+  },
+  "notePoint1": {
+    "message": "Pull-реквесты извлекаются на основе последней активности по проверке любого участника, а не только вашей. Пожалуйста, просмотрите и скорректируйте сгенерированный отчет SCRUM, чтобы убедиться, что он точно отражает вашу работу, прежде чем делиться им."
+  },
+  "noteSeeIssue": {
+    "message": "Смотрите эту проблему"
+  },
+  "platformLabel": {
+    "message": "Платформа"
+  },
+  "usernameLabel": {
+    "message": "Ваше имя пользователя"
+  },
+  "usernameRequiredError": {
+    "message": "Пожалуйста, введите имя пользователя для создания отчета."
+  },
+  "unknownPlatformError": {
+    "message": "Выбрана неизвестная платформа."
+  },
+  "gitlabFetchingError": {
+    "message": "Произошла ошибка при получении данных GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Произошла ошибка при создании отчета."
+  },
+  "githubUserNotFoundError": {
+    "message": "Пользователь GitHub \"$1\" не найден (404). Проверьте имя пользователя и попробуйте снова."
+  },
+  "githubUserValidationError": {
+    "message": "Ошибка при проверке пользователя GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Недопустимый поисковый запрос или диапазон дат. Проверьте формат и попробуйте снова."
+  },
+  "githubIssuesFetchError": {
+    "message": "Ошибка при получении задач GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Ошибка при получении данных проверки PR GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Ошибка при получении данных пользователя GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Недействительный или истекший токен GitHub. Проверьте токен в настройках Scrum Helper и попробуйте снова."
+  },
+  "displayModeNotice": {
+    "message": "Расширение откроется в режиме $1 при следующем запуске."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Фильтрация репозиториев доступна только для GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Загрузка репозиториев доступна только для GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Получение репозиториев доступно только для GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Репозитории загружаются автоматически..."
+  },
+  "gitlabUserFetchError": {
+    "message": "Ошибка при получении пользователя GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Пользователь GitLab '$1' не найден"
+  },
+  "gitlabMembershipError": {
+    "message": "Ошибка при получении проектов членства GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Ошибка при получении проектов с вкладом GitLab: $1 $2"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Включить в отчет только проверенные PR"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Если отмечено, отчёт будет включать только PR, проверенные вами."
+  },
+  "usernameMissingError": {
+    "message": "Требуется имя пользователя."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Создание отчёта..."
+  },
+  "copyingReportNotification": {
+    "message": "Копирование отчёта..."
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Вставка отчёта в письмо..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Отчёт вставлен в письмо!"
+  },
+  "tokenSetupTitle": {
+    "message": "Добавить токен GitHub"
+  },
+  "tokenSetupDescription": {
+    "message": "Включите продвинутые функции, добавив ваш токен GitHub"
+  },
+  "tokenSetupBenefits": {
+    "message": "Преимущества"
+  },
+  "tokenSetupBenefit1": {
+    "message": "Более высокие ограничения API"
+  },
+  "tokenSetupBenefit2": {
+    "message": "Доступ к приватным репозиториям"
+  },
+  "tokenSetupBenefit3": {
+    "message": "Показывать коммиты в PR"
+  },
+  "addTokenButton": {
+    "message": "Добавить токен"
+  },
+  "learnMoreLink": {
+    "message": "Узнать больше"
+  }
 }

--- a/src/manifests/chrome.json
+++ b/src/manifests/chrome.json
@@ -32,7 +32,9 @@
         "scripts/jquery-3.2.1.min.js",
         "scripts/emailClientAdapter.js",
         "scripts/gitlabHelper.js",
-        "scripts/scrumHelper.js"
+        "scripts/scrumHelper.js",
+        "scripts/utils/githubRequest.js",
+        "scripts/utils/gitlabRequest.js"
       ]
     }
   ],

--- a/src/popup.html
+++ b/src/popup.html
@@ -310,6 +310,108 @@
 					<div>
 						<div>
 							<h6 class="text-base font-semibold mt-2" data-i18n="scrumReportLabel">Scrum Report</h6>
+							 <!-- Rate Limit Warning — GitHub -->
+                <div
+                  id="rateLimitWarning"
+                  class="rate-limit-banner hidden my-3 p-4 border-2 rounded-xl"
+                  style="background-color: #fefce8; border-color: #fde047"
+                >
+                  <div class="flex items-start gap-3">
+                    <i
+                      class="fa fa-exclamation-triangle text-xl mt-1"
+                      style="color: #ca8a04"
+                    ></i>
+                    <div class="flex-1">
+                      <h4 class="font-semibold text-sm" style="color: #854d0e">
+                        API Rate Limit Reached
+                      </h4>
+                      <p
+                        class="text-xs mt-1"
+                        id="rateLimitMessage"
+                        style="color: #a16207"
+                      >
+                        You've exceeded the GitHub API rate limit for
+                        unauthenticated requests (60/hour). Adding a Personal
+                        Access Token increases your limit to 5,000 requests/hour
+                        and enables access to private repositories.
+                      </p>
+                      <div class="flex items-center gap-2 mt-3">
+                        <button
+                          id="rateLimitAddToken"
+                          class="flex items-center justify-center gap-2 text-white font-medium py-2 px-4 rounded-lg text-sm transition-colors duration-200"
+                          style="background-color: #ca8a04"
+                        >
+                          <i class="fa fa-key"></i>
+                          <span>Add GitHub Token</span>
+                        </button>
+                        <button
+                          id="rateLimitDismiss"
+                          class="text-xs underline ml-2"
+                          style="color: #ca8a04"
+                        >
+                          Dismiss
+                        </button>
+                      </div>
+                      <p
+                        class="text-xs mt-2"
+                        id="rateLimitRetryInfo"
+                        style="color: #a16207"
+                      ></p>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Rate Limit Warning — GitLab -->
+                <div
+                  id="rateLimitWarningGitlab"
+                  class="rate-limit-banner hidden my-3 p-4 border-2 rounded-xl"
+                  style="background-color: #fff7ed; border-color: #fdba74"
+                >
+                  <div class="flex items-start gap-3">
+                    <i
+                      class="fa fa-exclamation-triangle text-xl mt-1"
+                      style="color: #ea580c"
+                    ></i>
+                    <div class="flex-1">
+                      <h4 class="font-semibold text-sm" style="color: #9a3412">
+                        API Rate Limit Reached
+                      </h4>
+                      <p
+                        class="text-xs mt-1"
+                        id="rateLimitMessageGitlab"
+                        style="color: #c2410c"
+                      >
+                        You've exceeded the GitLab API rate limit. Adding a
+                        Personal Access Token increases your limit and enables
+                        access to private projects.
+                      </p>
+                      <div class="flex items-center gap-2 mt-3">
+                        <button
+                          id="rateLimitAddTokenGitlab"
+                          class="flex items-center justify-center gap-2 text-white font-medium py-2 px-4 rounded-lg text-sm transition-colors duration-200"
+                          style="background-color: #ea580c"
+                        >
+                          <i class="fa fa-key"></i>
+                          <span>Add GitLab Token</span>
+                        </button>
+                        <button
+                          id="rateLimitDismissGitlab"
+                          class="text-xs underline ml-2"
+                          style="color: #ea580c"
+                        >
+                          Dismiss
+                        </button>
+                      </div>
+                      <p
+                        class="text-xs mt-2"
+                        id="rateLimitRetryInfoGitlab"
+                        style="color: #c2410c"
+                      ></p>
+                    </div>
+                  </div>
+                </div>
+
+
 							<div id="scrumReport" contenteditable="true"
 								class="min-h-[200px] overflow-y-auto whitespace-pre-wrap border-2 border-gray-200 bg-gray-100 rounded-xl text-gray-800 p-2 my-2">
 							</div>
@@ -609,6 +711,8 @@
 	<script src="scripts/jquery-3.2.1.min.js"></script>
 	<script type="text/javascript" type="text/javascript" src="materialize/js/materialize.min.js"></script>
 	<script src="scripts/emailClientAdapter.js"></script>
+	<script src="scripts/utils/githubRequest.js"></script>
+	<script src="scripts/utils/gitlabRequest.js"></script>
 	<script src="scripts/main.js"></script>
 	<script src="scripts/gitlabHelper.js"></script>
 	<script src="scripts/scrumHelper.js"></script>

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,316 +1,644 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" class="mode-sidepanel">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <link rel="stylesheet" href="tailwindcss.css" />
+    <link rel="stylesheet" type="text/css" href="index.css" />
+    <link rel="stylesheet" href="fontawesome/css/all.min.css" />
+    <style type="text/css">
+      html,
+      body {
+        margin: 0;
+        background: #eae4e4;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+      }
 
-<head>
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
-	<link rel="stylesheet" href="tailwindcss.css">
-	<link rel="stylesheet" type="text/css" href="index.css">
-	<link rel="stylesheet" href="fontawesome/css/all.min.css">
-	<style type="text/css">
-		html,
-		body {
+      body {
+        display: flex;
+      }
 
-			margin: 0;
-			background: #eae4e4;
-			width: 100%;
-			height: 100%;
-			overflow: hidden;
-		}
+      html.mode-sidepanel,
+      body.mode-sidepanel {
+        width: 100% !important;
+        height: 100% !important;
+        max-width: 100% !important;
+        max-height: 100% !important;
+        min-width: 360px;
+        min-height: 100% !important;
+      }
 
-		body {
-			display: flex;
-		}
+      html.mode-popup,
+      body.mode-popup {
+        width: 360px !important;
+        height: 600px !important;
+        min-width: 360px;
+        max-width: 420px;
+        min-height: 600px !important;
+        max-height: 600px !important;
+        overflow: hidden !important;
+      }
 
-		html.mode-sidepanel,
-		body.mode-sidepanel {
-			width: 100% !important;
-			height: 100% !important;
-			max-width: 100% !important;
-			max-height: 100% !important;
-			min-width: 360px;
-			min-height: 100% !important;
-		}
+      #popupRoot {
+        flex: 1;
+        min-width: 360px;
+        flex-shrink: 0;
 
-		html.mode-popup,
-		body.mode-popup {
-			width: 360px !important;
-			height: 600px !important;
-			min-width: 360px;
-			max-width: 420px;
-			min-height: 600px !important;
-			max-height: 600px !important;
-			overflow: hidden !important;
-		}
+        height: 100%;
+        overflow-y: auto;
+        overflow-x: hidden;
+        scrollbar-width: auto;
+        -ms-overflow-style: auto;
+      }
 
-		#popupRoot {
-			flex: 1;
-			min-width: 360px;
-			flex-shrink: 0;
+      #platformSelect option {
+        font-family: "FontAwesome", "Arial", sans-serif;
+      }
 
-			height: 100%;
-			overflow-y: auto;
-			overflow-x: hidden;
-			scrollbar-width: auto;
-			-ms-overflow-style: auto;
-		}
+      #customPlatformDropdown {
+        position: relative;
+      }
 
-		#platformSelect option {
-			font-family: 'FontAwesome', 'Arial', sans-serif;
-		}
+      #platformDropdownList {
+        display: none;
+      }
 
-		#customPlatformDropdown {
-			position: relative;
-		}
+      #customPlatformDropdown.open #platformDropdownList {
+        display: block;
+      }
 
-		#platformDropdownList {
-			display: none;
-		}
+      #platformDropdownBtn:focus {
+        outline: 2px solid #2563eb;
+      }
 
-		#customPlatformDropdown.open #platformDropdownList {
-			display: block;
-		}
+      /* Firefox Sidebar Fixes ONLY */
+      html.firefox-sidebar,
+      body.firefox-sidebar {
+        background: transparent !important;
+        min-width: 100% !important;
+      }
+      body.firefox-sidebar #popupRoot {
+        min-width: 100% !important;
+      }
 
-		#platformDropdownBtn:focus {
-			outline: 2px solid #2563eb;
-		}
+      /* Token Setup UI - Theme Aware */
+      #tokenSetupContainer {
+        padding: 12px 6px;
+        border-radius: 6px;
+        text-align: center;
+        border: 4px solid;
+        transition: all 0.3s ease-in-out;
+        /* Light theme (default) */
+        background: #f3f4f6;
+        color: #374151;
+        border-color: #e5e7eb;
+      }
 
-		/* Firefox Sidebar Fixes ONLY */
-		html.firefox-sidebar, 
-		body.firefox-sidebar {
-			background: transparent !important;
-			min-width: 100% !important;
-		}
-		body.firefox-sidebar #popupRoot {
-			min-width: 100% !important;
-		}
-	</style>
-</head>
+      /* Dark mode */
+      body.dark-mode #tokenSetupContainer {
+        background: #2a2a2a;
+        color: #e5e7eb;
+        border-color: #404040;
+      }
 
-<body class="mode-sidepanel text-gray-800 bg-gray-50 flex flex-col font-sans">
-	<div id="popupRoot" class="pl-1 py-2 rounded-2xl">
-		<div class="bg-white px-4 py-4 mx-2 mb-2 rounded-3xl">
-			<div class="flex justify-between py-2">
-				<h3 id="scrumHelperHeading" class="text-3xl font-semibold cursor-pointer">Scrum Helper</h3>
-				<img src="icons/night-mode.png" alt="Night Mode" class="w-7 h-7 mx-3 cursor-pointer"
-					id="darkModeToggle">
-			</div>
-			<div>
-				<p class="" data-i18n="appDescription">Report your development progress by auto-fetching your Git
-					activity for a selected period
-				</p>
-			</div>
+      #tokenSetupContainer > div:nth-child(2) {
+        display: flex;
+        justify-content: center;
+        margin-bottom: 12px;
+      }
 
-			<div class="center mt-2 flex justify-end">
-				<div class="flex">
-					<button id="homeButton"
-						class="ml-1 p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition">
-						<i class="fa fa-home text-2xl text-gray-600 dark:text-gray-300"></i>
-					</button>
-					<button id="settingsToggle">
-						<img id="settingsIcon" src="icons/settings-light.png" alt="Settings"
-							class="w-6 h-6 mx-3 cursor-pointer">
-					</button>
-				</div>
-			</div>
-		</div>
+      #tokenSetupContainer i.fa-lock {
+        font-size: 32px;
+        color: #fbbf24;
+      }
 
-		<div class="rounded-2xl">
-			<div class=" border-gray-100 border-2 bg-white rounded-3xl px-4 py-4 mx-2 my-2">
+      #tokenSetupContainer h3 {
+        font-weight: 600;
+        font-size: 16px;
+        margin: 0 0 8px 0;
+        text-align: center;
+      }
 
-				<div id="reportSection" class="tab-content">
-					<div>
+      body.dark-mode #tokenSetupContainer h3 {
+        color: #ffffff;
+      }
 
+      body:not(.dark-mode) #tokenSetupContainer h3 {
+        color: #1f2937;
+      }
 
-						<p data-i18n="platformLabel" class="font-medium text-sm" style="margin-bottom: 0.3rem;">Platform
-						</p>
-						<div class="relative mb-4" id="customPlatformDropdown" style="margin-bottom: 0.8rem;">
-							<input type="hidden" id="platformSelect" value="github">
-							<button type="button" id="platformDropdownBtn"
-								class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 pr-8 flex items-center justify-between focus:outline-none focus:ring-2 focus:ring-blue-500">
-								<span id="platformDropdownSelected" class="flex items-center gap-2">
-									<i class="fab fa-github" style="margin-right:8px;"></i> GitHub
-								</span>
-								<i class="fa fa-chevron-down text-gray-500"></i>
-							</button>
-							<ul id="platformDropdownList"
-								class="absolute left-0 right-0 bg-white border-2 border-gray-200 rounded-xl mt-1 shadow-lg z-10 hidden">
-								<li style="padding-left: 8px; padding-right: 16px; padding-top: 8px; padding-bottom: 8px; display: flex; align-items: center; cursor: pointer;"
-									class="hover:bg-gray-100" data-value="github">
-									<i class="fab fa-github" style="margin-right: 12px; font-size: 18px;"></i> GitHub
-								</li>
-								<li style="padding-left: 8px; padding-right: 16px; padding-top: 8px; padding-bottom: 8px; display: flex; align-items: center; cursor: pointer;"
-									class="hover:bg-gray-100" data-value="gitlab">
-									<i class="fab fa-gitlab" style="margin-right: 12px; font-size: 18px;"></i> GitLab
-								</li>
-							</ul>
-						</div>
-					</div>
-					<div>
-						<div class="flex">
+      #tokenSetupContainer > p {
+        font-size: 13px;
+        line-height: 1.5;
+        text-align: center;
+        margin-bottom: 12px;
+      }
 
-							<p class=" font-medium text-sm" data-i18n="projectNameLabel">Project Name (used in email
-								subject)</p><span class="tooltip-container ml-2">
-								<i class="fa fa-question-circle question-icon"></i>
-								<span class="tooltip-bubble" data-i18n="projectNameTooltip">
-									This project name will appear in the subject line of your email as part of:
-									"[Scrum] Project Name - Date”. Leave blank to skip.
-								</span>
-							</span>
+      body.dark-mode #tokenSetupContainer > p {
+        color: #d1d5db;
+      }
 
-						</div>
+      body:not(.dark-mode) #tokenSetupContainer > p {
+        color: #4b5563;
+      }
 
+      /* Benefits Box */
+      #tokenSetupContainer .benefits-box {
+        padding: 12px;
+        border-radius: 6px;
+        margin: 0 auto 12px auto;
+        border: 1px solid;
+        max-width: 320px;
+        text-align: left;
+        transition: all 0.3s ease-in-out;
+      }
 
-						<input id="projectName" type="text"
-							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2"
-							data-i18n-placeholder="projectNamePlaceholder" style="margin-top: 0.3rem; margin-bottom: 0.8rem;">
-					</div>
-					<div>
+      body.dark-mode #tokenSetupContainer .benefits-box {
+        background: #1f2937;
+        border-color: #404040;
+      }
 
-						<p id="usernameLabel" class="font-medium text-sm" data-i18n="usernameLabel">Your Username</p>
-						<input id="platformUsername" type="text"
-							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2"
-							data-i18n-placeholder="githubUsernamePlaceholder"
-							style="margin-top: 0.3rem; margin-bottom: 0.8rem;">
-					</div>
+      body:not(.dark-mode) #tokenSetupContainer .benefits-box {
+        background: #f9fafb;
+        border-color: #e5e7eb;
+      }
 
-					<div>
-						<p class="text-lg mb-1 font-medium text-sm" data-i18n="contributionsLabel">Fetch your
-							contributions between:</p>
+      #tokenSetupContainer .benefits-title {
+        font-weight: 600;
+        font-size: 13px;
+        margin-bottom: 8px;
+      }
 
+      body.dark-mode #tokenSetupContainer .benefits-title {
+        color: #ffffff;
+      }
 
-						<div class="flex gap-[3px] justify-between items-center mt-2" style="gap: 8px">
+      body:not(.dark-mode) #tokenSetupContainer .benefits-title {
+        color: #1f2937;
+      }
 
-							<div id="customDateContainer" class="flex gap-2">
+      #tokenSetupContainer .benefit-item {
+        font-size: 13px;
+        margin-bottom: 6px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
 
-								<div>
-									<label for="startingDate" class="flex items-center font-medium text-xs"
-										data-i18n="startDateLabel">From:</label>
-									<input type="date" id="startingDate"
-										class="border-2 border-gray-200 bg-gray-200 rounded-xl p-1"
-										style="width: 96px;">
-								</div>
-								<div>
-									<label for="endingDate" class="flex items-center font-medium text-xs"
-										data-i18n="endDateLabel">To:</label>
-									<input type="date" id="endingDate"
-										class="border-2 border-gray-200 bg-gray-200 rounded-xl p-1"
-										style="width: 96px;">
-								</div>
-							</div>
-							<div class="flex items-center gap-1">
-								<input type="radio" id="yesterdayContribution" name="timeframe" class="form-radio"
-									style="margin-right: 4px;">
-								<label for="yesterdayContribution" class="font-medium text-xs"
-									data-i18n="last1DayLabel">Previous Day</label>
-							</div>
-						</div>
-					</div>
+      body.dark-mode #tokenSetupContainer .benefit-item {
+        color: #d1d5db;
+      }
 
-					<div style="margin-bottom: 1rem;">
-						<br />
-						<input type="checkbox" id="showOpenLabel" class="form-checkbox text-blue-600">
+      body:not(.dark-mode) #tokenSetupContainer .benefit-item {
+        color: #4b5563;
+      }
 
-						<label id="checkboxLabel" for="showOpenLabel" class="font-medium text-sm"
-							style="margin-left: 4px;" data-i18n="showOpenClosedLabel">Show
-							PRs Labels</label>
+      #tokenSetupContainer .benefit-item i {
+        color: #10b981;
+      }
 
-					</div>
-					<div class="my-4">
-						<div class="flex items-center">
-							<input type="checkbox" id="onlyIssues" class="form-checkbox text-blue-600">
-							<label for="onlyIssues" class="font-medium text-sm flex items-center"
-								style="margin-left: 4px;" data-i18n="onlyIssuesLabel">
-								Include only issues in the report
-							</label>
-							<span class="tooltip-container">
-								<i class="fa fa-question-circle question-icon"></i>
-								<span class="tooltip-bubble" data-i18n="onlyIssuesTooltip">
-									If checked, the report will only include issues created or assigned to the user.
-								</span>
-							</span>
-						</div>
-					</div>
+      /* Button */
+      #tokenSetupAddBtn {
+        padding: 8px 16px;
+        border-radius: 6px;
+        border: none;
+        cursor: pointer;
+        font-weight: 500;
+        font-size: 13px;
+        width: 100%;
+        transition: background-color 0.2s;
+        background: #2563eb;
+        color: #ffffff;
+      }
 
-					<div class="my-4">
-						<div class="flex items-center">
-							<input type="checkbox" id="onlyPRs" class="form-checkbox text-blue-600">
-							<label for="onlyPRs" class="font-medium text-sm flex items-center" style="margin-left: 4px;"
-								data-i18n="onlyPRsLabel">
-								Include only PRs in the report
-							</label>
-							<span class="tooltip-container">
-								<i class="fa fa-question-circle question-icon"></i>
-								<span class="tooltip-bubble" data-i18n="onlyPRsTooltip">
-									If checked, the report will only include PRs created by you.
-								</span>
-							</span>
-						</div>
-					</div>
+      #tokenSetupAddBtn:hover {
+        background: #1d4ed8;
+      }
 
-					<div class="my-4">
-						<div class="flex items-center">
-							<input type="checkbox" id="onlyRevPRs" class="form-checkbox text-blue-600">
-							<label for="onlyRevPRs" class="font-medium text-sm flex items-center"
-								style="margin-left: 4px;" data-i18n="onlyRevPRsLabel">
-								Include only Reviewed PRs in the report
-							</label>
-							<span class="tooltip-container">
-								<i class="fa fa-question-circle question-icon"></i>
-								<span class="tooltip-bubble" data-i18n="onlyPRsTooltip">
-									If checked, the report will only include PRs reviewed by you.
-								</span>
-							</span>
-						</div>
-					</div>
+      /* Learn More Link */
+      #tokenSetupLearnBtn {
+        font-size: 12px;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        text-decoration: none;
+        margin-top: 8px;
+      }
 
-					<div class="my-4 githubOnlySection">
-						<div class="flex items-center">
-							<input type="checkbox" id="onlyMergedPRs" class="form-checkbox text-blue-600">
-							<label for="onlyMergedPRs" class="font-medium text-sm flex items-center"
-								style="margin-left: 4px;" data-i18n="onlyMergedPRsLabel">
-								Include only Merged PRs in the report
-							</label>
-							<span class="tooltip-container">
-								<i class="fa fa-question-circle question-icon"></i>
-								<span class="tooltip-bubble" data-i18n="onlyMergedPRsTooltip">
-									If checked, the report will only include merged PRs. A GitHub token is required.
-								</span>
-							</span>
-						</div>
-						<div id="tokenWarningForMergedPRs"
-							class="hidden text-xs text-red-600 p-2 bg-red-50 border border-red-200 rounded-xl mt-2">
-							<span data-i18n="tokenRequiredMergedPRsWarning">A GitHub token is required to filter by merged PRs. Please add one in the settings.</span>
-						</div>
-					</div>
+      body.dark-mode #tokenSetupLearnBtn {
+        color: #60a5fa;
+      }
 
-					<div class="my-4 githubOnlySection">
-						<div class="flex items-center">
-							<input type="checkbox" id="showCommits" checked class="form-checkbox text-blue-600 ">
+      body:not(.dark-mode) #tokenSetupLearnBtn {
+        color: #2563eb;
+      }
 
-							<label id="showCommitsLabel" for="showCommits"
-								class="font-medium text-sm flex items-center pl-5 ml-4" style="margin-left: 4px;"
-								data-i18n="showCommitsLabel">Show commits on open PRs/ draft PRs</label><span
-								class="tooltip-container">
-								<i class="fa fa-question-circle question-icon"></i>
-								<span class="tooltip-bubble" data-i18n="showCommitsTooltip">
-									Github Token required, add it in the settings.
-								</span>
-							</span>
+      #tokenSetupLearnBtn:hover {
+        text-decoration: underline;
+      }
 
-						</div>
-						<div id="tokenWarningForShowCommits"
-							class="hidden text-xs text-red-600 p-2 bg-red-50 border border-red-200 rounded-xl mt-2">
-							<span data-i18n="tokenRequiredShowCommitsWarning">A GitHub token is required to show commits
-								on open or draft PRs. Please add one in the settings.</span>
-						</div>
-					</div>
+      .hidden {
+        display: none !important;
+      }
+    </style>
+  </head>
 
-					<div>
-						<div>
-							<h6 class="text-base font-semibold mt-2" data-i18n="scrumReportLabel">Scrum Report</h6>
-							 <!-- Rate Limit Warning — GitHub -->
+  <body class="mode-sidepanel text-gray-800 bg-gray-50 flex flex-col font-sans">
+    <div id="popupRoot" class="pl-1 py-2 rounded-2xl">
+      <div class="bg-white px-4 py-4 mx-2 mb-2 rounded-3xl">
+        <div class="flex justify-between py-2">
+          <h3
+            id="scrumHelperHeading"
+            class="text-3xl font-semibold cursor-pointer"
+          >
+            Scrum Helper
+          </h3>
+          <img
+            src="icons/night-mode.png"
+            alt="Night Mode"
+            class="w-7 h-7 mx-3 cursor-pointer"
+            id="darkModeToggle"
+          />
+        </div>
+        <div>
+          <p class="" data-i18n="appDescription">
+            Report your development progress by auto-fetching your Git activity
+            for a selected period
+          </p>
+        </div>
+
+        <div class="center mt-2 flex justify-end">
+          <div class="flex">
+            <button
+              id="homeButton"
+              class="ml-1 p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition"
+            >
+              <i
+                class="fa fa-home text-2xl text-gray-600 dark:text-gray-300"
+              ></i>
+            </button>
+            <button id="settingsToggle">
+              <img
+                id="settingsIcon"
+                src="icons/settings-light.png"
+                alt="Settings"
+                class="w-6 h-6 mx-3 cursor-pointer"
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div class="rounded-2xl">
+        <div
+          class="border-gray-100 border-2 bg-white rounded-3xl px-4 py-4 mx-2 my-2"
+        >
+          <div id="reportSection" class="tab-content">
+            <div>
+              <p
+                data-i18n="platformLabel"
+                class="font-medium text-sm"
+                style="margin-bottom: 0.3rem"
+              >
+                Platform
+              </p>
+              <div
+                class="relative mb-4"
+                id="customPlatformDropdown"
+                style="margin-bottom: 0.8rem"
+              >
+                <input type="hidden" id="platformSelect" value="github" />
+                <button
+                  type="button"
+                  id="platformDropdownBtn"
+                  class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 pr-8 flex items-center justify-between focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  <span
+                    id="platformDropdownSelected"
+                    class="flex items-center gap-2"
+                  >
+                    <i class="fab fa-github" style="margin-right: 8px"></i>
+                    GitHub
+                  </span>
+                  <i class="fa fa-chevron-down text-gray-500"></i>
+                </button>
+                <ul
+                  id="platformDropdownList"
+                  class="absolute left-0 right-0 bg-white border-2 border-gray-200 rounded-xl mt-1 shadow-lg z-10 hidden"
+                >
+                  <li
+                    style="
+                      padding-left: 8px;
+                      padding-right: 16px;
+                      padding-top: 8px;
+                      padding-bottom: 8px;
+                      display: flex;
+                      align-items: center;
+                      cursor: pointer;
+                    "
+                    class="hover:bg-gray-100"
+                    data-value="github"
+                  >
+                    <i
+                      class="fab fa-github"
+                      style="margin-right: 12px; font-size: 18px"
+                    ></i>
+                    GitHub
+                  </li>
+                  <li
+                    style="
+                      padding-left: 8px;
+                      padding-right: 16px;
+                      padding-top: 8px;
+                      padding-bottom: 8px;
+                      display: flex;
+                      align-items: center;
+                      cursor: pointer;
+                    "
+                    class="hover:bg-gray-100"
+                    data-value="gitlab"
+                  >
+                    <i
+                      class="fab fa-gitlab"
+                      style="margin-right: 12px; font-size: 18px"
+                    ></i>
+                    GitLab
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <div>
+              <div class="flex">
+                <p class="font-medium text-sm" data-i18n="projectNameLabel">
+                  Project Name (used in email subject)
+                </p>
+                <span class="tooltip-container ml-2">
+                  <i class="fa fa-question-circle question-icon"></i>
+                  <span class="tooltip-bubble" data-i18n="projectNameTooltip">
+                    This project name will appear in the subject line of your
+                    email as part of: "[Scrum] Project Name - Date”. Leave blank
+                    to skip.
+                  </span>
+                </span>
+              </div>
+
+              <input
+                id="projectName"
+                type="text"
+                class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2"
+                data-i18n-placeholder="projectNamePlaceholder"
+                style="margin-top: 0.3rem; margin-bottom: 0.8rem"
+              />
+            </div>
+            <div>
+              <p
+                id="usernameLabel"
+                class="font-medium text-sm"
+                data-i18n="usernameLabel"
+              >
+                Your Username
+              </p>
+              <input
+                id="platformUsername"
+                type="text"
+                class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2"
+                data-i18n-placeholder="githubUsernamePlaceholder"
+                style="margin-top: 0.3rem; margin-bottom: 0.8rem"
+              />
+            </div>
+
+            <div>
+              <p
+                class="text-lg mb-1 font-medium text-sm"
+                data-i18n="contributionsLabel"
+              >
+                Fetch your contributions between:
+              </p>
+
+              <div
+                class="flex gap-[3px] justify-between items-center mt-2"
+                style="gap: 8px"
+              >
+                <div id="customDateContainer" class="flex gap-2">
+                  <div>
+                    <label
+                      for="startingDate"
+                      class="flex items-center font-medium text-xs"
+                      data-i18n="startDateLabel"
+                      >From:</label
+                    >
+                    <input
+                      type="date"
+                      id="startingDate"
+                      class="border-2 border-gray-200 bg-gray-200 rounded-xl p-1"
+                      style="width: 96px"
+                    />
+                  </div>
+                  <div>
+                    <label
+                      for="endingDate"
+                      class="flex items-center font-medium text-xs"
+                      data-i18n="endDateLabel"
+                      >To:</label
+                    >
+                    <input
+                      type="date"
+                      id="endingDate"
+                      class="border-2 border-gray-200 bg-gray-200 rounded-xl p-1"
+                      style="width: 96px"
+                    />
+                  </div>
+                </div>
+                <div class="flex items-center gap-1">
+                  <input
+                    type="radio"
+                    id="yesterdayContribution"
+                    name="timeframe"
+                    class="form-radio"
+                    style="margin-right: 4px"
+                  />
+                  <label
+                    for="yesterdayContribution"
+                    class="font-medium text-xs"
+                    data-i18n="last1DayLabel"
+                    >Previous Day</label
+                  >
+                </div>
+              </div>
+            </div>
+
+            <div style="margin-bottom: 1rem">
+              <br />
+              <input
+                type="checkbox"
+                id="showOpenLabel"
+                class="form-checkbox text-blue-600"
+              />
+
+              <label
+                id="checkboxLabel"
+                for="showOpenLabel"
+                class="font-medium text-sm"
+                style="margin-left: 4px"
+                data-i18n="showOpenClosedLabel"
+                >Show PRs Labels</label
+              >
+            </div>
+            <div class="my-4">
+              <div class="flex items-center">
+                <input
+                  type="checkbox"
+                  id="onlyIssues"
+                  class="form-checkbox text-blue-600"
+                />
+                <label
+                  for="onlyIssues"
+                  class="font-medium text-sm flex items-center"
+                  style="margin-left: 4px"
+                  data-i18n="onlyIssuesLabel"
+                >
+                  Include only issues in the report
+                </label>
+                <span class="tooltip-container">
+                  <i class="fa fa-question-circle question-icon"></i>
+                  <span class="tooltip-bubble" data-i18n="onlyIssuesTooltip">
+                    If checked, the report will only include issues created or
+                    assigned to the user.
+                  </span>
+                </span>
+              </div>
+            </div>
+
+            <div class="my-4">
+              <div class="flex items-center">
+                <input
+                  type="checkbox"
+                  id="onlyPRs"
+                  class="form-checkbox text-blue-600"
+                />
+                <label
+                  for="onlyPRs"
+                  class="font-medium text-sm flex items-center"
+                  style="margin-left: 4px"
+                  data-i18n="onlyPRsLabel"
+                >
+                  Include only PRs in the report
+                </label>
+                <span class="tooltip-container">
+                  <i class="fa fa-question-circle question-icon"></i>
+                  <span class="tooltip-bubble" data-i18n="onlyPRsTooltip">
+                    If checked, the report will only include PRs created by you.
+                  </span>
+                </span>
+              </div>
+            </div>
+
+            <div class="my-4">
+              <div class="flex items-center">
+                <input
+                  type="checkbox"
+                  id="onlyRevPRs"
+                  class="form-checkbox text-blue-600"
+                />
+                <label
+                  for="onlyRevPRs"
+                  class="font-medium text-sm flex items-center"
+                  style="margin-left: 4px"
+                  data-i18n="onlyRevPRsLabel"
+                >
+                  Include only Reviewed PRs in the report
+                </label>
+                <span class="tooltip-container">
+                  <i class="fa fa-question-circle question-icon"></i>
+                  <span class="tooltip-bubble" data-i18n="onlyPRsTooltip">
+                    If checked, the report will only include PRs reviewed by
+                    you.
+                  </span>
+                </span>
+              </div>
+            </div>
+
+            <div class="my-4 githubOnlySection">
+              <div class="flex items-center">
+                <input
+                  type="checkbox"
+                  id="onlyMergedPRs"
+                  class="form-checkbox text-blue-600"
+                />
+                <label
+                  for="onlyMergedPRs"
+                  class="font-medium text-sm flex items-center"
+                  style="margin-left: 4px"
+                  data-i18n="onlyMergedPRsLabel"
+                >
+                  Include only Merged PRs in the report
+                </label>
+                <span class="tooltip-container">
+                  <i class="fa fa-question-circle question-icon"></i>
+                  <span class="tooltip-bubble" data-i18n="onlyMergedPRsTooltip">
+                    If checked, the report will only include merged PRs. A
+                    GitHub token is required.
+                  </span>
+                </span>
+              </div>
+              <div
+                id="tokenWarningForMergedPRs"
+                class="hidden text-xs text-red-600 p-2 bg-red-50 border border-red-200 rounded-xl mt-2"
+              >
+                <span data-i18n="tokenRequiredMergedPRsWarning"
+                  >A GitHub token is required to filter by merged PRs. Please
+                  add one in the settings.</span
+                >
+              </div>
+            </div>
+
+            <div class="my-4 githubOnlySection">
+              <div class="flex items-center">
+                <input
+                  type="checkbox"
+                  id="showCommits"
+                  checked
+                  class="form-checkbox text-blue-600"
+                />
+
+                <label
+                  id="showCommitsLabel"
+                  for="showCommits"
+                  class="font-medium text-sm flex items-center pl-5 ml-4"
+                  style="margin-left: 4px"
+                  data-i18n="showCommitsLabel"
+                  >Show commits on open PRs/ draft PRs</label
+                ><span class="tooltip-container">
+                  <i class="fa fa-question-circle question-icon"></i>
+                  <span class="tooltip-bubble" data-i18n="showCommitsTooltip">
+                    Github Token required, add it in the settings.
+                  </span>
+                </span>
+              </div>
+              <div
+                id="tokenWarningForShowCommits"
+                class="hidden text-xs text-red-600 p-2 bg-red-50 border border-red-200 rounded-xl mt-2"
+              >
+                <span data-i18n="tokenRequiredShowCommitsWarning"
+                  >A GitHub token is required to show commits on open or draft
+                  PRs. Please add one in the settings.</span
+                >
+              </div>
+            </div>
+
+            <div>
+              <div>
+                <h6
+                  class="text-base font-semibold mt-2"
+                  data-i18n="scrumReportLabel"
+                >
+                  Scrum Report
+                </h6>
+                <!-- Rate Limit Warning — GitHub -->
                 <div
                   id="rateLimitWarning"
                   class="rate-limit-banner hidden my-3 p-4 border-2 rounded-xl"
@@ -411,312 +739,501 @@
                   </div>
                 </div>
 
+                <!-- Scrum Report Container with Token Setup UI inside -->
+                <div
+                  id="scrumReport"
+                  contenteditable="false"
+                  class="min-h-[200px] overflow-y-auto whitespace-pre-wrap border-2 border-gray-200 bg-gray-100 rounded-xl text-gray-800 p-2 my-2"
+                >
+                  <!-- Token Setup UI Template (shown when rate limit hit and no token) -->
+                  <div id="tokenSetupContainer" class="hidden">
+                    <!-- Icon Container -->
+                    <div>
+                      <i class="fa fa-lock"></i>
+                    </div>
 
-							<div id="scrumReport" contenteditable="true"
-								class="min-h-[200px] overflow-y-auto whitespace-pre-wrap border-2 border-gray-200 bg-gray-100 rounded-xl text-gray-800 p-2 my-2">
-							</div>
-						</div>
+                    <!-- Title -->
+                    <h3>
+                      <span id="tokenSetupTitle" data-i18n="tokenSetupTitle"
+                        >GitHub Token Required</span
+                      >
+                    </h3>
 
-						<div class="scrum-actions my-2">
-							<div class="tooltip-container">
-								<button id="generateReport"
-									class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 rounded"
-									style="padding-left: 0.875rem; padding-right: 0.875rem;">
-									<i class="fa fa-refresh"></i> <span data-i18n="generateReportButton">Generate</span>
-								</button>
-								<span class="shortcut-tooltip" id="generateReportTooltipText">Ctrl+G</span>
-							</div>
+                    <!-- Description -->
+                    <p
+                      id="tokenSetupDescription"
+                      data-i18n="tokenSetupDescription"
+                    >
+                      A GitHub token is needed to fetch your contribution data
+                      and generate the scrum report.
+                    </p>
 
-							<div class="tooltip-container">
-								<button id="insertInEmail"
-									class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 rounded"
-									style="padding-left: 0.875rem; padding-right: 0.875rem;">
-									<i class="fa fa-envelope"></i> <span data-i18n="insertInEmailButton">Insert in
-										Email</span>
-								</button>
-								<span class="shortcut-tooltip" id="insertInEmailTooltipText">Ctrl+Shift+M</span>
-							</div>
+                    <!-- Benefits Box -->
+                    <div class="benefits-box">
+                      <!-- Benefits Title -->
+                      <div
+                        class="benefits-title"
+                        id="tokenSetupBenefits"
+                        data-i18n="tokenSetupBenefits"
+                      >
+                        Why is a token needed?
+                      </div>
 
-							<div class="tooltip-container">
-								<button id="copyReport"
-									class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded">
-									<i class="fa fa-copy"></i> <span data-i18n="copyReportButton">Copy</span>
-								</button>
-								<span class="shortcut-tooltip" id="copyReportTooltipText">Ctrl+Shift+Y</span>
-							</div>
-						</div>
+                      <!-- Benefits List -->
+                      <div class="benefit-item">
+                        <i class="fa fa-check-circle"></i>
+                        <span id="tokenBenefit1" data-i18n="tokenSetupBenefit1"
+                          >Access your GitHub activity</span
+                        >
+                      </div>
+                      <div class="benefit-item">
+                        <i class="fa fa-check-circle"></i>
+                        <span id="tokenBenefit2" data-i18n="tokenSetupBenefit2"
+                          >Higher API rate limits (5,000/hr)</span
+                        >
+                      </div>
+                      <div class="benefit-item">
+                        <i class="fa fa-check-circle"></i>
+                        <span id="tokenBenefit3" data-i18n="tokenSetupBenefit3"
+                          >Include private repositories</span
+                        >
+                      </div>
+                    </div>
 
+                    <!-- Add Token Button -->
+                    <button id="tokenSetupAddBtn">
+                      <i class="fa fa-cog" style="margin-right: 6px"></i>
+                      <span id="addTokenBtnText" data-i18n="addTokenButton"
+                        >Go to Settings</span
+                      >
+                    </button>
 
-					</div>
-					<div class="border-gray-100 border-2 bg-white rounded-3xl px-4 py-2 mx-2 my-2">
-						<div>
-							<h4 class="font-semibold text-xl" data-i18n="noteTitle">Note:</h4>
-							<ul class="text-xs list-disc list-inside">
-								<p data-i18n="notePoint1">Pull requests are fetched based on the most recent review
-									activity by any contributor, not just your own. Please review and adjust the
-									generated SCRUM report to ensure it accurately reflects your work before sharing.
-								</p>
-							</ul>
-						</div>
-					</div>
-				</div>
+                    <!-- Learn More Link -->
+                    <a id="tokenSetupLearnBtn" data-i18n="learnMoreLink">
+                      Learn how to create a token
+                    </a>
+                  </div>
 
-				<div id="settingsSection" class="tab-content hidden">
-					<div class="orgSection">
-						<div>
-							<div class="flex items-center justify-between">
-								<div class="flex">
-									<p class="text-sm font-medium" data-i18n="githubTokenLabel">Your GitHub Token</p>
-									<span class="tooltip-container">
-										<i class="fa fa-question-circle question-icon"></i>
-										<span class="tooltip-bubble" data-i18n="githubTokenTooltip">
-											<b>Why is it recommended to add a GitHub token?</b><br>
-											Scrum Helper works without a GitHub token, but adding a personal access
-											token is recommended for a
-											better experience. It raises your API limits, allows access to private
-											repos
-											(if permitted), and
-											improves accuracy and speed. Tokens are stored locally and never sent to
-											us
-											and used only to fetch
-											your git data. You can add one anytime in the extension
-											settings.<br><br>
-											<b>How to obtain:</b><br>
-											1. Go to <a href="https://github.com/settings/tokens" target="_blank"
-												rel="noopener noreferrer"
-												style="color:#2563eb;text-decoration:underline;">GitHub Developer
-												Settings</a>.<br>
-											3. Click "Generate new token", select classic token<br>
-											4. Paste it here.<br>
-											<i>Keep your token secret!</i>
-										</span>
-									</span>
+                  <!-- Scrum Report Text Content -->
+                  <div
+                    id="scrumReportContent"
+                    contenteditable="true"
+                    class="whitespace-pre-wrap"
+                  ></div>
+                </div>
+              </div>
 
-								</div>
-								<button id="toggleTokenVisibility" type="button" class="focus:outline-none">
-									<i id="tokenEyeIcon" class="fa fa-eye text-gray-600"></i>
-								</button>
-							</div>
-							<input id="githubToken" type="password"
-								class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2 pr-10"
-								data-i18n-placeholder="githubTokenPlaceholder">
-						</div>
-						<div class="githubOnlySection">
-							<div class="flex items-center mt-4">
-								<p class="text-sm font-semibold" data-i18n="settingsOrgNameLabel">Your Organization Name
-								</p>
-								<span class="tooltip-container ml-2">
-									<i class="fa fa-question-circle question-icon"></i>
-									<span class="tooltip-bubble" data-i18n="orgNameTooltip">
-										<b>Which organization's GitHub activity?</b><br>
-										Enter the GitHub organization name to fetch activities for. Leave empty to fetch
-										all
-										your GitHub
-										activities across all organizations.
-										Organization name is not case-sensitive.
-									</span>
-								</span>
-							</div>
-							<input id="orgInput" type="text"
-								class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2"
-								data-i18n-placeholder="settingsOrgNamePlaceholder"
-								style="margin-top: 0.3rem; margin-bottom: 0.8rem;">
+              <div class="scrum-actions my-2">
+                <div class="tooltip-container">
+                  <button
+                    id="generateReport"
+                    class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 rounded"
+                    style="padding-left: 0.875rem; padding-right: 0.875rem"
+                  >
+                    <i class="fa fa-refresh"></i>
+                    <span data-i18n="generateReportButton">Generate</span>
+                  </button>
+                  <span class="shortcut-tooltip" id="generateReportTooltipText"
+                    >Ctrl+G</span
+                  >
+                </div>
 
-							<!-- Organization validation feedback -->
-							<div id="orgValidationMessage" class="hidden text-xs mt-1 mb-2 px-3 py-2 rounded-lg">
-								<span id="orgValidationText"></span>
-							</div>
-						</div>
+                <div class="tooltip-container">
+                  <button
+                    id="insertInEmail"
+                    class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 rounded"
+                    style="padding-left: 0.875rem; padding-right: 0.875rem"
+                  >
+                    <i class="fa fa-envelope"></i>
+                    <span data-i18n="insertInEmailButton">Insert in Email</span>
+                  </button>
+                  <span class="shortcut-tooltip" id="insertInEmailTooltipText"
+                    >Ctrl+Shift+M</span
+                  >
+                </div>
 
-						<div class="mb-4">
-							<div class="flex items-center justify-between mb-2">
-								<p class="text-sm font-medium">
-									<span data-i18n="repoFilterLabel">Filter by repositories</span><span
-										class="tooltip-container">
-										<i class="fa fa-question-circle question-icon"></i>
-										<span class="tooltip-bubble" data-i18n="repoFilterTooltip">
-											Github Token required.<br>
-											To force a repo list update, <br>
-											click the Refresh Data button.
-										</span>
-									</span>
-								</p>
-								<div class="flex items-center">
+                <div class="tooltip-container">
+                  <button
+                    id="copyReport"
+                    class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded"
+                  >
+                    <i class="fa fa-copy"></i>
+                    <span data-i18n="copyReportButton">Copy</span>
+                  </button>
+                  <span class="shortcut-tooltip" id="copyReportTooltipText"
+                    >Ctrl+Shift+Y</span
+                  >
+                </div>
+              </div>
+            </div>
+            <div
+              class="border-gray-100 border-2 bg-white rounded-3xl px-4 py-2 mx-2 my-2"
+            >
+              <div>
+                <h4 class="font-semibold text-xl" data-i18n="noteTitle">
+                  Note:
+                </h4>
+                <ul class="text-xs list-disc list-inside">
+                  <p data-i18n="notePoint1">
+                    Pull requests are fetched based on the most recent review
+                    activity by any contributor, not just your own. Please
+                    review and adjust the generated SCRUM report to ensure it
+                    accurately reflects your work before sharing.
+                  </p>
+                </ul>
+              </div>
+            </div>
+          </div>
 
-									<input type="checkbox" id="useRepoFilter" class="mr-2" style="margin-right: 4px;">
-									<label for="useRepoFilter" class="text-xs text-gray-600"><span
-											data-i18n="enableFilteringLabel">Enable
-											filtering</span></label>
-								</div>
-							</div>
-							<div id="tokenWarningForFilter"
-								class="hidden text-xs text-red-600 p-2 bg-red-50 border border-red-200 rounded-xl mt-2">
-								<span data-i18n="tokenRequiredWarning">A GitHub token is required for repository
-									filtering. Please add one in the settings.</span>
-							</div>
+          <div id="settingsSection" class="tab-content hidden">
+            <div class="orgSection">
+              <div>
+                <div class="flex items-center justify-between">
+                  <div class="flex">
+                    <p class="text-sm font-medium" data-i18n="githubTokenLabel">
+                      Your GitHub Token
+                    </p>
+                    <span class="tooltip-container">
+                      <i class="fa fa-question-circle question-icon"></i>
+                      <span
+                        class="tooltip-bubble"
+                        data-i18n="githubTokenTooltip"
+                      >
+                        <b>Why is it recommended to add a GitHub token?</b
+                        ><br />
+                        Scrum Helper works without a GitHub token, but adding a
+                        personal access token is recommended for a better
+                        experience. It raises your API limits, allows access to
+                        private repos (if permitted), and improves accuracy and
+                        speed. Tokens are stored locally and never sent to us
+                        and used only to fetch your git data. You can add one
+                        anytime in the extension settings.<br /><br />
+                        <b>How to obtain:</b><br />
+                        1. Go to
+                        <a
+                          href="https://github.com/settings/tokens"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          style="color: #2563eb; text-decoration: underline"
+                          >GitHub Developer Settings</a
+                        >.<br />
+                        3. Click "Generate new token", select classic token<br />
+                        4. Paste it here.<br />
+                        <i>Keep your token secret!</i>
+                      </span>
+                    </span>
+                  </div>
+                  <button
+                    id="toggleTokenVisibility"
+                    type="button"
+                    class="focus:outline-none"
+                  >
+                    <i id="tokenEyeIcon" class="fa fa-eye text-gray-600"></i>
+                  </button>
+                </div>
+                <input
+                  id="githubToken"
+                  type="password"
+                  class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2 pr-10"
+                  data-i18n-placeholder="githubTokenPlaceholder"
+                />
+              </div>
+              <div class="githubOnlySection">
+                <div class="flex items-center mt-4">
+                  <p
+                    class="text-sm font-semibold"
+                    data-i18n="settingsOrgNameLabel"
+                  >
+                    Your Organization Name
+                  </p>
+                  <span class="tooltip-container ml-2">
+                    <i class="fa fa-question-circle question-icon"></i>
+                    <span class="tooltip-bubble" data-i18n="orgNameTooltip">
+                      <b>Which organization's GitHub activity?</b><br />
+                      Enter the GitHub organization name to fetch activities
+                      for. Leave empty to fetch all your GitHub activities
+                      across all organizations. Organization name is not
+                      case-sensitive.
+                    </span>
+                  </span>
+                </div>
+                <input
+                  id="orgInput"
+                  type="text"
+                  class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2"
+                  data-i18n-placeholder="settingsOrgNamePlaceholder"
+                  style="margin-top: 0.3rem; margin-bottom: 0.8rem"
+                />
 
-							<div id="repoFilterContainer" class="hidden">
-								<input id="repoSearch" type="text" data-i18n-placeholder="repoSearchPlaceholder"
-									class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 pr-10"
-									autocomplete="off">
-								<!-- Typeahead Input -->
-								<div class="relative">
+                <!-- Organization validation feedback -->
+                <div
+                  id="orgValidationMessage"
+                  class="hidden text-xs mt-1 mb-2 px-3 py-2 rounded-lg"
+                >
+                  <span id="orgValidationText"></span>
+                </div>
+              </div>
 
-									<!-- Dropdown -->
-									<div id="repoDropdown"
-										class="absolute w-full bg-white border border-gray-300 rounded-xl shadow-lg hidden max-h-48 overflow-y-auto"
-										style="z-index: 1000; margin-top: -10px;">
-									</div>
-								</div>
+              <div class="mb-4">
+                <div class="flex items-center justify-between mb-2">
+                  <p class="text-sm font-medium">
+                    <span data-i18n="repoFilterLabel"
+                      >Filter by repositories</span
+                    ><span class="tooltip-container">
+                      <i class="fa fa-question-circle question-icon"></i>
+                      <span
+                        class="tooltip-bubble"
+                        data-i18n="repoFilterTooltip"
+                      >
+                        Github Token required.<br />
+                        To force a repo list update, <br />
+                        click the Refresh Data button.
+                      </span>
+                    </span>
+                  </p>
+                  <div class="flex items-center">
+                    <input
+                      type="checkbox"
+                      id="useRepoFilter"
+                      class="mr-2"
+                      style="margin-right: 4px"
+                    />
+                    <label for="useRepoFilter" class="text-xs text-gray-600"
+                      ><span data-i18n="enableFilteringLabel"
+                        >Enable filtering</span
+                      ></label
+                    >
+                  </div>
+                </div>
+                <div
+                  id="tokenWarningForFilter"
+                  class="hidden text-xs text-red-600 p-2 bg-red-50 border border-red-200 rounded-xl mt-2"
+                >
+                  <span data-i18n="tokenRequiredWarning"
+                    >A GitHub token is required for repository filtering. Please
+                    add one in the settings.</span
+                  >
+                </div>
 
-								<!-- Selected Tags Container -->
-								<div id="selectedRepos"
-									class="mt-3 min-h-[32px] p-2 border-2 border-gray-200 bg-gray-50 rounded-xl">
-									<div class="flex flex-wrap gap-1" id="repoTags">
-										<span class="text-xs text-gray-500 select-none" id="repoPlaceholder"
-											data-i18n="repoPlaceholder">No
-											repositories selected (all will be included)</span>
-									</div>
-								</div>
+                <div id="repoFilterContainer" class="hidden">
+                  <input
+                    id="repoSearch"
+                    type="text"
+                    data-i18n-placeholder="repoSearchPlaceholder"
+                    class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 pr-10"
+                    autocomplete="off"
+                  />
+                  <!-- Typeahead Input -->
+                  <div class="relative">
+                    <!-- Dropdown -->
+                    <div
+                      id="repoDropdown"
+                      class="absolute w-full bg-white border border-gray-300 rounded-xl shadow-lg hidden max-h-48 overflow-y-auto"
+                      style="z-index: 1000; margin-top: -10px"
+                    ></div>
+                  </div>
 
-								<!-- Status/Info -->
-								<div class="mt-2 text-xs text-gray-600 flex justify-between">
-									<span id="repoCount" data-i18n="repoCountNone">0 repositories selected</span>
-									<span id="repoStatus" class="text-blue-600"></span>
-								</div>
-							</div>
-						</div>
-					</div>
+                  <!-- Selected Tags Container -->
+                  <div
+                    id="selectedRepos"
+                    class="mt-3 min-h-[32px] p-2 border-2 border-gray-200 bg-gray-50 rounded-xl"
+                  >
+                    <div class="flex flex-wrap gap-1" id="repoTags">
+                      <span
+                        class="text-xs text-gray-500 select-none"
+                        id="repoPlaceholder"
+                        data-i18n="repoPlaceholder"
+                        >No repositories selected (all will be included)</span
+                      >
+                    </div>
+                  </div>
 
-					<div class="gitlabOnlySection hidden mt-3">
-						<div class="flex items-center justify-between">
-							<div class="flex">
-								<p class="text-sm font-medium" data-i18n="gitlabTokenLabel">Your GitLab Token</p>
-								<span class="tooltip-container">
-									<i class="fa fa-question-circle question-icon"></i>
-									<span class="tooltip-bubble" data-i18n="gitlabTokenTooltip">
-										<b>Why add a GitLab token?</b><br>
-										Scrum Helper works without a token for public projects, but a personal access token enables
-										private repos and better rate limits. Your token stays local and is only used to
-										fetch your GitLab data.<br><br>
-										<b>How to get one:</b><br>
-										1. Go to <a href="https://gitlab.com/-/profile/personal_access_tokens"
-											target="_blank" rel="noopener noreferrer"
-											style="color:#2563eb;text-decoration:underline;">GitLab Access
-											Tokens</a><br>
-										2. Click "Add new token"<br>
-										3. Select "read_api" scope<br>
-										4. Paste it here<br>
-										<i>Keep it secret!</i>
-									</span>
-								</span>
-							</div>
-							<button id="toggleGitlabTokenVisibility" type="button" class="focus:outline-none">
-								<i id="gitlabTokenEyeIcon" class="fa fa-eye text-gray-600"></i>
-							</button>
-						</div>
-						<input id="gitlabToken" type="password"
-							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2 pr-10"
-							data-i18n-placeholder="gitlabTokenPlaceholder">
-					</div>
+                  <!-- Status/Info -->
+                  <div class="mt-2 text-xs text-gray-600 flex justify-between">
+                    <span id="repoCount" data-i18n="repoCountNone"
+                      >0 repositories selected</span
+                    >
+                    <span id="repoStatus" class="text-blue-600"></span>
+                  </div>
+                </div>
+              </div>
+            </div>
 
-					<div class="cacheSection mt-3">
-						<div class="flex items-center justify-between mb-2">
-							<div class="flex items-center">
-								<p class="text-sm font-medium" data-i18n="displayModeLabel">Display Mode</p>
-								<span class="tooltip-container ml-2">
-									<i class="fa fa-question-circle question-icon"></i>
-									<span class="tooltip-bubble" data-i18n="displayModeTooltip">
-										Choose how Scrum Helper opens when you click its icon.
-										<b>Side Panel</b> keeps it docked alongside your page.
-										<b>Popup</b> opens a floating window.
-									</span>
-								</span>
-							</div>
-						</div>
-						<select id="displayModeSelect"
-							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 mb-2">
-							<option value="sidePanel">Side Panel</option>
-							<option value="popup">Popup</option>
-						</select>
-						<div id="displayModeNotice"
-							class="hidden text-xs text-blue-700 bg-blue-50 border border-blue-200 rounded-xl p-2 mt-1 mb-2 flex items-center gap-2">
-							<i class="fa fa-info-circle"></i>
-							<span id="displayModeNoticeText"></span>
-						</div>
-					</div>
+            <div class="gitlabOnlySection hidden mt-3">
+              <div class="flex items-center justify-between">
+                <div class="flex">
+                  <p class="text-sm font-medium" data-i18n="gitlabTokenLabel">
+                    Your GitLab Token
+                  </p>
+                  <span class="tooltip-container">
+                    <i class="fa fa-question-circle question-icon"></i>
+                    <span class="tooltip-bubble" data-i18n="gitlabTokenTooltip">
+                      <b>Why add a GitLab token?</b><br />
+                      Scrum Helper works without a token for public projects,
+                      but a personal access token enables private repos and
+                      better rate limits. Your token stays local and is only
+                      used to fetch your GitLab data.<br /><br />
+                      <b>How to get one:</b><br />
+                      1. Go to
+                      <a
+                        href="https://gitlab.com/-/profile/personal_access_tokens"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style="color: #2563eb; text-decoration: underline"
+                        >GitLab Access Tokens</a
+                      ><br />
+                      2. Click "Add new token"<br />
+                      3. Select "read_api" scope<br />
+                      4. Paste it here<br />
+                      <i>Keep it secret!</i>
+                    </span>
+                  </span>
+                </div>
+                <button
+                  id="toggleGitlabTokenVisibility"
+                  type="button"
+                  class="focus:outline-none"
+                >
+                  <i
+                    id="gitlabTokenEyeIcon"
+                    class="fa fa-eye text-gray-600"
+                  ></i>
+                </button>
+              </div>
+              <input
+                id="gitlabToken"
+                type="password"
+                class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2 pr-10"
+                data-i18n-placeholder="gitlabTokenPlaceholder"
+              />
+            </div>
 
-					<div class="cacheSection mt-3">
-						<p class="text-sm font-medium"><span data-i18n="cacheTTLLabel">Enter cache TTL</span> <span
-								class="text-sm font-normal" data-i18n="cacheTTLUnit">(in
-								minutes)</span>
-							<span class="tooltip-container">
-								<i class="fa fa-question-circle question-icon"></i>
-								<span class="tooltip-bubble" data-i18n="cacheTTLTooltip">
-									We are caching the data to avoid redundant calls. By default the cache expires after
-									10 minutes, you
-									can change it here to your desired time. We have given a refresh cache button in
-									case you want to
-									fetch fresh data right now.
-								</span>
-							</span>
-						</p>
-						<input type="text" id="cacheInput"
-							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800  p-2 my-2"
-							data-i18n-placeholder="cacheTTLPlaceholder">
-					</div>
+            <div class="cacheSection mt-3">
+              <div class="flex items-center justify-between mb-2">
+                <div class="flex items-center">
+                  <p class="text-sm font-medium" data-i18n="displayModeLabel">
+                    Display Mode
+                  </p>
+                  <span class="tooltip-container ml-2">
+                    <i class="fa fa-question-circle question-icon"></i>
+                    <span class="tooltip-bubble" data-i18n="displayModeTooltip">
+                      Choose how Scrum Helper opens when you click its icon.
+                      <b>Side Panel</b> keeps it docked alongside your page.
+                      <b>Popup</b> opens a floating window.
+                    </span>
+                  </span>
+                </div>
+              </div>
+              <select
+                id="displayModeSelect"
+                class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 mb-2"
+              >
+                <option value="sidePanel">Side Panel</option>
+                <option value="popup">Popup</option>
+              </select>
+              <div
+                id="displayModeNotice"
+                class="hidden text-xs text-blue-700 bg-blue-50 border border-blue-200 rounded-xl p-2 mt-1 mb-2 flex items-center gap-2"
+              >
+                <i class="fa fa-info-circle"></i>
+                <span id="displayModeNoticeText"></span>
+              </div>
+            </div>
 
-					<div class="">
-						<button id="refreshCache"
-							class="w-full mt-3 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded flex items-center justify-center gap-2 transition-colors duration-200">
-							<i class="fa fa-refresh"></i>
-							<span data-i18n="refreshDataButton">Refresh Data (bypass cache)</span>
-						</button>
-						<p class="cache-info">
-							<i class="fa fa-info-circle"></i>
-							<span data-i18n="refreshDataInfo">Use this button to fetch fresh data immediately.</span>
-						</p>
-					</div>
+            <div class="cacheSection mt-3">
+              <p class="text-sm font-medium">
+                <span data-i18n="cacheTTLLabel">Enter cache TTL</span>
+                <span class="text-sm font-normal" data-i18n="cacheTTLUnit"
+                  >(in minutes)</span
+                >
+                <span class="tooltip-container">
+                  <i class="fa fa-question-circle question-icon"></i>
+                  <span class="tooltip-bubble" data-i18n="cacheTTLTooltip">
+                    We are caching the data to avoid redundant calls. By default
+                    the cache expires after 10 minutes, you can change it here
+                    to your desired time. We have given a refresh cache button
+                    in case you want to fetch fresh data right now.
+                  </span>
+                </span>
+              </p>
+              <input
+                type="text"
+                id="cacheInput"
+                class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2"
+                data-i18n-placeholder="cacheTTLPlaceholder"
+              />
+            </div>
 
-				</div>
-			</div>
+            <div class="">
+              <button
+                id="refreshCache"
+                class="w-full mt-3 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded flex items-center justify-center gap-2 transition-colors duration-200"
+              >
+                <i class="fa fa-refresh"></i>
+                <span data-i18n="refreshDataButton"
+                  >Refresh Data (bypass cache)</span
+                >
+              </button>
+              <p class="cache-info">
+                <i class="fa fa-info-circle"></i>
+                <span data-i18n="refreshDataInfo"
+                  >Use this button to fetch fresh data immediately.</span
+                >
+              </p>
+            </div>
+          </div>
+        </div>
 
-			<div class="mt-6 border-t border-gray-300">
-				<div class="bg-white rounded-3xl mx-2 mt-4 mb-2 p-4 border border-gray-100 shadow-sm">
-					<div class="flex items-center justify-center space-x-3">
-						<a target="_blank" rel="noopener noreferrer" href="https://github.com/fossasia/scrum_helper"
-							class="bg-blue-50 hover:bg-blue-100 text-blue-600 transition-all duration-200 rounded-lg px-4 py-2 flex items-center space-x-2 gap-2">
-							<i class="fa fa-code text-sm pl-1"></i>
-							<span class="text-sm font-medium" data-i18n="viewCodeButton">View Code</span>
-						</a>
-						<a target="_blank" rel="noopener noreferrer"
-							href="https://github.com/fossasia/scrum_helper/issues"
-							class="bg-blue-50 hover:bg-blue-100 text-blue-600 transition-all duration-200 rounded-lg px-4 py-2 flex items-center space-x-2 gap-2">
-							<i class="fa fa-bug text-sm"></i>
-							<span class="text-sm font-medium" data-i18n="reportIssueButton">Report Issue</span>
-						</a>
-					</div>
-				</div>
-				<div class="mt-3 pt-3 border-t border-gray-200 flex justify-center items-center py-">
-					<p class="text-xs text-gray-600 text-center">
-						Made with ❤️ by <strong>FOSSASIA</strong> •
-						<span class="text-gray-500 dark:text-gray-300">v2.1.4</span>
-					</p>
-				</div>
-			</div>
-		</div>
-	</div>
-	<!-- WebExtensions Polyfill for Cross-Browser compatibility (Chrome, Firefox, Edge, etc.) -->
-	<script src="scripts/browser-polyfill.min.js"></script>
-	<script src="scripts/jquery-3.2.1.min.js"></script>
-	<script type="text/javascript" type="text/javascript" src="materialize/js/materialize.min.js"></script>
-	<script src="scripts/emailClientAdapter.js"></script>
-	<script src="scripts/utils/githubRequest.js"></script>
-	<script src="scripts/utils/gitlabRequest.js"></script>
-	<script src="scripts/main.js"></script>
-	<script src="scripts/gitlabHelper.js"></script>
-	<script src="scripts/scrumHelper.js"></script>
-	<script src="scripts/popup.js"></script>
-</body>
-
+        <div class="mt-6 border-t border-gray-300">
+          <div
+            class="bg-white rounded-3xl mx-2 mt-4 mb-2 p-4 border border-gray-100 shadow-sm"
+          >
+            <div class="flex items-center justify-center space-x-3">
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://github.com/fossasia/scrum_helper"
+                class="bg-blue-50 hover:bg-blue-100 text-blue-600 transition-all duration-200 rounded-lg px-4 py-2 flex items-center space-x-2 gap-2"
+              >
+                <i class="fa fa-code text-sm pl-1"></i>
+                <span class="text-sm font-medium" data-i18n="viewCodeButton"
+                  >View Code</span
+                >
+              </a>
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://github.com/fossasia/scrum_helper/issues"
+                class="bg-blue-50 hover:bg-blue-100 text-blue-600 transition-all duration-200 rounded-lg px-4 py-2 flex items-center space-x-2 gap-2"
+              >
+                <i class="fa fa-bug text-sm"></i>
+                <span class="text-sm font-medium" data-i18n="reportIssueButton"
+                  >Report Issue</span
+                >
+              </a>
+            </div>
+          </div>
+          <div
+            class="mt-3 pt-3 border-t border-gray-200 flex justify-center items-center py-"
+          >
+            <p class="text-xs text-gray-600 text-center">
+              Made with ❤️ by <strong>FOSSASIA</strong> •
+              <span class="text-gray-500 dark:text-gray-300">v2.1.4</span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- WebExtensions Polyfill for Cross-Browser compatibility (Chrome, Firefox, Edge, etc.) -->
+    <script src="scripts/browser-polyfill.min.js"></script>
+    <script src="scripts/jquery-3.2.1.min.js"></script>
+    <!-- Materialize removed - not used in popup, uses Tailwind CSS instead -->
+    <script src="scripts/emailClientAdapter.js"></script>
+    <script src="scripts/utils/githubRequest.js"></script>
+    <script src="scripts/utils/gitlabRequest.js"></script>
+    <script src="scripts/main.js"></script>
+    <script src="scripts/gitlabHelper.js"></script>
+    <script src="scripts/scrumHelper.js"></script>
+    <script src="scripts/popup.js"></script>
+  </body>
 </html>

--- a/src/scripts/gitlabHelper.js
+++ b/src/scripts/gitlabHelper.js
@@ -1,16 +1,16 @@
 // GitLab API Helper for Scrum Helper Extension
 class GitLabHelper {
-  constructor() {
-    this.baseUrl = "https://gitlab.com/api/v4";
-    this.cache = {
-      data: null,
-      cacheKey: null,
-      timestamp: 0,
-      ttl: 10 * 60 * 1000, // 10 minutes
-      fetching: false,
-      queue: [],
-    };
-  }
+	constructor() {
+		this.baseUrl = 'https://gitlab.com/api/v4';
+		this.cache = {
+			data: null,
+			cacheKey: null,
+			timestamp: 0,
+			ttl: 10 * 60 * 1000, // 10 minutes
+			fetching: false,
+			queue: [],
+		};
+	}
 
 	async getCacheTTL() {
 		try {
@@ -50,276 +50,258 @@ class GitLabHelper {
 		}
 	}
 
-  async fetchGitLabData(username, startDate, endDate, token = null) {
-    // Include token state in cache key to invalidate when auth changes
-    const tokenMarker = token ? "auth" : "noauth";
-    const cacheKey = `${username}-${startDate}-${endDate}-${tokenMarker}`;
+	async fetchGitLabData(username, startDate, endDate, token = null) {
+		// Include token state in cache key to invalidate when auth changes
+		const tokenMarker = token ? 'auth' : 'noauth';
+		const cacheKey = `${username}-${startDate}-${endDate}-${tokenMarker}`;
 
-    if (
-      this.cache.fetching ||
-      (this.cache.cacheKey === cacheKey && this.cache.data)
-    ) {
-      return this.cache.data;
-    }
+		if (this.cache.fetching || (this.cache.cacheKey === cacheKey && this.cache.data)) {
+			return this.cache.data;
+		}
 
-    // Check if we need to load from storage
-    if (!this.cache.data && !this.cache.fetching) {
-      await this.loadFromStorage();
-    }
+		// Check if we need to load from storage
+		if (!this.cache.data && !this.cache.fetching) {
+			await this.loadFromStorage();
+		}
 
-    const currentTTL = await this.getCacheTTL();
-    this.cache.ttl = currentTTL;
+		const currentTTL = await this.getCacheTTL();
+		this.cache.ttl = currentTTL;
 
-    const now = Date.now();
-    const isCacheFresh = now - this.cache.timestamp < this.cache.ttl;
-    const isCacheKeyMatch = this.cache.cacheKey === cacheKey;
+		const now = Date.now();
+		const isCacheFresh = now - this.cache.timestamp < this.cache.ttl;
+		const isCacheKeyMatch = this.cache.cacheKey === cacheKey;
 
-    if (this.cache.data && isCacheFresh && isCacheKeyMatch) {
-      return this.cache.data;
-    }
+		if (this.cache.data && isCacheFresh && isCacheKeyMatch) {
+			return this.cache.data;
+		}
 
-    if (!isCacheKeyMatch) {
-      this.cache.data = null;
-    }
+		if (!isCacheKeyMatch) {
+			this.cache.data = null;
+		}
 
-    if (this.cache.fetching) {
-      return new Promise((resolve, reject) => {
-        this.cache.queue.push({ resolve, reject });
-      });
-    }
+		if (this.cache.fetching) {
+			return new Promise((resolve, reject) => {
+				this.cache.queue.push({ resolve, reject });
+			});
+		}
 
-    this.cache.fetching = true;
-    this.cache.cacheKey = cacheKey;
+		this.cache.fetching = true;
+		this.cache.cacheKey = cacheKey;
 
-    // Build headers with optional token
-    const headers = {};
-    if (token) {
-      headers["PRIVATE-TOKEN"] = token;
-    }
+		// Build headers with optional token
+		const headers = {};
+		if (token) {
+			headers['PRIVATE-TOKEN'] = token;
+		}
 
-    try {
-      // Throttling 500ms to avoid burst
-      await new Promise((res) => setTimeout(res, 500));
+		try {
+			// Throttling 500ms to avoid burst
+			await new Promise((res) => setTimeout(res, 500));
 
-      // Get user info first
-      const userUrl = `${this.baseUrl}/users?username=${username}`;
-      const userRes = await gitlabApiRequest(userUrl, headers);
-      if (!userRes.ok) {
-        throw new Error(
-         chrome?.i18n.getMessage('gitlabUserFetchError', [userRes.status, userRes.statusText]) || `Error fetching GitLab user: ${userRes.status} ${userRes.statusText}`,
-        );
-      }
-      const users = await userRes.json();
-      if (users.length === 0) {
-        throw new Error(`GitLab user '${username}' not found`);
-      }
-      const userId = users[0].id;
+			// Get user info first
+			const userUrl = `${this.baseUrl}/users?username=${username}`;
+			const userRes = await gitlabApiRequest(userUrl, headers);
+			if (!userRes.ok) {
+				throw new Error(
+					chrome?.i18n.getMessage('gitlabUserFetchError', [userRes.status, userRes.statusText]) ||
+						`Error fetching GitLab user: ${userRes.status} ${userRes.statusText}`,
+				);
+			}
+			const users = await userRes.json();
+			if (users.length === 0) {
+				throw new Error(`GitLab user '${username}' not found`);
+			}
+			const userId = users[0].id;
 
-      // Fetch all projects the user is a member of (including group projects)
-      const membershipProjectsUrl = `${this.baseUrl}/users/${userId}/projects?membership=true&per_page=100&order_by=updated_at&sort=desc`;
-      const membershipProjectsRes = await gitlabApiRequest(
-        membershipProjectsUrl,
-        headers,
-      );
-      if (!membershipProjectsRes.ok) {
-        throw new Error(
-         rome?.i18n.getMessage('gitlabMembershipError', [membershipProjectsRes.status, membershipProjectsRes.statusText]) || `Error fetching GitLab membership projects: ${membershipProjectsRes.status} ${membershipProjectsRes.statusText}`,
-        );
-      }
-      const membershipProjects = await membershipProjectsRes.json();
+			// Fetch all projects the user is a member of (including group projects)
+			const membershipProjectsUrl = `${this.baseUrl}/users/${userId}/projects?membership=true&per_page=100&order_by=updated_at&sort=desc`;
+			const membershipProjectsRes = await gitlabApiRequest(membershipProjectsUrl, headers);
+			if (!membershipProjectsRes.ok) {
+				throw new Error(
+					rome?.i18n.getMessage('gitlabMembershipError', [
+						membershipProjectsRes.status,
+						membershipProjectsRes.statusText,
+					]) ||
+						`Error fetching GitLab membership projects: ${membershipProjectsRes.status} ${membershipProjectsRes.statusText}`,
+				);
+			}
+			const membershipProjects = await membershipProjectsRes.json();
 
-      // Fetch all projects the user has contributed to (public, group, etc.)
-      const contributedProjectsUrl = `${this.baseUrl}/users/${userId}/contributed_projects?per_page=100&order_by=updated_at&sort=desc`;
-      const contributedProjectsRes = await gitlabApiRequest(
-        contributedProjectsUrl,
-        headers,
-      );
-      if (!contributedProjectsRes.ok) {
-        throw new Error(
-         chrome?.i18n.getMessage('gitlabContributedError', [contributedProjectsRes.status, contributedProjectsRes.statusText]) || `Error fetching GitLab contributed projects: ${contributedProjectsRes.status} ${contributedProjectsRes.statusText}`,
-        );
-      }
-      const contributedProjects = await contributedProjectsRes.json();
+			// Fetch all projects the user has contributed to (public, group, etc.)
+			const contributedProjectsUrl = `${this.baseUrl}/users/${userId}/contributed_projects?per_page=100&order_by=updated_at&sort=desc`;
+			const contributedProjectsRes = await gitlabApiRequest(contributedProjectsUrl, headers);
+			if (!contributedProjectsRes.ok) {
+				throw new Error(
+					chrome?.i18n.getMessage('gitlabContributedError', [
+						contributedProjectsRes.status,
+						contributedProjectsRes.statusText,
+					]) ||
+						`Error fetching GitLab contributed projects: ${contributedProjectsRes.status} ${contributedProjectsRes.statusText}`,
+				);
+			}
+			const contributedProjects = await contributedProjectsRes.json();
 
-      // Merge and deduplicate projects by project id
-      const allProjectsMap = new Map();
-      for (const p of [...membershipProjects, ...contributedProjects]) {
-        allProjectsMap.set(p.id, p);
-      }
-      const allProjects = Array.from(allProjectsMap.values());
+			// Merge and deduplicate projects by project id
+			const allProjectsMap = new Map();
+			for (const p of [...membershipProjects, ...contributedProjects]) {
+				allProjectsMap.set(p.id, p);
+			}
+			const allProjects = Array.from(allProjectsMap.values());
 
-      // Fetch merge requests from each project (works without auth for public projects)
-      let allMergeRequests = [];
-      for (const project of allProjects) {
-        try {
-          const projectMRsUrl = `${this.baseUrl}/projects/${project.id}/merge_requests?author_id=${userId}&created_after=${startDate}T00:00:00Z&created_before=${endDate}T23:59:59Z&per_page=100&order_by=updated_at&sort=desc`;
-          const projectMRsRes = await gitlabApiRequest(projectMRsUrl, headers);
-          if (projectMRsRes.ok) {
-            const projectMRs = await projectMRsRes.json();
-            allMergeRequests = allMergeRequests.concat(projectMRs);
-          }
-          // Add small delay to avoid rate limiting
-          await new Promise((resolve) => setTimeout(resolve, 100));
-        } catch (error) {
-          if (error.name === "RateLimitError") throw error; // Surface rate limit to caller
-          console.error(
-            `Error fetching MRs for project ${project.name}:`,
-            error,
-          );
-          // Continue with other projects
-        }
-      }
+			// Fetch merge requests from each project (works without auth for public projects)
+			let allMergeRequests = [];
+			for (const project of allProjects) {
+				try {
+					const projectMRsUrl = `${this.baseUrl}/projects/${project.id}/merge_requests?author_id=${userId}&created_after=${startDate}T00:00:00Z&created_before=${endDate}T23:59:59Z&per_page=100&order_by=updated_at&sort=desc`;
+					const projectMRsRes = await gitlabApiRequest(projectMRsUrl, headers);
+					if (projectMRsRes.ok) {
+						const projectMRs = await projectMRsRes.json();
+						allMergeRequests = allMergeRequests.concat(projectMRs);
+					}
+					// Add small delay to avoid rate limiting
+					await new Promise((resolve) => setTimeout(resolve, 100));
+				} catch (error) {
+					if (error.name === 'RateLimitError') throw error; // Surface rate limit to caller
+					console.error(`Error fetching MRs for project ${project.name}:`, error);
+					// Continue with other projects
+				}
+			}
 
-      // Fetch issues from each project (works without auth for public projects)
-      let allIssues = [];
-      for (const project of allProjects) {
-        try {
-          const projectIssuesUrl = `${this.baseUrl}/projects/${project.id}/issues?author_id=${userId}&created_after=${startDate}T00:00:00Z&created_before=${endDate}T23:59:59Z&per_page=100&order_by=updated_at&sort=desc`;
-          const projectIssuesRes = await gitlabApiRequest(
-            projectIssuesUrl,
-            headers,
-          );
-          if (projectIssuesRes.ok) {
-            const projectIssues = await projectIssuesRes.json();
-            allIssues = allIssues.concat(projectIssues);
-          }
-          // Add small delay to avoid rate limiting
-          await new Promise((resolve) => setTimeout(resolve, 100));
-        } catch (error) {
-          if (error.name === "RateLimitError") throw error; // Surface rate limit to caller
-          console.error(
-            `Error fetching issues for project ${project.name}:`,
-            error,
-          );
-          // Continue with other projects
-        }
-      }
+			// Fetch issues from each project (works without auth for public projects)
+			let allIssues = [];
+			for (const project of allProjects) {
+				try {
+					const projectIssuesUrl = `${this.baseUrl}/projects/${project.id}/issues?author_id=${userId}&created_after=${startDate}T00:00:00Z&created_before=${endDate}T23:59:59Z&per_page=100&order_by=updated_at&sort=desc`;
+					const projectIssuesRes = await gitlabApiRequest(projectIssuesUrl, headers);
+					if (projectIssuesRes.ok) {
+						const projectIssues = await projectIssuesRes.json();
+						allIssues = allIssues.concat(projectIssues);
+					}
+					// Add small delay to avoid rate limiting
+					await new Promise((resolve) => setTimeout(resolve, 100));
+				} catch (error) {
+					if (error.name === 'RateLimitError') throw error; // Surface rate limit to caller
+					console.error(`Error fetching issues for project ${project.name}:`, error);
+					// Continue with other projects
+				}
+			}
 
-      const gitlabData = {
-        user: users[0],
-        projects: allProjects,
-        mergeRequests: allMergeRequests, // use project-by-project response
-        issues: allIssues, // use project-by-project response
-        comments: [], // Empty array since we're not fetching comments
-      };
-      // Cache the data
-      this.cache.data = gitlabData;
-      this.cache.timestamp = Date.now();
+			const gitlabData = {
+				user: users[0],
+				projects: allProjects,
+				mergeRequests: allMergeRequests, // use project-by-project response
+				issues: allIssues, // use project-by-project response
+				comments: [], // Empty array since we're not fetching comments
+			};
+			// Cache the data
+			this.cache.data = gitlabData;
+			this.cache.timestamp = Date.now();
 
-      await this.saveToStorage(gitlabData);
+			await this.saveToStorage(gitlabData);
 
-      // Resolve queued calls
-      this.cache.queue.forEach(({ resolve }) => {
-        resolve(gitlabData);
-      });
-      this.cache.queue = [];
+			// Resolve queued calls
+			this.cache.queue.forEach(({ resolve }) => {
+				resolve(gitlabData);
+			});
+			this.cache.queue = [];
 
-      return gitlabData;
-    } catch (err) {
-      console.error("GitLab Fetch Failed:", err);
+			return gitlabData;
+		} catch (err) {
+			console.error('GitLab Fetch Failed:', err);
 
-      // Handle rate limit errors by showing the banner
-      if (err.name === "RateLimitError") {
-        if (typeof showRateLimitWarning === "function")
-          showRateLimitWarning(err);
-      }
+			// Handle rate limit errors by showing the banner
+			if (err.name === 'RateLimitError') {
+				if (typeof showRateLimitWarning === 'function') showRateLimitWarning(err);
+			}
 
-      // Reject queued calls on error
-      this.cache.queue.forEach(({ reject }) => {
-        reject(err);
-      });
-      this.cache.queue = [];
-      throw err;
-    } finally {
-      this.cache.fetching = false;
-    }
-  }
+			// Reject queued calls on error
+			this.cache.queue.forEach(({ reject }) => {
+				reject(err);
+			});
+			this.cache.queue = [];
+			throw err;
+		} finally {
+			this.cache.fetching = false;
+		}
+	}
 
-  async getDetailedMergeRequests(mergeRequests, token = null) {
-    const headers = {};
-    if (token) {
-      headers["PRIVATE-TOKEN"] = token;
-    }
-    const detailed = [];
-    for (const mr of mergeRequests) {
-      try {
-        const url = `${this.baseUrl}/projects/${mr.project_id}/merge_requests/${mr.iid}`;
-        const res = await gitlabApiRequest(url, headers);
-        if (res.ok) {
-          const detailedMr = await res.json();
-          detailed.push(detailedMr);
-        }
-        // Add small delay to avoid rate limiting
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      } catch (error) {
-        if (error.name === "RateLimitError") {
-          if (typeof showRateLimitWarning === "function")
-            showRateLimitWarning(error);
-          break; // Stop fetching more details
-        }
-        console.error(
-          `[GITLAB-DEBUG] Error fetching detailed MR ${mr.iid}:`,
-          error,
-        );
-        detailed.push(mr); // Use basic data if detailed fetch fails
-      }
-    }
-    return detailed;
-  }
+	async getDetailedMergeRequests(mergeRequests, token = null) {
+		const headers = {};
+		if (token) {
+			headers['PRIVATE-TOKEN'] = token;
+		}
+		const detailed = [];
+		for (const mr of mergeRequests) {
+			try {
+				const url = `${this.baseUrl}/projects/${mr.project_id}/merge_requests/${mr.iid}`;
+				const res = await gitlabApiRequest(url, headers);
+				if (res.ok) {
+					const detailedMr = await res.json();
+					detailed.push(detailedMr);
+				}
+				// Add small delay to avoid rate limiting
+				await new Promise((resolve) => setTimeout(resolve, 100));
+			} catch (error) {
+				if (error.name === 'RateLimitError') {
+					if (typeof showRateLimitWarning === 'function') showRateLimitWarning(error);
+					break; // Stop fetching more details
+				}
+				console.error(`[GITLAB-DEBUG] Error fetching detailed MR ${mr.iid}:`, error);
+				detailed.push(mr); // Use basic data if detailed fetch fails
+			}
+		}
+		return detailed;
+	}
 
-  async getDetailedIssues(issues, token = null) {
-    const headers = {};
-    if (token) {
-      headers["PRIVATE-TOKEN"] = token;
-    }
-    const detailed = [];
-    for (const issue of issues) {
-      try {
-        const url = `${this.baseUrl}/projects/${issue.project_id}/issues/${issue.iid}`;
-        const res = await gitlabApiRequest(url, headers);
-        if (res.ok) {
-          const detailedIssue = await res.json();
-          detailed.push(detailedIssue);
-        }
-        // Add small delay to avoid rate limiting
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      } catch (error) {
-        if (error.name === "RateLimitError") {
-          if (typeof showRateLimitWarning === "function")
-            showRateLimitWarning(error);
-          break; // Stop fetching more details
-        }
-        console.error(
-          `[GITLAB-DEBUG] Error fetching detailed issue ${issue.iid}:`,
-          error,
-        );
-        detailed.push(issue); // Use basic data if detailed fetch fails
-      }
-    }
-    return detailed;
-  }
+	async getDetailedIssues(issues, token = null) {
+		const headers = {};
+		if (token) {
+			headers['PRIVATE-TOKEN'] = token;
+		}
+		const detailed = [];
+		for (const issue of issues) {
+			try {
+				const url = `${this.baseUrl}/projects/${issue.project_id}/issues/${issue.iid}`;
+				const res = await gitlabApiRequest(url, headers);
+				if (res.ok) {
+					const detailedIssue = await res.json();
+					detailed.push(detailedIssue);
+				}
+				// Add small delay to avoid rate limiting
+				await new Promise((resolve) => setTimeout(resolve, 100));
+			} catch (error) {
+				if (error.name === 'RateLimitError') {
+					if (typeof showRateLimitWarning === 'function') showRateLimitWarning(error);
+					break; // Stop fetching more details
+				}
+				console.error(`[GITLAB-DEBUG] Error fetching detailed issue ${issue.iid}:`, error);
+				detailed.push(issue); // Use basic data if detailed fetch fails
+			}
+		}
+		return detailed;
+	}
 
-  formatDate(dateString) {
-    const date = new Date(dateString);
-    const options = { day: "2-digit", month: "short", year: "numeric" };
-    return date.toLocaleDateString("en-US", options);
-  }
+	formatDate(dateString) {
+		const date = new Date(dateString);
+		const options = { day: '2-digit', month: 'short', year: 'numeric' };
+		return date.toLocaleDateString('en-US', options);
+	}
 
-  processGitLabData(data) {
-    const processed = {
-      mergeRequests: data.mergeRequests || [],
-      issues: data.issues || [],
-      comments: data.comments || [],
-      user: data.user,
-    };
+	processGitLabData(data) {
+		const processed = {
+			mergeRequests: data.mergeRequests || [],
+			issues: data.issues || [],
+			comments: data.comments || [],
+			user: data.user,
+		};
 
-    return processed;
-  }
+		return processed;
+	}
 }
 
 // Export for use in other scripts
-if (typeof module !== "undefined" && module.exports) {
-  module.exports = GitLabHelper;
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = GitLabHelper;
 } else {
-  window.GitLabHelper = GitLabHelper;
+	window.GitLabHelper = GitLabHelper;
 }

--- a/src/scripts/gitlabHelper.js
+++ b/src/scripts/gitlabHelper.js
@@ -1,16 +1,16 @@
 // GitLab API Helper for Scrum Helper Extension
 class GitLabHelper {
-	constructor() {
-		this.baseUrl = 'https://gitlab.com/api/v4';
-		this.cache = {
-			data: null,
-			cacheKey: null,
-			timestamp: 0,
-			ttl: 10 * 60 * 1000, // 10 minutes
-			fetching: false,
-			queue: [],
-		};
-	}
+  constructor() {
+    this.baseUrl = "https://gitlab.com/api/v4";
+    this.cache = {
+      data: null,
+      cacheKey: null,
+      timestamp: 0,
+      ttl: 10 * 60 * 1000, // 10 minutes
+      fetching: false,
+      queue: [],
+    };
+  }
 
 	async getCacheTTL() {
 		try {
@@ -50,229 +50,276 @@ class GitLabHelper {
 		}
 	}
 
-	async fetchGitLabData(username, startDate, endDate, token = null) {
-		// Include token state in cache key to invalidate when auth changes
-		const tokenMarker = token ? 'auth' : 'noauth';
-		const cacheKey = `${username}-${startDate}-${endDate}-${tokenMarker}`;
+  async fetchGitLabData(username, startDate, endDate, token = null) {
+    // Include token state in cache key to invalidate when auth changes
+    const tokenMarker = token ? "auth" : "noauth";
+    const cacheKey = `${username}-${startDate}-${endDate}-${tokenMarker}`;
 
-		if (this.cache.fetching || (this.cache.cacheKey === cacheKey && this.cache.data)) {
-			return this.cache.data;
-		}
+    if (
+      this.cache.fetching ||
+      (this.cache.cacheKey === cacheKey && this.cache.data)
+    ) {
+      return this.cache.data;
+    }
 
-		// Check if we need to load from storage
-		if (!this.cache.data && !this.cache.fetching) {
-			await this.loadFromStorage();
-		}
+    // Check if we need to load from storage
+    if (!this.cache.data && !this.cache.fetching) {
+      await this.loadFromStorage();
+    }
 
-		const currentTTL = await this.getCacheTTL();
-		this.cache.ttl = currentTTL;
+    const currentTTL = await this.getCacheTTL();
+    this.cache.ttl = currentTTL;
 
-		const now = Date.now();
-		const isCacheFresh = now - this.cache.timestamp < this.cache.ttl;
-		const isCacheKeyMatch = this.cache.cacheKey === cacheKey;
+    const now = Date.now();
+    const isCacheFresh = now - this.cache.timestamp < this.cache.ttl;
+    const isCacheKeyMatch = this.cache.cacheKey === cacheKey;
 
-		if (this.cache.data && isCacheFresh && isCacheKeyMatch) {
-			return this.cache.data;
-		}
+    if (this.cache.data && isCacheFresh && isCacheKeyMatch) {
+      return this.cache.data;
+    }
 
-		if (!isCacheKeyMatch) {
-			this.cache.data = null;
-		}
+    if (!isCacheKeyMatch) {
+      this.cache.data = null;
+    }
 
-		if (this.cache.fetching) {
-			return new Promise((resolve, reject) => {
-				this.cache.queue.push({ resolve, reject });
-			});
-		}
+    if (this.cache.fetching) {
+      return new Promise((resolve, reject) => {
+        this.cache.queue.push({ resolve, reject });
+      });
+    }
 
-		this.cache.fetching = true;
-		this.cache.cacheKey = cacheKey;
+    this.cache.fetching = true;
+    this.cache.cacheKey = cacheKey;
 
-		// Build headers with optional token
-		const headers = {};
-		if (token) {
-			headers['PRIVATE-TOKEN'] = token;
-		}
+    // Build headers with optional token
+    const headers = {};
+    if (token) {
+      headers["PRIVATE-TOKEN"] = token;
+    }
 
-		try {
-			// Throttling 500ms to avoid burst
-			await new Promise((res) => setTimeout(res, 500));
+    try {
+      // Throttling 500ms to avoid burst
+      await new Promise((res) => setTimeout(res, 500));
 
-			// Get user info first
-			const userUrl = `${this.baseUrl}/users?username=${username}`;
-			const userRes = await fetch(userUrl, { headers });
-			if (!userRes.ok) {
-				throw new Error(chrome?.i18n.getMessage('gitlabUserFetchError', [userRes.status, userRes.statusText]) || `Error fetching GitLab user: ${userRes.status} ${userRes.statusText}`);
-			}
-			const users = await userRes.json();
-			if (users.length === 0) {
-				throw new Error(chrome?.i18n.getMessage('gitlabUserNotFoundError', [username]) || `GitLab user '${username}' not found`);
-			}
-			const userId = users[0].id;
+      // Get user info first
+      const userUrl = `${this.baseUrl}/users?username=${username}`;
+      const userRes = await gitlabApiRequest(userUrl, headers);
+      if (!userRes.ok) {
+        throw new Error(
+         chrome?.i18n.getMessage('gitlabUserFetchError', [userRes.status, userRes.statusText]) || `Error fetching GitLab user: ${userRes.status} ${userRes.statusText}`,
+        );
+      }
+      const users = await userRes.json();
+      if (users.length === 0) {
+        throw new Error(`GitLab user '${username}' not found`);
+      }
+      const userId = users[0].id;
 
-			// Fetch all projects the user is a member of (including group projects)
-			const membershipProjectsUrl = `${this.baseUrl}/users/${userId}/projects?membership=true&per_page=100&order_by=updated_at&sort=desc`;
-			const membershipProjectsRes = await fetch(membershipProjectsUrl, { headers });
-			if (!membershipProjectsRes.ok) {
-				throw new Error(chrome?.i18n.getMessage('gitlabMembershipError', [membershipProjectsRes.status, membershipProjectsRes.statusText]) || `Error fetching GitLab membership projects: ${membershipProjectsRes.status} ${membershipProjectsRes.statusText}`);
-			}
-			const membershipProjects = await membershipProjectsRes.json();
+      // Fetch all projects the user is a member of (including group projects)
+      const membershipProjectsUrl = `${this.baseUrl}/users/${userId}/projects?membership=true&per_page=100&order_by=updated_at&sort=desc`;
+      const membershipProjectsRes = await gitlabApiRequest(
+        membershipProjectsUrl,
+        headers,
+      );
+      if (!membershipProjectsRes.ok) {
+        throw new Error(
+         rome?.i18n.getMessage('gitlabMembershipError', [membershipProjectsRes.status, membershipProjectsRes.statusText]) || `Error fetching GitLab membership projects: ${membershipProjectsRes.status} ${membershipProjectsRes.statusText}`,
+        );
+      }
+      const membershipProjects = await membershipProjectsRes.json();
 
-			// Fetch all projects the user has contributed to (public, group, etc.)
-			const contributedProjectsUrl = `${this.baseUrl}/users/${userId}/contributed_projects?per_page=100&order_by=updated_at&sort=desc`;
-			const contributedProjectsRes = await fetch(contributedProjectsUrl, { headers });
-			if (!contributedProjectsRes.ok) {
-				throw new Error(
-					chrome?.i18n.getMessage('gitlabContributedError', [contributedProjectsRes.status, contributedProjectsRes.statusText]) || `Error fetching GitLab contributed projects: ${contributedProjectsRes.status} ${contributedProjectsRes.statusText}`,
-				);
-			}
-			const contributedProjects = await contributedProjectsRes.json();
+      // Fetch all projects the user has contributed to (public, group, etc.)
+      const contributedProjectsUrl = `${this.baseUrl}/users/${userId}/contributed_projects?per_page=100&order_by=updated_at&sort=desc`;
+      const contributedProjectsRes = await gitlabApiRequest(
+        contributedProjectsUrl,
+        headers,
+      );
+      if (!contributedProjectsRes.ok) {
+        throw new Error(
+         chrome?.i18n.getMessage('gitlabContributedError', [contributedProjectsRes.status, contributedProjectsRes.statusText]) || `Error fetching GitLab contributed projects: ${contributedProjectsRes.status} ${contributedProjectsRes.statusText}`,
+        );
+      }
+      const contributedProjects = await contributedProjectsRes.json();
 
-			// Merge and deduplicate projects by project id
-			const allProjectsMap = new Map();
-			for (const p of [...membershipProjects, ...contributedProjects]) {
-				allProjectsMap.set(p.id, p);
-			}
-			const allProjects = Array.from(allProjectsMap.values());
+      // Merge and deduplicate projects by project id
+      const allProjectsMap = new Map();
+      for (const p of [...membershipProjects, ...contributedProjects]) {
+        allProjectsMap.set(p.id, p);
+      }
+      const allProjects = Array.from(allProjectsMap.values());
 
-			// Fetch merge requests from each project (works without auth for public projects)
-			let allMergeRequests = [];
-			for (const project of allProjects) {
-				try {
-					const projectMRsUrl = `${this.baseUrl}/projects/${project.id}/merge_requests?author_id=${userId}&created_after=${startDate}T00:00:00Z&created_before=${endDate}T23:59:59Z&per_page=100&order_by=updated_at&sort=desc`;
-					const projectMRsRes = await fetch(projectMRsUrl, { headers });
-					if (projectMRsRes.ok) {
-						const projectMRs = await projectMRsRes.json();
-						allMergeRequests = allMergeRequests.concat(projectMRs);
-					}
-					// Add small delay to avoid rate limiting
-					await new Promise((resolve) => setTimeout(resolve, 100));
-				} catch (error) {
-					console.error(`Error fetching MRs for project ${project.name}:`, error);
-					// Continue with other projects
-				}
-			}
+      // Fetch merge requests from each project (works without auth for public projects)
+      let allMergeRequests = [];
+      for (const project of allProjects) {
+        try {
+          const projectMRsUrl = `${this.baseUrl}/projects/${project.id}/merge_requests?author_id=${userId}&created_after=${startDate}T00:00:00Z&created_before=${endDate}T23:59:59Z&per_page=100&order_by=updated_at&sort=desc`;
+          const projectMRsRes = await gitlabApiRequest(projectMRsUrl, headers);
+          if (projectMRsRes.ok) {
+            const projectMRs = await projectMRsRes.json();
+            allMergeRequests = allMergeRequests.concat(projectMRs);
+          }
+          // Add small delay to avoid rate limiting
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        } catch (error) {
+          if (error.name === "RateLimitError") throw error; // Surface rate limit to caller
+          console.error(
+            `Error fetching MRs for project ${project.name}:`,
+            error,
+          );
+          // Continue with other projects
+        }
+      }
 
-			// Fetch issues from each project (works without auth for public projects)
-			let allIssues = [];
-			for (const project of allProjects) {
-				try {
-					const projectIssuesUrl = `${this.baseUrl}/projects/${project.id}/issues?author_id=${userId}&created_after=${startDate}T00:00:00Z&created_before=${endDate}T23:59:59Z&per_page=100&order_by=updated_at&sort=desc`;
-					const projectIssuesRes = await fetch(projectIssuesUrl, { headers });
-					if (projectIssuesRes.ok) {
-						const projectIssues = await projectIssuesRes.json();
-						allIssues = allIssues.concat(projectIssues);
-					}
-					// Add small delay to avoid rate limiting
-					await new Promise((resolve) => setTimeout(resolve, 100));
-				} catch (error) {
-					console.error(`Error fetching issues for project ${project.name}:`, error);
-					// Continue with other projects
-				}
-			}
+      // Fetch issues from each project (works without auth for public projects)
+      let allIssues = [];
+      for (const project of allProjects) {
+        try {
+          const projectIssuesUrl = `${this.baseUrl}/projects/${project.id}/issues?author_id=${userId}&created_after=${startDate}T00:00:00Z&created_before=${endDate}T23:59:59Z&per_page=100&order_by=updated_at&sort=desc`;
+          const projectIssuesRes = await gitlabApiRequest(
+            projectIssuesUrl,
+            headers,
+          );
+          if (projectIssuesRes.ok) {
+            const projectIssues = await projectIssuesRes.json();
+            allIssues = allIssues.concat(projectIssues);
+          }
+          // Add small delay to avoid rate limiting
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        } catch (error) {
+          if (error.name === "RateLimitError") throw error; // Surface rate limit to caller
+          console.error(
+            `Error fetching issues for project ${project.name}:`,
+            error,
+          );
+          // Continue with other projects
+        }
+      }
 
-			const gitlabData = {
-				user: users[0],
-				projects: allProjects,
-				mergeRequests: allMergeRequests, // use project-by-project response
-				issues: allIssues, // use project-by-project response
-				comments: [], // Empty array since we're not fetching comments
-			};
-			// Cache the data
-			this.cache.data = gitlabData;
-			this.cache.timestamp = Date.now();
+      const gitlabData = {
+        user: users[0],
+        projects: allProjects,
+        mergeRequests: allMergeRequests, // use project-by-project response
+        issues: allIssues, // use project-by-project response
+        comments: [], // Empty array since we're not fetching comments
+      };
+      // Cache the data
+      this.cache.data = gitlabData;
+      this.cache.timestamp = Date.now();
 
-			await this.saveToStorage(gitlabData);
+      await this.saveToStorage(gitlabData);
 
-			// Resolve queued calls
-			this.cache.queue.forEach(({ resolve }) => {
-				resolve(gitlabData);
-			});
-			this.cache.queue = [];
+      // Resolve queued calls
+      this.cache.queue.forEach(({ resolve }) => {
+        resolve(gitlabData);
+      });
+      this.cache.queue = [];
 
-			return gitlabData;
-		} catch (err) {
-			console.error('GitLab Fetch Failed:', err);
-			// Reject queued calls on error
-			this.cache.queue.forEach(({ reject }) => {
-				reject(err);
-			});
-			this.cache.queue = [];
-			throw err;
-		} finally {
-			this.cache.fetching = false;
-		}
-	}
+      return gitlabData;
+    } catch (err) {
+      console.error("GitLab Fetch Failed:", err);
 
-	async getDetailedMergeRequests(mergeRequests, token = null) {
-		const headers = {};
-		if (token) {
-			headers['PRIVATE-TOKEN'] = token;
-		}
-		const detailed = [];
-		for (const mr of mergeRequests) {
-			try {
-				const url = `${this.baseUrl}/projects/${mr.project_id}/merge_requests/${mr.iid}`;
-				const res = await fetch(url, { headers });
-				if (res.ok) {
-					const detailedMr = await res.json();
-					detailed.push(detailedMr);
-				}
-				// Add small delay to avoid rate limiting
-				await new Promise((resolve) => setTimeout(resolve, 100));
-			} catch (error) {
-				console.error(`[GITLAB-DEBUG] Error fetching detailed MR ${mr.iid}:`, error);
-				detailed.push(mr); // Use basic data if detailed fetch fails
-			}
-		}
-		return detailed;
-	}
+      // Handle rate limit errors by showing the banner
+      if (err.name === "RateLimitError") {
+        if (typeof showRateLimitWarning === "function")
+          showRateLimitWarning(err);
+      }
 
-	async getDetailedIssues(issues, token = null) {
-		const headers = {};
-		if (token) {
-			headers['PRIVATE-TOKEN'] = token;
-		}
-		const detailed = [];
-		for (const issue of issues) {
-			try {
-				const url = `${this.baseUrl}/projects/${issue.project_id}/issues/${issue.iid}`;
-				const res = await fetch(url, { headers });
-				if (res.ok) {
-					const detailedIssue = await res.json();
-					detailed.push(detailedIssue);
-				}
-				// Add small delay to avoid rate limiting
-				await new Promise((resolve) => setTimeout(resolve, 100));
-			} catch (error) {
-				console.error(`[GITLAB-DEBUG] Error fetching detailed issue ${issue.iid}:`, error);
-				detailed.push(issue); // Use basic data if detailed fetch fails
-			}
-		}
-		return detailed;
-	}
+      // Reject queued calls on error
+      this.cache.queue.forEach(({ reject }) => {
+        reject(err);
+      });
+      this.cache.queue = [];
+      throw err;
+    } finally {
+      this.cache.fetching = false;
+    }
+  }
 
-	formatDate(dateString) {
-		const date = new Date(dateString);
-		const options = { day: '2-digit', month: 'short', year: 'numeric' };
-		return date.toLocaleDateString('en-US', options);
-	}
+  async getDetailedMergeRequests(mergeRequests, token = null) {
+    const headers = {};
+    if (token) {
+      headers["PRIVATE-TOKEN"] = token;
+    }
+    const detailed = [];
+    for (const mr of mergeRequests) {
+      try {
+        const url = `${this.baseUrl}/projects/${mr.project_id}/merge_requests/${mr.iid}`;
+        const res = await gitlabApiRequest(url, headers);
+        if (res.ok) {
+          const detailedMr = await res.json();
+          detailed.push(detailedMr);
+        }
+        // Add small delay to avoid rate limiting
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      } catch (error) {
+        if (error.name === "RateLimitError") {
+          if (typeof showRateLimitWarning === "function")
+            showRateLimitWarning(error);
+          break; // Stop fetching more details
+        }
+        console.error(
+          `[GITLAB-DEBUG] Error fetching detailed MR ${mr.iid}:`,
+          error,
+        );
+        detailed.push(mr); // Use basic data if detailed fetch fails
+      }
+    }
+    return detailed;
+  }
 
-	processGitLabData(data) {
-		const processed = {
-			mergeRequests: data.mergeRequests || [],
-			issues: data.issues || [],
-			comments: data.comments || [],
-			user: data.user,
-		};
+  async getDetailedIssues(issues, token = null) {
+    const headers = {};
+    if (token) {
+      headers["PRIVATE-TOKEN"] = token;
+    }
+    const detailed = [];
+    for (const issue of issues) {
+      try {
+        const url = `${this.baseUrl}/projects/${issue.project_id}/issues/${issue.iid}`;
+        const res = await gitlabApiRequest(url, headers);
+        if (res.ok) {
+          const detailedIssue = await res.json();
+          detailed.push(detailedIssue);
+        }
+        // Add small delay to avoid rate limiting
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      } catch (error) {
+        if (error.name === "RateLimitError") {
+          if (typeof showRateLimitWarning === "function")
+            showRateLimitWarning(error);
+          break; // Stop fetching more details
+        }
+        console.error(
+          `[GITLAB-DEBUG] Error fetching detailed issue ${issue.iid}:`,
+          error,
+        );
+        detailed.push(issue); // Use basic data if detailed fetch fails
+      }
+    }
+    return detailed;
+  }
 
-		return processed;
-	}
+  formatDate(dateString) {
+    const date = new Date(dateString);
+    const options = { day: "2-digit", month: "short", year: "numeric" };
+    return date.toLocaleDateString("en-US", options);
+  }
+
+  processGitLabData(data) {
+    const processed = {
+      mergeRequests: data.mergeRequests || [],
+      issues: data.issues || [],
+      comments: data.comments || [],
+      user: data.user,
+    };
+
+    return processed;
+  }
 }
 
 // Export for use in other scripts
-if (typeof module !== 'undefined' && module.exports) {
-	module.exports = GitLabHelper;
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = GitLabHelper;
 } else {
-	window.GitLabHelper = GitLabHelper;
+  window.GitLabHelper = GitLabHelper;
 }

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1,11 +1,11 @@
 /* global chrome */
 
 function debounce(func, wait) {
-  let timeout;
-  return function (...args) {
-    clearTimeout(timeout);
-    timeout = setTimeout(() => func.apply(this, args), wait);
-  };
+	let timeout;
+	return function (...args) {
+		clearTimeout(timeout);
+		timeout = setTimeout(() => func.apply(this, args), wait);
+	};
 }
 
 // Utility: Detect if the current OS is macOS
@@ -78,16 +78,94 @@ function setupButtonTooltips() {
 	}
 }
 
+// Render token setup UI when rate limit is hit and user has no token
+window.renderTokenSetupUI = function (error) {
+	const tokenSetupContainer = document.getElementById('tokenSetupContainer');
+	if (!tokenSetupContainer) {
+		console.log("Render token container not exist or failed to fetch",tokenSetupContainer);
+		return;
+	}
+
+	const isGithub = error.platform === 'github';
+	const tokenInput = document.getElementById(isGithub ? 'githubToken' : 'gitlabToken');
+	const hasToken = tokenInput && tokenInput.value.trim().length > 0;
+
+	// If user has token, hide the setup UI and show only rate limit warning
+	if (hasToken) {
+		tokenSetupContainer.classList.add('hidden');
+		if (typeof showRateLimitWarning === 'function') {
+			showRateLimitWarning(error);
+		}
+		return;
+	}
+
+	// Update titles and descriptions based on platform
+	const platformName = isGithub ? 'GitHub' : 'GitLab';
+	const titleElement = document.getElementById('tokenSetupTitle');
+	const descriptionElement = document.getElementById('tokenSetupDescription');
+	
+	if (titleElement) {
+		titleElement.textContent = chrome?.i18n.getMessage('tokenSetupTitle') || `Add ${platformName} Token`;
+	}
+	if (descriptionElement) {
+		descriptionElement.textContent = chrome?.i18n.getMessage('tokenSetupDescription') || `Enable advanced features by adding your ${platformName} token`;
+	}
+
+	// Show the container
+	tokenSetupContainer.classList.remove('hidden');
+
+	// Set up event listeners (remove old ones first to prevent duplicates)
+	const addBtn = document.getElementById('tokenSetupAddBtn');
+	const learnBtn = document.getElementById('tokenSetupLearnBtn');
+
+	// Clone buttons to remove old event listeners
+	if (addBtn && addBtn.parentNode) {
+		const newAddBtn = addBtn.cloneNode(true);
+		addBtn.parentNode.replaceChild(newAddBtn, addBtn);
+
+		newAddBtn.addEventListener('click', () => {
+			showSettingsView();
+			const tokenInputElement = document.getElementById(isGithub ? 'githubToken' : 'gitlabToken');
+			if (tokenInputElement) {
+				setTimeout(() => {
+					tokenInputElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+					tokenInputElement.focus();
+					const borderColor = isGithub ? '#3b82f6' : '#f97316';
+					const shadowColor = isGithub ? 'rgba(59, 130, 246, 0.3)' : 'rgba(249, 115, 22, 0.3)';
+					tokenInputElement.style.borderColor = borderColor;
+					tokenInputElement.style.boxShadow = `0 0 0 3px ${shadowColor}`;
+					setTimeout(() => {
+						tokenInputElement.style.borderColor = '';
+						tokenInputElement.style.boxShadow = '';
+					}, 3000);
+				}, 100);
+			}
+		});
+	}
+
+	if (learnBtn && learnBtn.parentNode) {
+		const newLearnBtn = learnBtn.cloneNode(true);
+		learnBtn.parentNode.replaceChild(newLearnBtn, learnBtn);
+
+		newLearnBtn.addEventListener('click', () => {
+			const url = isGithub
+				? 'https://github.com/settings/tokens'
+				: 'https://gitlab.com/-/user_settings/personal_access_tokens';
+			chrome.tabs && chrome.tabs.create && chrome.tabs.create({ url });
+		});
+	}
+};
+
 function getToday() {
-  const today = new Date();
-  return today.toISOString().split("T")[0];
+	const today = new Date();
+	return today.toISOString().split('T')[0];
 }
 
 function getYesterday() {
-  const today = new Date();
-  const yesterday = new Date(today);
-  yesterday.setDate(today.getDate() - 1);
-  return yesterday.toISOString().split("T")[0];
+	const today = new Date();
+	const yesterday = new Date(today);
+	yesterday.setDate(today.getDate() - 1);
+	return yesterday.toISOString().split('T')[0];
 }
 
 function applyI18n() {
@@ -126,32 +204,30 @@ document.addEventListener('DOMContentLoaded', () => {
 	applyI18n();
 	setupButtonTooltips();
 
-  // Dark mode setup
-  const darkModeToggle = document.querySelector('img[alt="Night Mode"]');
-  const settingsIcon = document.getElementById("settingsIcon");
-  const body = document.body;
-  const homeButton = document.getElementById("homeButton");
-  const scrumHelperHeading = document.getElementById("scrumHelperHeading");
-  const settingsToggle = document.getElementById("settingsToggle");
-  const reportSection = document.getElementById("reportSection");
-  const settingsSection = document.getElementById("settingsSection");
+	// Dark mode setup
+	const darkModeToggle = document.querySelector('img[alt="Night Mode"]');
+	const settingsIcon = document.getElementById('settingsIcon');
+	const body = document.body;
+	const homeButton = document.getElementById('homeButton');
+	const scrumHelperHeading = document.getElementById('scrumHelperHeading');
+	const settingsToggle = document.getElementById('settingsToggle');
+	const reportSection = document.getElementById('reportSection');
+	const settingsSection = document.getElementById('settingsSection');
 
-  let isSettingsVisible = false;
-  const githubTokenInput = document.getElementById("githubToken");
-  const toggleTokenBtn = document.getElementById("toggleTokenVisibility");
-  const tokenEyeIcon = document.getElementById("tokenEyeIcon");
-  const tokenPreview = document.getElementById("tokenPreview");
-  let tokenVisible = false;
+	let isSettingsVisible = false;
+	const githubTokenInput = document.getElementById('githubToken');
+	const toggleTokenBtn = document.getElementById('toggleTokenVisibility');
+	const tokenEyeIcon = document.getElementById('tokenEyeIcon');
+	const tokenPreview = document.getElementById('tokenPreview');
+	let tokenVisible = false;
 
-  // GitLab token elements
-  const gitlabTokenInput = document.getElementById("gitlabToken");
-  const toggleGitlabTokenBtn = document.getElementById(
-    "toggleGitlabTokenVisibility",
-  );
-  const gitlabTokenEyeIcon = document.getElementById("gitlabTokenEyeIcon");
-  let gitlabTokenVisible = false;
+	// GitLab token elements
+	const gitlabTokenInput = document.getElementById('gitlabToken');
+	const toggleGitlabTokenBtn = document.getElementById('toggleGitlabTokenVisibility');
+	const gitlabTokenEyeIcon = document.getElementById('gitlabTokenEyeIcon');
+	let gitlabTokenVisible = false;
 
-  const orgInput = document.getElementById("orgInput");
+	const orgInput = document.getElementById('orgInput');
 
 	const platformSelect = document.getElementById('platformSelect');
 	const usernameLabel = document.getElementById('usernameLabel');
@@ -159,22 +235,17 @@ document.addEventListener('DOMContentLoaded', () => {
 	let showCommitsWarningTimeout;
 	let mergedPRsWarningTimeout;
 
-  function checkTokenForFilter() {
-    const useRepoFilter = document.getElementById("useRepoFilter");
-    const githubTokenInput = document.getElementById("githubToken");
-    const tokenWarning = document.getElementById("tokenWarningForFilter");
-    const repoFilterContainer = document.getElementById("repoFilterContainer");
+	function checkTokenForFilter() {
+		const useRepoFilter = document.getElementById('useRepoFilter');
+		const githubTokenInput = document.getElementById('githubToken');
+		const tokenWarning = document.getElementById('tokenWarningForFilter');
+		const repoFilterContainer = document.getElementById('repoFilterContainer');
 
-    if (
-      !useRepoFilter ||
-      !githubTokenInput ||
-      !tokenWarning ||
-      !repoFilterContainer
-    ) {
-      return;
-    }
-    const isFilterEnabled = useRepoFilter.checked;
-    const hasToken = githubTokenInput.value.trim() !== "";
+		if (!useRepoFilter || !githubTokenInput || !tokenWarning || !repoFilterContainer) {
+			return;
+		}
+		const isFilterEnabled = useRepoFilter.checked;
+		const hasToken = githubTokenInput.value.trim() !== '';
 
 		if (isFilterEnabled && !hasToken) {
 			useRepoFilter.checked = false;
@@ -323,42 +394,32 @@ document.addEventListener('DOMContentLoaded', () => {
 		}
 	});
 
-  toggleTokenBtn.addEventListener("click", () => {
-    tokenVisible = !tokenVisible;
-    githubTokenInput.type = tokenVisible ? "text" : "password";
+	toggleTokenBtn.addEventListener('click', () => {
+		tokenVisible = !tokenVisible;
+		githubTokenInput.type = tokenVisible ? 'text' : 'password';
 
-    tokenEyeIcon.classList.add("eye-animating");
-    setTimeout(() => tokenEyeIcon.classList.remove("eye-animating"), 400);
-    tokenEyeIcon.className = tokenVisible
-      ? "fa fa-eye-slash text-gray-600"
-      : "fa fa-eye text-gray-600";
+		tokenEyeIcon.classList.add('eye-animating');
+		setTimeout(() => tokenEyeIcon.classList.remove('eye-animating'), 400);
+		tokenEyeIcon.className = tokenVisible ? 'fa fa-eye-slash text-gray-600' : 'fa fa-eye text-gray-600';
 
-    githubTokenInput.classList.add("token-animating");
-    setTimeout(() => githubTokenInput.classList.remove("token-animating"), 300);
-  });
+		githubTokenInput.classList.add('token-animating');
+		setTimeout(() => githubTokenInput.classList.remove('token-animating'), 300);
+	});
 
-  // GitLab token visibility toggle
-  if (toggleGitlabTokenBtn && gitlabTokenInput) {
-    toggleGitlabTokenBtn.addEventListener("click", () => {
-      gitlabTokenVisible = !gitlabTokenVisible;
-      gitlabTokenInput.type = gitlabTokenVisible ? "text" : "password";
+	// GitLab token visibility toggle
+	if (toggleGitlabTokenBtn && gitlabTokenInput) {
+		toggleGitlabTokenBtn.addEventListener('click', () => {
+			gitlabTokenVisible = !gitlabTokenVisible;
+			gitlabTokenInput.type = gitlabTokenVisible ? 'text' : 'password';
 
-      gitlabTokenEyeIcon.classList.add("eye-animating");
-      setTimeout(
-        () => gitlabTokenEyeIcon.classList.remove("eye-animating"),
-        400,
-      );
-      gitlabTokenEyeIcon.className = gitlabTokenVisible
-        ? "fa fa-eye-slash text-gray-600"
-        : "fa fa-eye text-gray-600";
+			gitlabTokenEyeIcon.classList.add('eye-animating');
+			setTimeout(() => gitlabTokenEyeIcon.classList.remove('eye-animating'), 400);
+			gitlabTokenEyeIcon.className = gitlabTokenVisible ? 'fa fa-eye-slash text-gray-600' : 'fa fa-eye text-gray-600';
 
-      gitlabTokenInput.classList.add("token-animating");
-      setTimeout(
-        () => gitlabTokenInput.classList.remove("token-animating"),
-        300,
-      );
-    });
-  }
+			gitlabTokenInput.classList.add('token-animating');
+			setTimeout(() => gitlabTokenInput.classList.remove('token-animating'), 300);
+		});
+	}
 
 	githubTokenInput.addEventListener('input', checkTokenForFilter);
 	githubTokenInput.addEventListener('input', () =>
@@ -380,25 +441,25 @@ document.addEventListener('DOMContentLoaded', () => {
 		renderTokenPreview();
 	});
 
-  function renderTokenPreview() {
-    if (!tokenPreview || !githubTokenInput) return;
-    tokenPreview.innerHTML = "";
-    const value = githubTokenInput.value;
-    const isDark = document.body.classList.contains("dark-mode");
-    for (let i = 0; i < value.length; i++) {
-      const charBox = document.createElement("span");
-      charBox.className = "token-preview-char" + (isDark ? " dark-mode" : "");
-      if (tokenVisible) {
-        charBox.textContent = value[i];
-      } else {
-        const dot = document.createElement("span");
-        dot.className = "token-preview-dot" + (isDark ? " dark-mode" : "");
-        charBox.appendChild(dot);
-      }
-      tokenPreview.appendChild(charBox);
-      setTimeout(() => charBox.classList.add("flip"), 10 + i * 30);
-    }
-  }
+	function renderTokenPreview() {
+		if (!tokenPreview || !githubTokenInput) return;
+		tokenPreview.innerHTML = '';
+		const value = githubTokenInput.value;
+		const isDark = document.body.classList.contains('dark-mode');
+		for (let i = 0; i < value.length; i++) {
+			const charBox = document.createElement('span');
+			charBox.className = 'token-preview-char' + (isDark ? ' dark-mode' : '');
+			if (tokenVisible) {
+				charBox.textContent = value[i];
+			} else {
+				const dot = document.createElement('span');
+				dot.className = 'token-preview-dot' + (isDark ? ' dark-mode' : '');
+				charBox.appendChild(dot);
+			}
+			tokenPreview.appendChild(charBox);
+			setTimeout(() => charBox.classList.add('flip'), 10 + i * 30);
+		}
+	}
 
 	browser.storage.local.remove(['enableToggle']).then(() => {
 		initializePopup();
@@ -426,89 +487,87 @@ document.addEventListener('DOMContentLoaded', () => {
 		});
 	}
 
-  function parsePositiveInt(value) {
-    const n = Number.parseInt(value, 10);
-    return Number.isFinite(n) && n > 0 ? n : null;
-  }
+	function parsePositiveInt(value) {
+		const n = Number.parseInt(value, 10);
+		return Number.isFinite(n) && n > 0 ? n : null;
+	}
 
-  function setGenerateButtonLoading(generateBtn, isLoading) {
-    if (!generateBtn) return;
-    if (!isLoading) return;
+	function setGenerateButtonLoading(generateBtn, isLoading) {
+		if (!generateBtn) return;
+		if (!isLoading) return;
 
 		const msg = browser.i18n.getMessage('generatingButton') || 'Generating...';
 		generateBtn.innerHTML = `<i class="fa fa-spinner fa-spin"></i> ${msg}`;
 		generateBtn.disabled = true;
 	}
 
-  function showPopupMessage(message) {
-    if (!message) return;
+	function showPopupMessage(message) {
+		if (!message) return;
 
-    // Materialize toast if available
-    if (window.Materialize && typeof window.Materialize.toast === "function") {
-      window.Materialize.toast(message, 4000);
-      return;
-    }
+		// Materialize toast if available
+		if (window.Materialize && typeof window.Materialize.toast === 'function') {
+			window.Materialize.toast(message, 4000);
+			return;
+		}
 
-    const old = document.getElementById("scrum-cache-toast");
-    if (old) old.remove();
+		const old = document.getElementById('scrum-cache-toast');
+		if (old) old.remove();
 
-    const toast = document.createElement("div");
-    toast.id = "scrum-cache-toast";
-    toast.className = "toast";
-    toast.style.background = "#2563eb";
-    toast.style.color = "#fff";
-    toast.style.fontWeight = "bold";
-    toast.style.padding = "12px 24px";
-    toast.style.borderRadius = "8px";
-    toast.style.position = "fixed";
-    toast.style.top = "24px";
-    toast.style.left = "50%";
-    toast.style.transform = "translateX(-50%)";
-    toast.style.zIndex = "9999";
-    toast.textContent = message;
+		const toast = document.createElement('div');
+		toast.id = 'scrum-cache-toast';
+		toast.className = 'toast';
+		toast.style.background = '#2563eb';
+		toast.style.color = '#fff';
+		toast.style.fontWeight = 'bold';
+		toast.style.padding = '12px 24px';
+		toast.style.borderRadius = '8px';
+		toast.style.position = 'fixed';
+		toast.style.top = '24px';
+		toast.style.left = '50%';
+		toast.style.transform = 'translateX(-50%)';
+		toast.style.zIndex = '9999';
+		toast.textContent = message;
 
-    document.body.appendChild(toast);
-    setTimeout(() => toast.remove(), 4000);
-  }
+		document.body.appendChild(toast);
+		setTimeout(() => toast.remove(), 4000);
+	}
 
-  async function bootstrapScrumReportOnPopupLoad(generateBtn) {
-    console.log("[BOOTSTRAP] bootstrapScrumReportOnPopupLoad called");
+	async function bootstrapScrumReportOnPopupLoad(generateBtn) {
+		console.log('[BOOTSTRAP] bootstrapScrumReportOnPopupLoad called');
 
-    if (typeof window.generateScrumReport !== "function") {
-      return;
-    }
+		if (typeof window.generateScrumReport !== 'function') {
+			return;
+		}
 
-    const scrumReport = document.getElementById("scrumReport");
-    if (!scrumReport) {
-      return;
-    }
+		const scrumReport = document.getElementById('scrumReport');
+		if (!scrumReport) {
+			return;
+		}
 
-    const { platform, cacheInput, githubCache, gitlabCache } =
-      await storageLocalGet([
-        "platform",
-        "cacheInput",
-        "githubCache",
-        "gitlabCache",
-      ]);
+		const { platform, cacheInput, githubCache, gitlabCache } = await storageLocalGet([
+			'platform',
+			'cacheInput',
+			'githubCache',
+			'gitlabCache',
+		]);
 
-    const ttlMinutes = parsePositiveInt(cacheInput) ?? 10;
-    const ttlMs = ttlMinutes * 60 * 1000;
+		const ttlMinutes = parsePositiveInt(cacheInput) ?? 10;
+		const ttlMs = ttlMinutes * 60 * 1000;
 
-    const activePlatform = platform || "github";
-    const cache = activePlatform === "gitlab" ? gitlabCache : githubCache;
+		const activePlatform = platform || 'github';
+		const cache = activePlatform === 'gitlab' ? gitlabCache : githubCache;
 
-    const hasCacheData = !!cache?.data;
-    const timestamp =
-      typeof cache?.timestamp === "number" ? cache.timestamp : 0;
+		const hasCacheData = !!cache?.data;
+		const timestamp = typeof cache?.timestamp === 'number' ? cache.timestamp : 0;
 
-    if (!hasCacheData) {
-      setGenerateButtonLoading(generateBtn, true);
-      window.generateScrumReport();
-      return;
-    }
+		if (!hasCacheData) {
+			setGenerateButtonLoading(generateBtn, true);
+			window.generateScrumReport();
+			return;
+		}
 
-    if (timestamp > 0) {
-      const age = Date.now() - timestamp;
+		if (timestamp > 0) {
+			const age = Date.now() - timestamp;
 
 			const storageValues = await storageLocalGet([
 				`${activePlatform}LastScrumReportHtml`,
@@ -520,7 +579,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				'lastScrumReportUsername',
 				'githubUsername',
 				'gitlabUsername',
-				'platformUsername'
+				'platformUsername',
 			]);
 
 			let lastScrumReportHtml = storageValues[`${activePlatform}LastScrumReportHtml`];
@@ -539,7 +598,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			const isUsernameMatch = lastScrumReportUsername 
 				? lastScrumReportUsername === expectedUsername
-				: (lastScrumReportCacheKey && expectedUsername && lastScrumReportCacheKey.startsWith(expectedUsername + '-'));
+				: lastScrumReportCacheKey && expectedUsername && lastScrumReportCacheKey.startsWith(expectedUsername + '-');
 
 			if (age < ttlMs) {
 				const cacheKey = cache?.cacheKey ?? null;
@@ -549,39 +608,32 @@ document.addEventListener('DOMContentLoaded', () => {
 					(!lastScrumReportCacheKey || lastScrumReportCacheKey === cacheKey) &&
 					isUsernameMatch;
 
-        if (reportEmpty && lastScrumReportHtml && matches) {
-          scrumReport.innerHTML = lastScrumReportHtml;
-          if (generateBtn) generateBtn.disabled = false;
-          return;
-        }
+				if (reportEmpty && lastScrumReportHtml && matches) {
+					scrumReport.innerHTML = lastScrumReportHtml;
+					if (generateBtn) generateBtn.disabled = false;
+					return;
+				}
 
-        setGenerateButtonLoading(generateBtn, true);
-        window.generateScrumReport();
-        return;
-      }
+				setGenerateButtonLoading(generateBtn, true);
+				window.generateScrumReport();
+				return;
+			}
 
-      const { lastScrumReportHtml } = await storageLocalGet([
-        "lastScrumReportHtml",
-      ]);
-      if (
-        (!scrumReport.innerHTML || !scrumReport.innerHTML.trim()) &&
-        lastScrumReportHtml
-      ) {
-        scrumReport.innerHTML = lastScrumReportHtml;
-      }
+			if ((!scrumReport.innerHTML || !scrumReport.innerHTML.trim()) && lastScrumReportHtml) {
+				scrumReport.innerHTML = lastScrumReportHtml;
+			}
 
-      showPopupMessage(
-        chrome?.i18n.getMessage("cacheExpiredMessage") ||
-          'Cache expired. Click "Generate" to fetch fresh data.',
-      );
+			showPopupMessage(
+				chrome?.i18n.getMessage('cacheExpiredMessage') || 'Cache expired. Click "Generate" to fetch fresh data.',
+			);
 
-      if (generateBtn) generateBtn.disabled = false;
-      return;
-    }
+			if (generateBtn) generateBtn.disabled = false;
+			return;
+		}
 
-    setGenerateButtonLoading(generateBtn, true);
-    window.generateScrumReport();
-  }
+		setGenerateButtonLoading(generateBtn, true);
+		window.generateScrumReport();
+	}
 
 	function initializePopup() {
 		browser.storage.local.get(['platform', 'platformUsername']).then((result) => {
@@ -604,12 +656,12 @@ document.addEventListener('DOMContentLoaded', () => {
 		const onlyRevPRsCheckbox = document.getElementById('onlyRevPRs');
 		const onlyMergedPRsCheckbox = document.getElementById('onlyMergedPRs');
 
-    const githubTokenInput = document.getElementById("githubToken");
-    const cacheInput = document.getElementById("cacheInput");
-    const yesterdayRadio = document.getElementById("yesterdayContribution");
-    const startingDateInput = document.getElementById("startingDate");
-    const endingDateInput = document.getElementById("endingDate");
-    const platformUsername = document.getElementById("platformUsername");
+		const githubTokenInput = document.getElementById('githubToken');
+		const cacheInput = document.getElementById('cacheInput');
+		const yesterdayRadio = document.getElementById('yesterdayContribution');
+		const startingDateInput = document.getElementById('startingDate');
+		const endingDateInput = document.getElementById('endingDate');
+		const platformUsername = document.getElementById('platformUsername');
 
 		browser.storage.local
 			.get([
@@ -690,16 +742,16 @@ document.addEventListener('DOMContentLoaded', () => {
 			},
 		);
 
-    // Button setup
-    const generateBtn = document.getElementById("generateReport");
-    const copyBtn = document.getElementById("copyReport");
-    const insertBtn = document.getElementById("insertInEmail");
+		// Button setup
+		const generateBtn = document.getElementById('generateReport');
+		const copyBtn = document.getElementById('copyReport');
+		const insertBtn = document.getElementById('insertInEmail');
 
-    if (insertBtn) {
-      insertBtn.addEventListener("click", () => {
-        const scrumReport = document.getElementById("scrumReport");
-        const content = scrumReport ? scrumReport.innerHTML : "";
-        const subject = buildScrumSubjectFromPopup();
+		if (insertBtn) {
+			insertBtn.addEventListener('click', () => {
+				const scrumReport = document.getElementById('scrumReport');
+				const content = scrumReport ? scrumReport.innerHTML : '';
+				const subject = buildScrumSubjectFromPopup();
 
 				if (!content) {
 					insertBtn._triggeredByShortcut = false;
@@ -761,19 +813,19 @@ document.addEventListener('DOMContentLoaded', () => {
 			});
 		});
 
-    copyBtn.addEventListener("click", function () {
-      const scrumReport = document.getElementById("scrumReport");
-      const tempDiv = document.createElement("div");
-      tempDiv.innerHTML = scrumReport.innerHTML;
-      document.body.appendChild(tempDiv);
-      tempDiv.style.position = "absolute";
-      tempDiv.style.left = "-9999px";
+		copyBtn.addEventListener('click', function () {
+			const scrumReport = document.getElementById('scrumReport');
+			const tempDiv = document.createElement('div');
+			tempDiv.innerHTML = scrumReport.innerHTML;
+			document.body.appendChild(tempDiv);
+			tempDiv.style.position = 'absolute';
+			tempDiv.style.left = '-9999px';
 
-      const range = document.createRange();
-      range.selectNode(tempDiv);
-      const selection = window.getSelection();
-      selection.removeAllRanges();
-      selection.addRange(range);
+			const range = document.createRange();
+			range.selectNode(tempDiv);
+			const selection = window.getSelection();
+			selection.removeAllRanges();
+			selection.addRange(range);
 
 			try {
 				document.execCommand('copy');
@@ -797,21 +849,17 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		});
 
-    // Custom date container click handler
-    document
-      .getElementById("customDateContainer")
-      .addEventListener("click", () => {
-        document
-          .querySelectorAll('input[name="timeframe"]')
-          .forEach((radio) => {
-            radio.checked = false;
-            radio.dataset.wasChecked = "false";
-          });
+		// Custom date container click handler
+		document.getElementById('customDateContainer').addEventListener('click', () => {
+			document.querySelectorAll('input[name="timeframe"]').forEach((radio) => {
+				radio.checked = false;
+				radio.dataset.wasChecked = 'false';
+			});
 
-        const startDateInput = document.getElementById("startingDate");
-        const endDateInput = document.getElementById("endingDate");
-        startDateInput.readOnly = false;
-        endDateInput.readOnly = false;
+			const startDateInput = document.getElementById('startingDate');
+			const endDateInput = document.getElementById('endingDate');
+			startDateInput.readOnly = false;
+			endDateInput.readOnly = false;
 
 			browser.storage.local.set({
 				yesterdayContribution: false,
@@ -1046,174 +1094,159 @@ document.addEventListener('DOMContentLoaded', () => {
 		});
 	}
 
-  function showReportView() {
-    isSettingsVisible = false;
-    reportSection.classList.remove("hidden");
-    settingsSection.classList.add("hidden");
-    settingsToggle.classList.remove("active");
-  }
+	function showReportView() {
+		isSettingsVisible = false;
+		reportSection.classList.remove('hidden');
+		settingsSection.classList.add('hidden');
+		settingsToggle.classList.remove('active');
+	}
 
-  function showSettingsView() {
-    isSettingsVisible = true;
-    reportSection.classList.add("hidden");
-    settingsSection.classList.remove("hidden");
-    settingsToggle.classList.add("active");
-  }
+	function showSettingsView() {
+		isSettingsVisible = true;
+		reportSection.classList.add('hidden');
+		settingsSection.classList.remove('hidden');
+		settingsToggle.classList.add('active');
+	}
 
-  if (settingsToggle) {
-    settingsToggle.addEventListener("click", () => {
-      if (isSettingsVisible) {
-        showReportView();
-      } else {
-        showSettingsView();
-      }
-    });
-  }
+	if (settingsToggle) {
+		settingsToggle.addEventListener('click', () => {
+			if (isSettingsVisible) {
+				showReportView();
+			} else {
+				showSettingsView();
+			}
+		});
+	}
 
-  if (homeButton) {
-    homeButton.addEventListener("click", showReportView);
-  }
-  if (scrumHelperHeading) {
-    scrumHelperHeading.addEventListener("click", showReportView);
-  }
+	if (homeButton) {
+		homeButton.addEventListener('click', showReportView);
+	}
+	if (scrumHelperHeading) {
+		scrumHelperHeading.addEventListener('click', showReportView);
+	}
 
-  // ── Rate Limit Warning Banner Handlers ──
+	// ── Rate Limit Warning Banner Handlers ──
 
-  /**
-   * Show the rate-limit warning banner.
-   * Called from scrumHelper.js / gitlabHelper.js when a RateLimitError is caught.
-   * Exposed globally so other scripts can call it.
-   * @param {Error} error — must have .name === "RateLimitError", .platform, .resetAt, .retryAfter
-   */
-  window.showRateLimitWarning = function (error) {
-    const isGithub = error.platform === "github";
-    const warningEl = document.getElementById(
-      isGithub ? "rateLimitWarning" : "rateLimitWarningGitlab",
-    );
-    const messageEl = document.getElementById(
-      isGithub ? "rateLimitMessage" : "rateLimitMessageGitlab",
-    );
-    const retryInfoEl = document.getElementById(
-      isGithub ? "rateLimitRetryInfo" : "rateLimitRetryInfoGitlab",
-    );
+	/**
+	 * Show the rate-limit warning banner.
+	 * Called from scrumHelper.js / gitlabHelper.js when a RateLimitError is caught.
+	 * Exposed globally so other scripts can call it.
+	 * @param {Error} error — must have .name === "RateLimitError", .platform, .resetAt, .retryAfter
+	 */
+	window.showRateLimitWarning = function (error) {
+		const isGithub = error.platform === 'github';
+		const warningEl = document.getElementById(isGithub ? 'rateLimitWarning' : 'rateLimitWarningGitlab');
+		const messageEl = document.getElementById(isGithub ? 'rateLimitMessage' : 'rateLimitMessageGitlab');
+		const retryInfoEl = document.getElementById(isGithub ? 'rateLimitRetryInfo' : 'rateLimitRetryInfoGitlab');
 
-    if (!warningEl) return;
+		if (!warningEl) return;
 
-    // Check whether the user already has a token set
-    const tokenInput = document.getElementById(
-      isGithub ? "githubToken" : "gitlabToken",
-    );
-    const hasToken = tokenInput && tokenInput.value.trim().length > 0;
+		// Check whether the user already has a token set
+		const tokenInput = document.getElementById(isGithub ? 'githubToken' : 'gitlabToken');
+		const hasToken = tokenInput && tokenInput.value.trim().length > 0;
 
-    if (hasToken) {
-      messageEl.textContent =
-        `You've exceeded the ${isGithub ? "GitHub" : "GitLab"} API rate limit even with a token. ` +
-        "Please wait for the limit to reset and try again.";
-    } else {
-      messageEl.textContent =
-        `You've hit the ${isGithub ? "GitHub" : "GitLab"} API rate limit for unauthenticated requests. ` +
-        "Adding a Personal Access Token increases your limit significantly and enables access to private repositories.";
-    }
+		if (hasToken) {
+			messageEl.textContent =
+				`You've exceeded the ${isGithub ? 'GitHub' : 'GitLab'} API rate limit even with a token. ` +
+				'Please wait for the limit to reset and try again.';
+		} else {
+			messageEl.textContent =
+				`You've hit the ${isGithub ? 'GitHub' : 'GitLab'} API rate limit for unauthenticated requests. ` +
+				'Adding a Personal Access Token increases your limit significantly and enables access to private repositories.';
+		}
 
-    // Show reset countdown
-    if (error.resetAt) {
-      const resetDate = new Date(error.resetAt);
-      const minutes = Math.max(
-        1,
-        Math.ceil((error.resetAt - Date.now()) / 60000),
-      );
-      retryInfoEl.textContent = `Rate limit resets at ${resetDate.toLocaleTimeString()} (~${minutes} min).`;
-    } else {
-      retryInfoEl.textContent = `Try again in about ${error.retryAfter || 60} seconds.`;
-    }
+		// Show reset countdown
+		if (error.resetAt) {
+			const resetDate = new Date(error.resetAt);
+			const minutes = Math.max(1, Math.ceil((error.resetAt - Date.now()) / 60000));
+			retryInfoEl.textContent = `Rate limit resets at ${resetDate.toLocaleTimeString()} (~${minutes} min).`;
+		} else {
+			retryInfoEl.textContent = `Try again in about ${error.retryAfter || 60} seconds.`;
+		}
 
-    warningEl.classList.remove("hidden");
-    warningEl.scrollIntoView({ behavior: "smooth", block: "center" });
+		warningEl.classList.remove('hidden');
+		warningEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
 
-    // Reset the Generate button so the user can try again later
-    const generateBtn = document.getElementById("generateReport");
-    if (generateBtn) {
-      const iconEl = generateBtn.querySelector("i");
-      if (iconEl) {
-        iconEl.className = "fa fa-refresh";
-      }
-      const labelEl = generateBtn.querySelector('[data-i18n="generateReportButton"]');
-      if (labelEl && typeof chrome !== "undefined" && chrome.i18n && chrome.i18n.getMessage) {
-        labelEl.textContent = chrome.i18n.getMessage("generateReportButton");
-      }
-      generateBtn.disabled = false;
-    }
-  };
+		// Reset the Generate button so the user can try again later
+		const generateBtn = document.getElementById('generateReport');
+		if (generateBtn) {
+			const iconEl = generateBtn.querySelector('i');
+			if (iconEl) {
+				iconEl.className = 'fa fa-refresh';
+			}
+			const labelEl = generateBtn.querySelector('[data-i18n="generateReportButton"]');
+			if (labelEl && typeof chrome !== 'undefined' && chrome.i18n && chrome.i18n.getMessage) {
+				labelEl.textContent = chrome.i18n.getMessage('generateReportButton');
+			}
+			generateBtn.disabled = false;
+		}
+	};
 
-  // GitHub — "Add GitHub Token" → navigate to settings, focus token input
-  const rateLimitAddTokenBtn = document.getElementById("rateLimitAddToken");
-  if (rateLimitAddTokenBtn) {
-    rateLimitAddTokenBtn.addEventListener("click", () => {
-      showSettingsView();
-      const tokenInput = document.getElementById("githubToken");
-      if (tokenInput) {
-        setTimeout(() => {
-          tokenInput.scrollIntoView({ behavior: "smooth", block: "center" });
-          tokenInput.focus();
-          tokenInput.style.borderColor = "#ca8a04";
-          tokenInput.style.boxShadow = "0 0 0 2px #fde047";
-          setTimeout(() => {
-            tokenInput.style.borderColor = "";
-            tokenInput.style.boxShadow = "";
-          }, 3000);
-        }, 100);
-      }
-    });
-  }
+	// GitHub — "Add GitHub Token" → navigate to settings, focus token input
+	const rateLimitAddTokenBtn = document.getElementById('rateLimitAddToken');
+	if (rateLimitAddTokenBtn) {
+		rateLimitAddTokenBtn.addEventListener('click', () => {
+			showSettingsView();
+			const tokenInput = document.getElementById('githubToken');
+			if (tokenInput) {
+				setTimeout(() => {
+					tokenInput.scrollIntoView({ behavior: 'smooth', block: 'center' });
+					tokenInput.focus();
+					tokenInput.style.borderColor = '#ca8a04';
+					tokenInput.style.boxShadow = '0 0 0 2px #fde047';
+					setTimeout(() => {
+						tokenInput.style.borderColor = '';
+						tokenInput.style.boxShadow = '';
+					}, 3000);
+				}, 100);
+			}
+		});
+	}
 
-  // Dismiss buttons — hide their closest rate-limit banner
-  document
-    .querySelectorAll("#rateLimitDismiss, #rateLimitDismissGitlab")
-    .forEach((btn) => {
-      btn.addEventListener("click", () => {
-        btn.closest(".rate-limit-banner").classList.add("hidden");
-      });
-    });
+	// Dismiss buttons — hide their closest rate-limit banner
+	document.querySelectorAll('#rateLimitDismiss, #rateLimitDismissGitlab').forEach((btn) => {
+		btn.addEventListener('click', () => {
+			btn.closest('.rate-limit-banner').classList.add('hidden');
+		});
+	});
 
-  // GitLab — "Add GitLab Token" → navigate to settings, focus token input
-  const rateLimitAddTokenGitlabBtn = document.getElementById(
-    "rateLimitAddTokenGitlab",
-  );
-  if (rateLimitAddTokenGitlabBtn) {
-    rateLimitAddTokenGitlabBtn.addEventListener("click", () => {
-      showSettingsView();
-      // Ensure the GitLab section is visible
-      const gitlabSection = document.querySelector(".gitlabOnlySection");
-      if (gitlabSection) gitlabSection.classList.remove("hidden");
+	// GitLab — "Add GitLab Token" → navigate to settings, focus token input
+	const rateLimitAddTokenGitlabBtn = document.getElementById('rateLimitAddTokenGitlab');
+	if (rateLimitAddTokenGitlabBtn) {
+		rateLimitAddTokenGitlabBtn.addEventListener('click', () => {
+			showSettingsView();
+			// Ensure the GitLab section is visible
+			const gitlabSection = document.querySelector('.gitlabOnlySection');
+			if (gitlabSection) gitlabSection.classList.remove('hidden');
 
-      const tokenInput = document.getElementById("gitlabToken");
-      if (tokenInput) {
-        setTimeout(() => {
-          tokenInput.scrollIntoView({ behavior: "smooth", block: "center" });
-          tokenInput.focus();
-          tokenInput.style.borderColor = "#ea580c";
-          tokenInput.style.boxShadow = "0 0 0 2px #fdba74";
-          setTimeout(() => {
-            tokenInput.style.borderColor = "";
-            tokenInput.style.boxShadow = "";
-          }, 3000);
-        }, 100);
-      }
-    });
-  }
+			const tokenInput = document.getElementById('gitlabToken');
+			if (tokenInput) {
+				setTimeout(() => {
+					tokenInput.scrollIntoView({ behavior: 'smooth', block: 'center' });
+					tokenInput.focus();
+					tokenInput.style.borderColor = '#ea580c';
+					tokenInput.style.boxShadow = '0 0 0 2px #fdba74';
+					setTimeout(() => {
+						tokenInput.style.borderColor = '';
+						tokenInput.style.boxShadow = '';
+					}, 3000);
+				}, 100);
+			}
+		});
+	}
 
-  showReportView();
+	showReportView();
 
-  //report filter
-  const repoSearch = document.getElementById("repoSearch");
-  const repoDropdown = document.getElementById("repoDropdown");
-  const selectedReposDiv = document.getElementById("selectedRepos");
-  const repoTags = document.getElementById("repoTags");
-  const repoPlaceholder = document.getElementById("repoPlaceholder");
-  const repoCount = document.getElementById("repoCount");
-  const repoStatus = document.getElementById("repoStatus");
-  const useRepoFilter = document.getElementById("useRepoFilter");
-  const repoFilterContainer = document.getElementById("repoFilterContainer");
+	//report filter
+	const repoSearch = document.getElementById('repoSearch');
+	const repoDropdown = document.getElementById('repoDropdown');
+	const selectedReposDiv = document.getElementById('selectedRepos');
+	const repoTags = document.getElementById('repoTags');
+	const repoPlaceholder = document.getElementById('repoPlaceholder');
+	const repoCount = document.getElementById('repoCount');
+	const repoStatus = document.getElementById('repoStatus');
+	const useRepoFilter = document.getElementById('useRepoFilter');
+	const repoFilterContainer = document.getElementById('repoFilterContainer');
 
 	if (repoSearch && useRepoFilter && repoFilterContainer) {
 		repoSearch.addEventListener('click', () => {
@@ -1225,12 +1258,12 @@ document.addEventListener('DOMContentLoaded', () => {
 		});
 	}
 
-  if (!repoSearch || !useRepoFilter) {
-    console.log("Repository, filter elements not found in DOM");
-  } else {
-    let availableRepos = [];
-    let selectedRepos = [];
-    let highlightedIndex = -1;
+	if (!repoSearch || !useRepoFilter) {
+		console.log('Repository, filter elements not found in DOM');
+	} else {
+		let availableRepos = [];
+		let selectedRepos = [];
+		let highlightedIndex = -1;
 
 		async function triggerRepoFetchIfEnabled() {
 			// --- PLATFORM CHECK: Only run for GitHub ---
@@ -1241,7 +1274,9 @@ document.addEventListener('DOMContentLoaded', () => {
 			} catch {}
 			if (platform !== 'github') {
 				// Do not run repo fetch for non-GitHub platforms
-				if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('repoFilteringGithubOnly') || 'Repository filtering is only available for GitHub.';
+				if (repoStatus)
+					repoStatus.textContent =
+						chrome?.i18n.getMessage('repoFilteringGithubOnly') || 'Repository filtering is only available for GitHub.';
 				return;
 			}
 			if (!useRepoFilter.checked) {
@@ -1262,9 +1297,9 @@ document.addEventListener('DOMContentLoaded', () => {
 					'orgName',
 				]);
 
-        const platform = items.platform || "github";
-        const platformUsernameKey = `${platform}Username`;
-        const username = items[platformUsernameKey];
+				const platform = items.platform || 'github';
+				const platformUsernameKey = `${platform}Username`;
+				const username = items[platformUsernameKey];
 
 				if (!username) {
 					if (repoStatus) {
@@ -1273,14 +1308,10 @@ document.addEventListener('DOMContentLoaded', () => {
 					return;
 				}
 
-        if (window.fetchUserRepositories) {
-          const repos = await window.fetchUserRepositories(
-            username,
-            items.githubToken,
-            items.orgName || "",
-          );
+				if (window.fetchUserRepositories) {
+					const repos = await window.fetchUserRepositories(username, items.githubToken, items.orgName || '');
 
-          availableRepos = repos;
+					availableRepos = repos;
 
 					if (repoStatus) {
 						repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [repos.length]);
@@ -1310,7 +1341,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		}
 
-    window.triggerRepoFetchIfEnabled = triggerRepoFetchIfEnabled;
+		window.triggerRepoFetchIfEnabled = triggerRepoFetchIfEnabled;
 
 		browser.storage.local.get(['selectedRepos', 'useRepoFilter']).then((items) => {
 			if (items.selectedRepos) {
@@ -1334,7 +1365,10 @@ document.addEventListener('DOMContentLoaded', () => {
 				if (platform !== 'github') {
 					repoFilterContainer.classList.add('hidden');
 					useRepoFilter.checked = false;
-					if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('repoFilteringGithubOnly') || 'Repository filtering is only available for GitHub.';
+					if (repoStatus)
+						repoStatus.textContent =
+							chrome?.i18n.getMessage('repoFilteringGithubOnly') ||
+							'Repository filtering is only available for GitHub.';
 					return;
 				}
 				const enabled = useRepoFilter.checked;
@@ -1364,7 +1398,8 @@ document.addEventListener('DOMContentLoaded', () => {
 				});
 				checkTokenForFilter();
 				if (enabled) {
-					repoStatus.textContent = chrome?.i18n.getMessage('loadingReposAutomatically') || 'Loading repos automatically...';
+					repoStatus.textContent =
+						chrome?.i18n.getMessage('loadingReposAutomatically') || 'Loading repos automatically...';
 
 					try {
 						const cacheData = await browser.storage.local.get(['repoCache']);
@@ -1376,37 +1411,37 @@ document.addEventListener('DOMContentLoaded', () => {
 							'orgName',
 						]);
 
-            const platform = items.platform || "github";
-            const platformUsernameKey = `${platform}Username`;
-            const username = items[platformUsernameKey];
+						const platform = items.platform || 'github';
+						const platformUsernameKey = `${platform}Username`;
+						const username = items[platformUsernameKey];
 
 						if (!username) {
 							repoStatus.textContent = chrome?.i18n.getMessage('usernameMissingError') || 'Username required';
 							return;
 						}
 
-            const repoCacheKey = `repos-${username}-${items.orgName || ""}`;
+						const repoCacheKey = `repos-${username}-${items.orgName || ''}`;
 
-            const now = Date.now();
-            const cacheAge = cacheData.repoCache?.timestamp
-              ? now - cacheData.repoCache.timestamp
-              : Number.POSITIVE_INFINITY;
-            const cacheTTL = 10 * 60 * 1000; // 10 minutes
+						const now = Date.now();
+						const cacheAge = cacheData.repoCache?.timestamp
+							? now - cacheData.repoCache.timestamp
+							: Number.POSITIVE_INFINITY;
+						const cacheTTL = 10 * 60 * 1000; // 10 minutes
 
 						if (cacheData.repoCache && cacheData.repoCache.cacheKey === repoCacheKey && cacheAge < cacheTTL) {
 							console.log('Using cached repositories');
 							availableRepos = cacheData.repoCache.data;
 							repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [availableRepos.length]);
 
-              if (document.activeElement === repoSearch) {
-                filterAndDisplayRepos(repoSearch.value.toLowerCase());
-              }
-              return;
-            }
+							if (document.activeElement === repoSearch) {
+								filterAndDisplayRepos(repoSearch.value.toLowerCase());
+							}
+							return;
+						}
 
-            if (window.fetchUserRepositories) {
-              const repos = await window.fetchUserRepositories(
-                username,
+						if (window.fetchUserRepositories) {
+							const repos = await window.fetchUserRepositories(
+								username,
 
 								items.githubToken,
 								items.orgName || '',
@@ -1422,12 +1457,12 @@ document.addEventListener('DOMContentLoaded', () => {
 								},
 							});
 
-              if (document.activeElement === repoSearch) {
-                filterAndDisplayRepos(repoSearch.value.toLowerCase());
-              }
-            }
-          } catch (err) {
-            console.error("Auto load repos failed", err);
+							if (document.activeElement === repoSearch) {
+								filterAndDisplayRepos(repoSearch.value.toLowerCase());
+							}
+						}
+					} catch (err) {
+						console.error('Auto load repos failed', err);
 
 						if (err.message?.includes('401')) {
 							repoStatus.textContent = browser.i18n.getMessage('repoTokenPrivate');
@@ -1446,54 +1481,51 @@ document.addEventListener('DOMContentLoaded', () => {
 			}, 300),
 		);
 
-    repoSearch.addEventListener("keydown", (e) => {
-      const items = repoDropdown.querySelectorAll(".repository-dropdown-item");
+		repoSearch.addEventListener('keydown', (e) => {
+			const items = repoDropdown.querySelectorAll('.repository-dropdown-item');
 
-      switch (e.key) {
-        case "ArrowDown":
-          e.preventDefault();
-          highlightedIndex = Math.min(highlightedIndex + 1, items.length - 1);
-          updateHighlight(items);
-          break;
-        case "ArrowUp":
-          e.preventDefault();
-          highlightedIndex = Math.max(highlightedIndex - 1, 0);
-          updateHighlight(items);
-          break;
-        case "Enter":
-          e.preventDefault();
-          if (highlightedIndex >= 0 && items[highlightedIndex]) {
-            fnSelectedRepos(items[highlightedIndex].dataset.repoName);
-          }
-          break;
-        case "Escape":
-          hideDropdown();
-          break;
-      }
-    });
+			switch (e.key) {
+				case 'ArrowDown':
+					e.preventDefault();
+					highlightedIndex = Math.min(highlightedIndex + 1, items.length - 1);
+					updateHighlight(items);
+					break;
+				case 'ArrowUp':
+					e.preventDefault();
+					highlightedIndex = Math.max(highlightedIndex - 1, 0);
+					updateHighlight(items);
+					break;
+				case 'Enter':
+					e.preventDefault();
+					if (highlightedIndex >= 0 && items[highlightedIndex]) {
+						fnSelectedRepos(items[highlightedIndex].dataset.repoName);
+					}
+					break;
+				case 'Escape':
+					hideDropdown();
+					break;
+			}
+		});
 
-    repoSearch.addEventListener("input", (e) => {
-      const query = e.target.value.toLowerCase();
-      filterAndDisplayRepos(query);
-    });
-    let programmaticFocus = false;
-    repoSearch.addEventListener("focus", () => {
-      if (programmaticFocus) {
-        programmaticFocus = false;
-        return;
-      }
-      const searchTerm = repoSearch.value.toLowerCase();
-      filterAndDisplayRepos(searchTerm);
-    });
+		repoSearch.addEventListener('input', (e) => {
+			const query = e.target.value.toLowerCase();
+			filterAndDisplayRepos(query);
+		});
+		let programmaticFocus = false;
+		repoSearch.addEventListener('focus', () => {
+			if (programmaticFocus) {
+				programmaticFocus = false;
+				return;
+			}
+			const searchTerm = repoSearch.value.toLowerCase();
+			filterAndDisplayRepos(searchTerm);
+		});
 
-    document.addEventListener("click", (e) => {
-      if (
-        !e.target.closest("#repoSearch") &&
-        !e.target.closest("#repoDropdown")
-      ) {
-        hideDropdown();
-      }
-    });
+		document.addEventListener('click', (e) => {
+			if (!e.target.closest('#repoSearch') && !e.target.closest('#repoDropdown')) {
+				hideDropdown();
+			}
+		});
 
 		function debugRepoFetch() {
 			browser.storage.local.get(['platform', 'githubUsername', 'githubToken', 'orgName']).then((items) => {
@@ -1516,7 +1548,9 @@ document.addEventListener('DOMContentLoaded', () => {
 				platform = items.platform || 'github';
 			} catch {}
 			if (platform !== 'github') {
-				if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('repoLoadingGithubOnly') || 'Repository loading is only available for GitHub.';
+				if (repoStatus)
+					repoStatus.textContent =
+						chrome?.i18n.getMessage('repoLoadingGithubOnly') || 'Repository loading is only available for GitHub.';
 				return;
 			}
 			console.log('window.fetchUserRepositories exists:', !!window.fetchUserRepositories);
@@ -1525,10 +1559,10 @@ document.addEventListener('DOMContentLoaded', () => {
 				Object.keys(window).filter((key) => key.includes('fetch')),
 			);
 
-      if (!window.fetchUserRepositories) {
-        repoStatus.textContent = "Repository fetching not available";
-        return;
-      }
+			if (!window.fetchUserRepositories) {
+				repoStatus.textContent = 'Repository fetching not available';
+				return;
+			}
 
 			browser.storage.local.get(['platform', 'githubUsername', 'githubToken']).then((items) => {
 				const platform = items.platform || 'github';
@@ -1545,10 +1579,9 @@ document.addEventListener('DOMContentLoaded', () => {
 					return;
 				}
 
-          performRepoFetch();
-        },
-      );
-    }
+				performRepoFetch();
+			});
+		}
 
 		async function performRepoFetch() {
 			let platform = 'github';
@@ -1557,7 +1590,9 @@ document.addEventListener('DOMContentLoaded', () => {
 				platform = items.platform || 'github';
 			} catch (e) {}
 			if (platform !== 'github') {
-				if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('repoFetchingGithubOnly') || 'Repository fetching is only available for GitHub.';
+				if (repoStatus)
+					repoStatus.textContent =
+						chrome?.i18n.getMessage('repoFetchingGithubOnly') || 'Repository fetching is only available for GitHub.';
 				return;
 			}
 			console.log('[POPUP-DEBUG] performRepoFetch called.');
@@ -1583,27 +1618,27 @@ document.addEventListener('DOMContentLoaded', () => {
 					: Number.POSITIVE_INFINITY;
 				const cacheTTL = 10 * 60 * 1000; // 10 minutes
 
-        console.log("[POPUP-DEBUG] Repo cache check:", {
-          key: repoCacheKey,
-          cacheKeyInCache: cacheData.repoCache?.cacheKey,
-          isMatch: cacheData.repoCache?.cacheKey === repoCacheKey,
-          age: cacheAge,
-          isFresh: cacheAge < cacheTTL,
-        });
+				console.log('[POPUP-DEBUG] Repo cache check:', {
+					key: repoCacheKey,
+					cacheKeyInCache: cacheData.repoCache?.cacheKey,
+					isMatch: cacheData.repoCache?.cacheKey === repoCacheKey,
+					age: cacheAge,
+					isFresh: cacheAge < cacheTTL,
+				});
 
 				if (cacheData.repoCache && cacheData.repoCache.cacheKey === repoCacheKey && cacheAge < cacheTTL) {
 					console.log('[POPUP-DEBUG] Using cached repositories in manual fetch');
 					availableRepos = cacheData.repoCache.data;
 					repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [availableRepos.length]);
 
-          if (document.activeElement === repoSearch) {
-            filterAndDisplayRepos(repoSearch.value.toLowerCase());
-          }
-          return;
-        }
-        console.log("[POPUP-DEBUG] No valid cache. Fetching from network.");
-        availableRepos = await window.fetchUserRepositories(
-          username,
+					if (document.activeElement === repoSearch) {
+						filterAndDisplayRepos(repoSearch.value.toLowerCase());
+					}
+					return;
+				}
+				console.log('[POPUP-DEBUG] No valid cache. Fetching from network.');
+				availableRepos = await window.fetchUserRepositories(
+					username,
 
 					storageItems.githubToken,
 					storageItems.orgName || '',
@@ -1619,11 +1654,11 @@ document.addEventListener('DOMContentLoaded', () => {
 					},
 				});
 
-        if (document.activeElement === repoSearch) {
-          filterAndDisplayRepos(repoSearch.value.toLowerCase());
-        }
-      } catch (err) {
-        console.error(`Failed to load repos:`, err);
+				if (document.activeElement === repoSearch) {
+					filterAndDisplayRepos(repoSearch.value.toLowerCase());
+				}
+			} catch (err) {
+				console.error(`Failed to load repos:`, err);
 
 				if (err.message && err.message.includes('401')) {
 					repoStatus.textContent = browser.i18n.getMessage('repoTokenPrivate');
@@ -1644,18 +1679,15 @@ document.addEventListener('DOMContentLoaded', () => {
 				return;
 			}
 
-      const filtered = availableRepos.filter((repo) => {
-        if (selectedRepos.includes(repo.fullName)) {
-          return false;
-        }
-        if (!query) {
-          return true;
-        }
-        return (
-          repo.name.toLowerCase().includes(query) ||
-          repo.description?.toLowerCase().includes(query)
-        );
-      });
+			const filtered = availableRepos.filter((repo) => {
+				if (selectedRepos.includes(repo.fullName)) {
+					return false;
+				}
+				if (!query) {
+					return true;
+				}
+				return repo.name.toLowerCase().includes(query) || repo.description?.toLowerCase().includes(query);
+			});
 
 			if (filtered.length === 0) {
 				repoDropdown.innerHTML = `<div class="p-3 text-center text-gray-500 text-sm" style="padding-left: 10px; ">${browser.i18n.getMessage('repoNotFound')}</div>`;
@@ -1667,52 +1699,50 @@ document.addEventListener('DOMContentLoaded', () => {
                     <div class="repository-dropdown-item" data-repo-name="${repo.fullName}">
                         <div class="repo-name">
                             <span>${repo.name}</span>
-                            ${repo.language ? `<span class="repo-language">${repo.language}</span>` : ""}
-                            ${repo.stars ? `<span class="repo-stars"><i class="fa fa-star"></i> ${repo.stars}</span>` : ""}
+                            ${repo.language ? `<span class="repo-language">${repo.language}</span>` : ''}
+                            ${repo.stars ? `<span class="repo-stars"><i class="fa fa-star"></i> ${repo.stars}</span>` : ''}
                         </div>
                         <div class="repo-info">
-                            ${repo.description ? `<span class="repo-desc">${repo.description.substring(0, 50)}${repo.description.length > 50 ? "..." : ""}</span>` : ""}
+                            ${repo.description ? `<span class="repo-desc">${repo.description.substring(0, 50)}${repo.description.length > 50 ? '...' : ''}</span>` : ''}
                         </div>
                     </div>
                 `,
-          )
-          .join("");
+					)
+					.join('');
 
-        repoDropdown
-          .querySelectorAll(".repository-dropdown-item")
-          .forEach((item) => {
-            item.addEventListener("click", (e) => {
-              e.stopPropagation();
-              fnSelectedRepos(item.dataset.repoName);
-            });
-          });
-      }
-      highlightedIndex = -1;
-      showDropdown();
-    }
+				repoDropdown.querySelectorAll('.repository-dropdown-item').forEach((item) => {
+					item.addEventListener('click', (e) => {
+						e.stopPropagation();
+						fnSelectedRepos(item.dataset.repoName);
+					});
+				});
+			}
+			highlightedIndex = -1;
+			showDropdown();
+		}
 
-    function fnSelectedRepos(repoFullName) {
-      if (!selectedRepos.includes(repoFullName)) {
-        selectedRepos.push(repoFullName);
-        updateRepoDisplay();
-        saveRepoSelection();
-      }
+		function fnSelectedRepos(repoFullName) {
+			if (!selectedRepos.includes(repoFullName)) {
+				selectedRepos.push(repoFullName);
+				updateRepoDisplay();
+				saveRepoSelection();
+			}
 
-      repoSearch.value = "";
-      filterAndDisplayRepos("");
-      programmaticFocus = true;
-      repoSearch.focus();
-    }
+			repoSearch.value = '';
+			filterAndDisplayRepos('');
+			programmaticFocus = true;
+			repoSearch.focus();
+		}
 
-    function removeRepo(repoFullName) {
-      selectedRepos = selectedRepos.filter((name) => name !== repoFullName);
-      updateRepoDisplay();
-      saveRepoSelection();
+		function removeRepo(repoFullName) {
+			selectedRepos = selectedRepos.filter((name) => name !== repoFullName);
+			updateRepoDisplay();
+			saveRepoSelection();
 
-      if (repoSearch.value) {
-        filterAndDisplayRepos(repoSearch.value.toLowerCase());
-      }
-    }
+			if (repoSearch.value) {
+				filterAndDisplayRepos(repoSearch.value.toLowerCase());
+			}
+		}
 
 		function updateRepoDisplay() {
 			if (selectedRepos.length === 0) {
@@ -1751,26 +1781,26 @@ document.addEventListener('DOMContentLoaded', () => {
 			});
 		}
 
-    function showDropdown() {
-      repoDropdown.classList.remove("hidden");
-    }
+		function showDropdown() {
+			repoDropdown.classList.remove('hidden');
+		}
 
-    function hideDropdown() {
-      repoDropdown.classList.add("hidden");
-      highlightedIndex = -1;
-    }
+		function hideDropdown() {
+			repoDropdown.classList.add('hidden');
+			highlightedIndex = -1;
+		}
 
-    function updateHighlight(items) {
-      items.forEach((item, index) => {
-        item.classList.toggle("highlighted", index === highlightedIndex);
-      });
+		function updateHighlight(items) {
+			items.forEach((item, index) => {
+				item.classList.toggle('highlighted', index === highlightedIndex);
+			});
 
-      if (highlightedIndex >= 0 && items[highlightedIndex]) {
-        items[highlightedIndex].scrollIntoView({ block: "nearest" });
-      }
-    }
+			if (highlightedIndex >= 0 && items[highlightedIndex]) {
+				items[highlightedIndex].scrollIntoView({ block: 'nearest' });
+			}
+		}
 
-    window.removeRepo = removeRepo;
+		window.removeRepo = removeRepo;
 
 		browser.storage.local.get(['platform', 'githubUsername']).then((items) => {
 			const platform = items.platform || 'github';
@@ -1783,7 +1813,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 });
 
-const cacheInput = document.getElementById("cacheInput");
+const cacheInput = document.getElementById('cacheInput');
 if (cacheInput) {
 	browser.storage.local.get(['cacheInput']).then((result) => {
 		if (result.cacheInput) {
@@ -1793,19 +1823,19 @@ if (cacheInput) {
 		}
 	});
 
-  cacheInput.addEventListener("blur", function () {
-    let ttlValue = Number.parseInt(this.value, 10);
-    if (Number.isNaN(ttlValue) || ttlValue <= 0 || this.value.trim() === "") {
-      ttlValue = 10;
-      this.value = ttlValue;
-      this.style.borderColor = "#ef4444";
-    } else if (ttlValue > 1440) {
-      ttlValue = 1440;
-      this.value = ttlValue;
-      this.style.borderColor = "#f59e0b";
-    } else {
-      this.style.borderColor = "#10b981";
-    }
+	cacheInput.addEventListener('blur', function () {
+		let ttlValue = Number.parseInt(this.value, 10);
+		if (Number.isNaN(ttlValue) || ttlValue <= 0 || this.value.trim() === '') {
+			ttlValue = 10;
+			this.value = ttlValue;
+			this.style.borderColor = '#ef4444';
+		} else if (ttlValue > 1440) {
+			ttlValue = 1440;
+			this.value = ttlValue;
+			this.style.borderColor = '#f59e0b';
+		} else {
+			this.style.borderColor = '#10b981';
+		}
 
 		browser.storage.local.set({ cacheInput: ttlValue }).then(() => {
 			console.log('Cache TTL saved:', ttlValue, 'minutes');
@@ -1835,30 +1865,30 @@ function updatePlatformUI(platform) {
 		}
 	}
 
-  const orgSection = document.querySelector(".orgSection");
-  if (orgSection) {
-    if (platform === "gitlab") {
-      orgSection.classList.add("hidden");
-    } else {
-      orgSection.classList.remove("hidden");
-    }
-  }
-  const githubOnlySections = document.querySelectorAll(".githubOnlySection");
-  githubOnlySections.forEach((el) => {
-    if (platform === "gitlab") {
-      el.classList.add("hidden");
-    } else {
-      el.classList.remove("hidden");
-    }
-  });
-  const gitlabOnlySections = document.querySelectorAll(".gitlabOnlySection");
-  gitlabOnlySections.forEach((el) => {
-    if (platform === "github") {
-      el.classList.add("hidden");
-    } else {
-      el.classList.remove("hidden");
-    }
-  });
+	const orgSection = document.querySelector('.orgSection');
+	if (orgSection) {
+		if (platform === 'gitlab') {
+			orgSection.classList.add('hidden');
+		} else {
+			orgSection.classList.remove('hidden');
+		}
+	}
+	const githubOnlySections = document.querySelectorAll('.githubOnlySection');
+	githubOnlySections.forEach((el) => {
+		if (platform === 'gitlab') {
+			el.classList.add('hidden');
+		} else {
+			el.classList.remove('hidden');
+		}
+	});
+	const gitlabOnlySections = document.querySelectorAll('.gitlabOnlySection');
+	gitlabOnlySections.forEach((el) => {
+		if (platform === 'github') {
+			el.classList.add('hidden');
+		} else {
+			el.classList.remove('hidden');
+		}
+	});
 }
 
 platformSelect.addEventListener('change', () => {
@@ -1888,33 +1918,30 @@ platformSelect.addEventListener('change', () => {
 		}
 	});
 
-  updatePlatformUI(platform);
+	updatePlatformUI(platform);
 });
 
-const customDropdown = document.getElementById("customPlatformDropdown");
-const dropdownBtn = document.getElementById("platformDropdownBtn");
-const dropdownList = document.getElementById("platformDropdownList");
-const dropdownSelected = document.getElementById("platformDropdownSelected");
-const platformSelectHidden = document.getElementById("platformSelect");
+const customDropdown = document.getElementById('customPlatformDropdown');
+const dropdownBtn = document.getElementById('platformDropdownBtn');
+const dropdownList = document.getElementById('platformDropdownList');
+const dropdownSelected = document.getElementById('platformDropdownSelected');
+const platformSelectHidden = document.getElementById('platformSelect');
 
 function buildScrumSubjectFromPopup() {
-  const projectName =
-    document.getElementById("projectName")?.value?.trim() || "";
-  const now = new Date();
-  const dateCode =
-    String(now.getFullYear()) +
-    String(now.getMonth() + 1).padStart(2, "0") +
-    String(now.getDate()).padStart(2, "0");
+	const projectName = document.getElementById('projectName')?.value?.trim() || '';
+	const now = new Date();
+	const dateCode =
+		String(now.getFullYear()) + String(now.getMonth() + 1).padStart(2, '0') + String(now.getDate()).padStart(2, '0');
 
-  return `[Scrum]${projectName ? " - " + projectName : ""} - ${dateCode}`;
+	return `[Scrum]${projectName ? ' - ' + projectName : ''} - ${dateCode}`;
 }
 
 function setPlatformDropdown(value) {
-  if (value === "gitlab") {
-    dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
-  } else {
-    dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
-  }
+	if (value === 'gitlab') {
+		dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
+	} else {
+		dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
+	}
 
 	const platformUsername = document.getElementById('platformUsername');
 	if (platformUsername) {
@@ -1942,19 +1969,19 @@ function setPlatformDropdown(value) {
 		}
 	});
 
-  updatePlatformUI(value);
+	updatePlatformUI(value);
 }
 
-dropdownBtn.addEventListener("click", (e) => {
-  e.stopPropagation();
-  customDropdown.classList.toggle("open");
-  dropdownList.classList.toggle("hidden");
+dropdownBtn.addEventListener('click', (e) => {
+	e.stopPropagation();
+	customDropdown.classList.toggle('open');
+	dropdownList.classList.toggle('hidden');
 });
 
-dropdownList.querySelectorAll("li").forEach((item) => {
-  item.addEventListener("click", function (e) {
-    const newPlatform = this.getAttribute("data-value");
-    const currentPlatform = platformSelectHidden.value;
+dropdownList.querySelectorAll('li').forEach((item) => {
+	item.addEventListener('click', function (e) {
+		const newPlatform = this.getAttribute('data-value');
+		const currentPlatform = platformSelectHidden.value;
 
 		if (newPlatform !== currentPlatform) {
 			const platformUsername = document.getElementById('platformUsername');
@@ -1966,41 +1993,41 @@ dropdownList.querySelectorAll("li").forEach((item) => {
 			}
 		}
 
-    setPlatformDropdown(newPlatform);
-    customDropdown.classList.remove("open");
-    dropdownList.classList.add("hidden");
-  });
+		setPlatformDropdown(newPlatform);
+		customDropdown.classList.remove('open');
+		dropdownList.classList.add('hidden');
+	});
 });
 
-document.addEventListener("click", (e) => {
-  if (!customDropdown.contains(e.target)) {
-    customDropdown.classList.remove("open");
-    dropdownList.classList.add("hidden");
-  }
+document.addEventListener('click', (e) => {
+	if (!customDropdown.contains(e.target)) {
+		customDropdown.classList.remove('open');
+		dropdownList.classList.add('hidden');
+	}
 });
 
 // Keyboard navigation
-platformDropdownBtn.addEventListener("keydown", (e) => {
-  if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
-    e.preventDefault();
-    customDropdown.classList.add("open");
-    dropdownList.classList.remove("hidden");
-    dropdownList.querySelector("li").focus();
-  }
+platformDropdownBtn.addEventListener('keydown', (e) => {
+	if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+		e.preventDefault();
+		customDropdown.classList.add('open');
+		dropdownList.classList.remove('hidden');
+		dropdownList.querySelector('li').focus();
+	}
 });
-dropdownList.querySelectorAll("li").forEach((item, idx, arr) => {
-  item.setAttribute("tabindex", "0");
-  item.addEventListener("keydown", function (e) {
-    if (e.key === "ArrowDown") {
-      e.preventDefault();
-      (arr[idx + 1] || arr[0]).focus();
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      (arr[idx - 1] || arr[arr.length - 1]).focus();
-    } else if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      const newPlatform = this.getAttribute("data-value");
-      const currentPlatform = platformSelectHidden.value;
+dropdownList.querySelectorAll('li').forEach((item, idx, arr) => {
+	item.setAttribute('tabindex', '0');
+	item.addEventListener('keydown', function (e) {
+		if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			(arr[idx + 1] || arr[0]).focus();
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			(arr[idx - 1] || arr[arr.length - 1]).focus();
+		} else if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			const newPlatform = this.getAttribute('data-value');
+			const currentPlatform = platformSelectHidden.value;
 
 			// Save current username for current platform before switching
 			if (newPlatform !== currentPlatform) {
@@ -2013,12 +2040,12 @@ dropdownList.querySelectorAll("li").forEach((item, idx, arr) => {
 				}
 			}
 
-      setPlatformDropdown(newPlatform);
-      customDropdown.classList.remove("open");
-      dropdownList.classList.add("hidden");
-      dropdownBtn.focus();
-    }
-  });
+			setPlatformDropdown(newPlatform);
+			customDropdown.classList.remove('open');
+			dropdownList.classList.add('hidden');
+			dropdownBtn.focus();
+		}
+	});
 });
 
 // On load, restore platform from storage
@@ -2035,56 +2062,56 @@ browser.storage.local.get(['platform']).then((result) => {
 });
 
 // Tooltip bubble
-document.querySelectorAll(".tooltip-container").forEach((container) => {
-  const bubble = container.querySelector(".tooltip-bubble");
-  if (!bubble) return;
+document.querySelectorAll('.tooltip-container').forEach((container) => {
+	const bubble = container.querySelector('.tooltip-bubble');
+	if (!bubble) return;
 
-  function positionTooltip() {
-    const icon = container.querySelector(".question-icon") || container;
-    const rect = icon.getBoundingClientRect();
-    const bubbleRect = bubble.getBoundingClientRect();
-    const padding = 8;
+	function positionTooltip() {
+		const icon = container.querySelector('.question-icon') || container;
+		const rect = icon.getBoundingClientRect();
+		const bubbleRect = bubble.getBoundingClientRect();
+		const padding = 8;
 
-    let top = rect.top + window.scrollY;
-    let left = rect.right + padding + window.scrollX;
+		let top = rect.top + window.scrollY;
+		let left = rect.right + padding + window.scrollX;
 
-    if (left + bubbleRect.width > window.innerWidth - 10) {
-      left = rect.left - bubbleRect.width - padding + window.scrollX;
-    }
-    if (left < 8) left = 8;
-    if (top + bubbleRect.height > window.innerHeight - 10) {
-      top = rect.top - bubbleRect.height - padding + window.scrollY;
-    }
-    if (top < 8) top = 8;
+		if (left + bubbleRect.width > window.innerWidth - 10) {
+			left = rect.left - bubbleRect.width - padding + window.scrollX;
+		}
+		if (left < 8) left = 8;
+		if (top + bubbleRect.height > window.innerHeight - 10) {
+			top = rect.top - bubbleRect.height - padding + window.scrollY;
+		}
+		if (top < 8) top = 8;
 
-    bubble.style.left = left + "px";
-    bubble.style.top = top + "px";
-  }
+		bubble.style.left = left + 'px';
+		bubble.style.top = top + 'px';
+	}
 
-  container.addEventListener("mouseenter", positionTooltip);
-  container.addEventListener("focusin", positionTooltip);
-  container.addEventListener("mousemove", positionTooltip);
-  container.addEventListener("mouseleave", () => {
-    bubble.style.left = "";
-    bubble.style.top = "";
-  });
-  container.addEventListener("focusout", () => {
-    bubble.style.left = "";
-    bubble.style.top = "";
-  });
+	container.addEventListener('mouseenter', positionTooltip);
+	container.addEventListener('focusin', positionTooltip);
+	container.addEventListener('mousemove', positionTooltip);
+	container.addEventListener('mouseleave', () => {
+		bubble.style.left = '';
+		bubble.style.top = '';
+	});
+	container.addEventListener('focusout', () => {
+		bubble.style.left = '';
+		bubble.style.top = '';
+	});
 });
 
 // Radio button click handlers with toggle functionality
 document.querySelectorAll('input[name="timeframe"]').forEach((radio) => {
-  radio.addEventListener("click", function () {
-    if (this.dataset.wasChecked === "true") {
-      this.checked = false;
-      this.dataset.wasChecked = "false";
+	radio.addEventListener('click', function () {
+		if (this.dataset.wasChecked === 'true') {
+			this.checked = false;
+			this.dataset.wasChecked = 'false';
 
-      const startDateInput = document.getElementById("startingDate");
-      const endDateInput = document.getElementById("endingDate");
-      startDateInput.readOnly = false;
-      endDateInput.readOnly = false;
+			const startDateInput = document.getElementById('startingDate');
+			const endDateInput = document.getElementById('endingDate');
+			startDateInput.readOnly = false;
+			endDateInput.readOnly = false;
 
 			browser.storage.local.set({
 				yesterdayContribution: false,
@@ -2121,10 +2148,8 @@ document.querySelectorAll('input[name="timeframe"]').forEach((radio) => {
 
 // refresh cache button
 
-document
-  .getElementById("refreshCache")
-  .addEventListener("click", async function () {
-    const originalText = this.innerHTML;
+document.getElementById('refreshCache').addEventListener('click', async function () {
+	const originalText = this.innerHTML;
 
 	this.classList.add('loading');
 	this.innerHTML = `<i class="fa fa-refresh fa-spin"></i><span>${browser.i18n.getMessage('refreshingButton')}</span>`;
@@ -2148,19 +2173,19 @@ document
 			scrumReport.innerHTML = `<p style="text-align: center; color: #666; padding: 20px;">${browser.i18n.getMessage('cacheClearedMessage')}</p>`;
 		}
 
-      if (typeof availableRepos !== "undefined") {
-        availableRepos = [];
-      }
+		if (typeof availableRepos !== 'undefined') {
+			availableRepos = [];
+		}
 
-      const repoStatus = document.getElementById("repoStatus");
-      if (repoStatus) {
-        repoStatus.textContent = "";
-      }
+		const repoStatus = document.getElementById('repoStatus');
+		if (repoStatus) {
+			repoStatus.textContent = '';
+		}
 
 		this.innerHTML = `<i class="fa fa-check"></i><span>${browser.i18n.getMessage('cacheClearedButton')}</span>`;
 		this.classList.remove('loading');
 
-      // Do NOT trigger report generation automatically
+		// Do NOT trigger report generation automatically
 
 		setTimeout(() => {
 			this.innerHTML = originalText;
@@ -2171,25 +2196,25 @@ document
 		this.innerHTML = `<i class="fa fa-exclamation-triangle"></i><span>${browser.i18n.getMessage('cacheClearFailed')}</span>`;
 		this.classList.remove('loading');
 
-      setTimeout(() => {
-        this.innerHTML = originalText;
-        this.disabled = false;
-      }, 3000);
-    }
-  });
+		setTimeout(() => {
+			this.innerHTML = originalText;
+			this.disabled = false;
+		}, 3000);
+	}
+});
 
 function toggleRadio(radio) {
-  const startDateInput = document.getElementById("startingDate");
-  const endDateInput = document.getElementById("endingDate");
+	const startDateInput = document.getElementById('startingDate');
+	const endDateInput = document.getElementById('endingDate');
 
-  console.log("Toggling radio:", radio.id);
+	console.log('Toggling radio:', radio.id);
 
-  if (radio.id === "yesterdayContribution") {
-    startDateInput.value = getYesterday();
-    endDateInput.value = getToday();
-  }
+	if (radio.id === 'yesterdayContribution') {
+		startDateInput.value = getYesterday();
+		endDateInput.value = getToday();
+	}
 
-  startDateInput.readOnly = endDateInput.readOnly = true;
+	startDateInput.readOnly = endDateInput.readOnly = true;
 
 	browser.storage.local
 		.set({
@@ -2210,9 +2235,9 @@ function toggleRadio(radio) {
 }
 
 async function triggerRepoFetchIfEnabled() {
-  if (window.triggerRepoFetchIfEnabled) {
-    await window.triggerRepoFetchIfEnabled();
-  }
+	if (window.triggerRepoFetchIfEnabled) {
+		await window.triggerRepoFetchIfEnabled();
+	}
 }
 
 // Keyboard shortcuts: Ctrl+G / Cmd+G to generate, Ctrl+Shift+Y / Cmd+Shift+Y to copy, Ctrl+Shift+M / Cmd+Shift+M to insert in email

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1133,7 +1133,14 @@ document.addEventListener('DOMContentLoaded', () => {
     // Reset the Generate button so the user can try again later
     const generateBtn = document.getElementById("generateReport");
     if (generateBtn) {
-      generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
+      const iconEl = generateBtn.querySelector("i");
+      if (iconEl) {
+        iconEl.className = "fa fa-refresh";
+      }
+      const labelEl = generateBtn.querySelector('[data-i18n="generateReportButton"]');
+      if (labelEl && typeof chrome !== "undefined" && chrome.i18n && chrome.i18n.getMessage) {
+        labelEl.textContent = chrome.i18n.getMessage("generateReportButton");
+      }
       generateBtn.disabled = false;
     }
   };

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1,11 +1,11 @@
 /* global chrome */
 
 function debounce(func, wait) {
-	let timeout;
-	return function (...args) {
-		clearTimeout(timeout);
-		timeout = setTimeout(() => func.apply(this, args), wait);
-	};
+  let timeout;
+  return function (...args) {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func.apply(this, args), wait);
+  };
 }
 
 // Utility: Detect if the current OS is macOS
@@ -79,15 +79,15 @@ function setupButtonTooltips() {
 }
 
 function getToday() {
-	const today = new Date();
-	return today.toISOString().split('T')[0];
+  const today = new Date();
+  return today.toISOString().split("T")[0];
 }
 
 function getYesterday() {
-	const today = new Date();
-	const yesterday = new Date(today);
-	yesterday.setDate(today.getDate() - 1);
-	return yesterday.toISOString().split('T')[0];
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  return yesterday.toISOString().split("T")[0];
 }
 
 function applyI18n() {
@@ -126,30 +126,32 @@ document.addEventListener('DOMContentLoaded', () => {
 	applyI18n();
 	setupButtonTooltips();
 
-	// Dark mode setup
-	const darkModeToggle = document.querySelector('img[alt="Night Mode"]');
-	const settingsIcon = document.getElementById('settingsIcon');
-	const body = document.body;
-	const homeButton = document.getElementById('homeButton');
-	const scrumHelperHeading = document.getElementById('scrumHelperHeading');
-	const settingsToggle = document.getElementById('settingsToggle');
-	const reportSection = document.getElementById('reportSection');
-	const settingsSection = document.getElementById('settingsSection');
+  // Dark mode setup
+  const darkModeToggle = document.querySelector('img[alt="Night Mode"]');
+  const settingsIcon = document.getElementById("settingsIcon");
+  const body = document.body;
+  const homeButton = document.getElementById("homeButton");
+  const scrumHelperHeading = document.getElementById("scrumHelperHeading");
+  const settingsToggle = document.getElementById("settingsToggle");
+  const reportSection = document.getElementById("reportSection");
+  const settingsSection = document.getElementById("settingsSection");
 
-	let isSettingsVisible = false;
-	const githubTokenInput = document.getElementById('githubToken');
-	const toggleTokenBtn = document.getElementById('toggleTokenVisibility');
-	const tokenEyeIcon = document.getElementById('tokenEyeIcon');
-	const tokenPreview = document.getElementById('tokenPreview');
-	let tokenVisible = false;
+  let isSettingsVisible = false;
+  const githubTokenInput = document.getElementById("githubToken");
+  const toggleTokenBtn = document.getElementById("toggleTokenVisibility");
+  const tokenEyeIcon = document.getElementById("tokenEyeIcon");
+  const tokenPreview = document.getElementById("tokenPreview");
+  let tokenVisible = false;
 
-	// GitLab token elements
-	const gitlabTokenInput = document.getElementById('gitlabToken');
-	const toggleGitlabTokenBtn = document.getElementById('toggleGitlabTokenVisibility');
-	const gitlabTokenEyeIcon = document.getElementById('gitlabTokenEyeIcon');
-	let gitlabTokenVisible = false;
+  // GitLab token elements
+  const gitlabTokenInput = document.getElementById("gitlabToken");
+  const toggleGitlabTokenBtn = document.getElementById(
+    "toggleGitlabTokenVisibility",
+  );
+  const gitlabTokenEyeIcon = document.getElementById("gitlabTokenEyeIcon");
+  let gitlabTokenVisible = false;
 
-	const orgInput = document.getElementById('orgInput');
+  const orgInput = document.getElementById("orgInput");
 
 	const platformSelect = document.getElementById('platformSelect');
 	const usernameLabel = document.getElementById('usernameLabel');
@@ -157,17 +159,22 @@ document.addEventListener('DOMContentLoaded', () => {
 	let showCommitsWarningTimeout;
 	let mergedPRsWarningTimeout;
 
-	function checkTokenForFilter() {
-		const useRepoFilter = document.getElementById('useRepoFilter');
-		const githubTokenInput = document.getElementById('githubToken');
-		const tokenWarning = document.getElementById('tokenWarningForFilter');
-		const repoFilterContainer = document.getElementById('repoFilterContainer');
+  function checkTokenForFilter() {
+    const useRepoFilter = document.getElementById("useRepoFilter");
+    const githubTokenInput = document.getElementById("githubToken");
+    const tokenWarning = document.getElementById("tokenWarningForFilter");
+    const repoFilterContainer = document.getElementById("repoFilterContainer");
 
-		if (!useRepoFilter || !githubTokenInput || !tokenWarning || !repoFilterContainer) {
-			return;
-		}
-		const isFilterEnabled = useRepoFilter.checked;
-		const hasToken = githubTokenInput.value.trim() !== '';
+    if (
+      !useRepoFilter ||
+      !githubTokenInput ||
+      !tokenWarning ||
+      !repoFilterContainer
+    ) {
+      return;
+    }
+    const isFilterEnabled = useRepoFilter.checked;
+    const hasToken = githubTokenInput.value.trim() !== "";
 
 		if (isFilterEnabled && !hasToken) {
 			useRepoFilter.checked = false;
@@ -316,32 +323,42 @@ document.addEventListener('DOMContentLoaded', () => {
 		}
 	});
 
-	toggleTokenBtn.addEventListener('click', () => {
-		tokenVisible = !tokenVisible;
-		githubTokenInput.type = tokenVisible ? 'text' : 'password';
+  toggleTokenBtn.addEventListener("click", () => {
+    tokenVisible = !tokenVisible;
+    githubTokenInput.type = tokenVisible ? "text" : "password";
 
-		tokenEyeIcon.classList.add('eye-animating');
-		setTimeout(() => tokenEyeIcon.classList.remove('eye-animating'), 400);
-		tokenEyeIcon.className = tokenVisible ? 'fa fa-eye-slash text-gray-600' : 'fa fa-eye text-gray-600';
+    tokenEyeIcon.classList.add("eye-animating");
+    setTimeout(() => tokenEyeIcon.classList.remove("eye-animating"), 400);
+    tokenEyeIcon.className = tokenVisible
+      ? "fa fa-eye-slash text-gray-600"
+      : "fa fa-eye text-gray-600";
 
-		githubTokenInput.classList.add('token-animating');
-		setTimeout(() => githubTokenInput.classList.remove('token-animating'), 300);
-	});
+    githubTokenInput.classList.add("token-animating");
+    setTimeout(() => githubTokenInput.classList.remove("token-animating"), 300);
+  });
 
-	// GitLab token visibility toggle
-	if (toggleGitlabTokenBtn && gitlabTokenInput) {
-		toggleGitlabTokenBtn.addEventListener('click', () => {
-			gitlabTokenVisible = !gitlabTokenVisible;
-			gitlabTokenInput.type = gitlabTokenVisible ? 'text' : 'password';
+  // GitLab token visibility toggle
+  if (toggleGitlabTokenBtn && gitlabTokenInput) {
+    toggleGitlabTokenBtn.addEventListener("click", () => {
+      gitlabTokenVisible = !gitlabTokenVisible;
+      gitlabTokenInput.type = gitlabTokenVisible ? "text" : "password";
 
-			gitlabTokenEyeIcon.classList.add('eye-animating');
-			setTimeout(() => gitlabTokenEyeIcon.classList.remove('eye-animating'), 400);
-			gitlabTokenEyeIcon.className = gitlabTokenVisible ? 'fa fa-eye-slash text-gray-600' : 'fa fa-eye text-gray-600';
+      gitlabTokenEyeIcon.classList.add("eye-animating");
+      setTimeout(
+        () => gitlabTokenEyeIcon.classList.remove("eye-animating"),
+        400,
+      );
+      gitlabTokenEyeIcon.className = gitlabTokenVisible
+        ? "fa fa-eye-slash text-gray-600"
+        : "fa fa-eye text-gray-600";
 
-			gitlabTokenInput.classList.add('token-animating');
-			setTimeout(() => gitlabTokenInput.classList.remove('token-animating'), 300);
-		});
-	}
+      gitlabTokenInput.classList.add("token-animating");
+      setTimeout(
+        () => gitlabTokenInput.classList.remove("token-animating"),
+        300,
+      );
+    });
+  }
 
 	githubTokenInput.addEventListener('input', checkTokenForFilter);
 	githubTokenInput.addEventListener('input', () =>
@@ -363,25 +380,25 @@ document.addEventListener('DOMContentLoaded', () => {
 		renderTokenPreview();
 	});
 
-	function renderTokenPreview() {
-		if (!tokenPreview || !githubTokenInput) return;
-		tokenPreview.innerHTML = '';
-		const value = githubTokenInput.value;
-		const isDark = document.body.classList.contains('dark-mode');
-		for (let i = 0; i < value.length; i++) {
-			const charBox = document.createElement('span');
-			charBox.className = 'token-preview-char' + (isDark ? ' dark-mode' : '');
-			if (tokenVisible) {
-				charBox.textContent = value[i];
-			} else {
-				const dot = document.createElement('span');
-				dot.className = 'token-preview-dot' + (isDark ? ' dark-mode' : '');
-				charBox.appendChild(dot);
-			}
-			tokenPreview.appendChild(charBox);
-			setTimeout(() => charBox.classList.add('flip'), 10 + i * 30);
-		}
-	}
+  function renderTokenPreview() {
+    if (!tokenPreview || !githubTokenInput) return;
+    tokenPreview.innerHTML = "";
+    const value = githubTokenInput.value;
+    const isDark = document.body.classList.contains("dark-mode");
+    for (let i = 0; i < value.length; i++) {
+      const charBox = document.createElement("span");
+      charBox.className = "token-preview-char" + (isDark ? " dark-mode" : "");
+      if (tokenVisible) {
+        charBox.textContent = value[i];
+      } else {
+        const dot = document.createElement("span");
+        dot.className = "token-preview-dot" + (isDark ? " dark-mode" : "");
+        charBox.appendChild(dot);
+      }
+      tokenPreview.appendChild(charBox);
+      setTimeout(() => charBox.classList.add("flip"), 10 + i * 30);
+    }
+  }
 
 	browser.storage.local.remove(['enableToggle']).then(() => {
 		initializePopup();
@@ -409,87 +426,89 @@ document.addEventListener('DOMContentLoaded', () => {
 		});
 	}
 
-	function parsePositiveInt(value) {
-		const n = Number.parseInt(value, 10);
-		return Number.isFinite(n) && n > 0 ? n : null;
-	}
+  function parsePositiveInt(value) {
+    const n = Number.parseInt(value, 10);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  }
 
-	function setGenerateButtonLoading(generateBtn, isLoading) {
-		if (!generateBtn) return;
-		if (!isLoading) return;
+  function setGenerateButtonLoading(generateBtn, isLoading) {
+    if (!generateBtn) return;
+    if (!isLoading) return;
 
 		const msg = browser.i18n.getMessage('generatingButton') || 'Generating...';
 		generateBtn.innerHTML = `<i class="fa fa-spinner fa-spin"></i> ${msg}`;
 		generateBtn.disabled = true;
 	}
 
-	function showPopupMessage(message) {
-		if (!message) return;
+  function showPopupMessage(message) {
+    if (!message) return;
 
-		// Materialize toast if available
-		if (window.Materialize && typeof window.Materialize.toast === 'function') {
-			window.Materialize.toast(message, 4000);
-			return;
-		}
+    // Materialize toast if available
+    if (window.Materialize && typeof window.Materialize.toast === "function") {
+      window.Materialize.toast(message, 4000);
+      return;
+    }
 
-		const old = document.getElementById('scrum-cache-toast');
-		if (old) old.remove();
+    const old = document.getElementById("scrum-cache-toast");
+    if (old) old.remove();
 
-		const toast = document.createElement('div');
-		toast.id = 'scrum-cache-toast';
-		toast.className = 'toast';
-		toast.style.background = '#2563eb';
-		toast.style.color = '#fff';
-		toast.style.fontWeight = 'bold';
-		toast.style.padding = '12px 24px';
-		toast.style.borderRadius = '8px';
-		toast.style.position = 'fixed';
-		toast.style.top = '24px';
-		toast.style.left = '50%';
-		toast.style.transform = 'translateX(-50%)';
-		toast.style.zIndex = '9999';
-		toast.textContent = message;
+    const toast = document.createElement("div");
+    toast.id = "scrum-cache-toast";
+    toast.className = "toast";
+    toast.style.background = "#2563eb";
+    toast.style.color = "#fff";
+    toast.style.fontWeight = "bold";
+    toast.style.padding = "12px 24px";
+    toast.style.borderRadius = "8px";
+    toast.style.position = "fixed";
+    toast.style.top = "24px";
+    toast.style.left = "50%";
+    toast.style.transform = "translateX(-50%)";
+    toast.style.zIndex = "9999";
+    toast.textContent = message;
 
-		document.body.appendChild(toast);
-		setTimeout(() => toast.remove(), 4000);
-	}
+    document.body.appendChild(toast);
+    setTimeout(() => toast.remove(), 4000);
+  }
 
-	async function bootstrapScrumReportOnPopupLoad(generateBtn) {
-		console.log('[BOOTSTRAP] bootstrapScrumReportOnPopupLoad called');
+  async function bootstrapScrumReportOnPopupLoad(generateBtn) {
+    console.log("[BOOTSTRAP] bootstrapScrumReportOnPopupLoad called");
 
-		if (typeof window.generateScrumReport !== 'function') {
-			return;
-		}
+    if (typeof window.generateScrumReport !== "function") {
+      return;
+    }
 
-		const scrumReport = document.getElementById('scrumReport');
-		if (!scrumReport) {
-			return;
-		}
+    const scrumReport = document.getElementById("scrumReport");
+    if (!scrumReport) {
+      return;
+    }
 
-		const { platform, cacheInput, githubCache, gitlabCache } = await storageLocalGet([
-			'platform',
-			'cacheInput',
-			'githubCache',
-			'gitlabCache',
-		]);
+    const { platform, cacheInput, githubCache, gitlabCache } =
+      await storageLocalGet([
+        "platform",
+        "cacheInput",
+        "githubCache",
+        "gitlabCache",
+      ]);
 
-		const ttlMinutes = parsePositiveInt(cacheInput) ?? 10;
-		const ttlMs = ttlMinutes * 60 * 1000;
+    const ttlMinutes = parsePositiveInt(cacheInput) ?? 10;
+    const ttlMs = ttlMinutes * 60 * 1000;
 
-		const activePlatform = platform || 'github';
-		const cache = activePlatform === 'gitlab' ? gitlabCache : githubCache;
+    const activePlatform = platform || "github";
+    const cache = activePlatform === "gitlab" ? gitlabCache : githubCache;
 
-		const hasCacheData = !!cache?.data;
-		const timestamp = typeof cache?.timestamp === 'number' ? cache.timestamp : 0;
+    const hasCacheData = !!cache?.data;
+    const timestamp =
+      typeof cache?.timestamp === "number" ? cache.timestamp : 0;
 
-		if (!hasCacheData) {
-			setGenerateButtonLoading(generateBtn, true);
-			window.generateScrumReport();
-			return;
-		}
+    if (!hasCacheData) {
+      setGenerateButtonLoading(generateBtn, true);
+      window.generateScrumReport();
+      return;
+    }
 
-		if (timestamp > 0) {
-			const age = Date.now() - timestamp;
+    if (timestamp > 0) {
+      const age = Date.now() - timestamp;
 
 			const storageValues = await storageLocalGet([
 				`${activePlatform}LastScrumReportHtml`,
@@ -530,29 +549,39 @@ document.addEventListener('DOMContentLoaded', () => {
 					(!lastScrumReportCacheKey || lastScrumReportCacheKey === cacheKey) &&
 					isUsernameMatch;
 
-				if (reportEmpty && lastScrumReportHtml && matches) {
-					scrumReport.innerHTML = lastScrumReportHtml;
-					if (generateBtn) generateBtn.disabled = false;
-					return;
-				}
+        if (reportEmpty && lastScrumReportHtml && matches) {
+          scrumReport.innerHTML = lastScrumReportHtml;
+          if (generateBtn) generateBtn.disabled = false;
+          return;
+        }
 
-				setGenerateButtonLoading(generateBtn, true);
-				window.generateScrumReport();
-				return;
-			}
+        setGenerateButtonLoading(generateBtn, true);
+        window.generateScrumReport();
+        return;
+      }
 
-			// If cache is expired, still only show the old HTML if it was for the current username
-			if ((!scrumReport.innerHTML || !scrumReport.innerHTML.trim()) && lastScrumReportHtml && isUsernameMatch) {
-				scrumReport.innerHTML = lastScrumReportHtml;
-			}
+      const { lastScrumReportHtml } = await storageLocalGet([
+        "lastScrumReportHtml",
+      ]);
+      if (
+        (!scrumReport.innerHTML || !scrumReport.innerHTML.trim()) &&
+        lastScrumReportHtml
+      ) {
+        scrumReport.innerHTML = lastScrumReportHtml;
+      }
 
-			if (generateBtn) generateBtn.disabled = false;
-			return;
-		}
+      showPopupMessage(
+        chrome?.i18n.getMessage("cacheExpiredMessage") ||
+          'Cache expired. Click "Generate" to fetch fresh data.',
+      );
 
-		setGenerateButtonLoading(generateBtn, true);
-		window.generateScrumReport();
-	}
+      if (generateBtn) generateBtn.disabled = false;
+      return;
+    }
+
+    setGenerateButtonLoading(generateBtn, true);
+    window.generateScrumReport();
+  }
 
 	function initializePopup() {
 		browser.storage.local.get(['platform', 'platformUsername']).then((result) => {
@@ -575,12 +604,12 @@ document.addEventListener('DOMContentLoaded', () => {
 		const onlyRevPRsCheckbox = document.getElementById('onlyRevPRs');
 		const onlyMergedPRsCheckbox = document.getElementById('onlyMergedPRs');
 
-		const githubTokenInput = document.getElementById('githubToken');
-		const cacheInput = document.getElementById('cacheInput');
-		const yesterdayRadio = document.getElementById('yesterdayContribution');
-		const startingDateInput = document.getElementById('startingDate');
-		const endingDateInput = document.getElementById('endingDate');
-		const platformUsername = document.getElementById('platformUsername');
+    const githubTokenInput = document.getElementById("githubToken");
+    const cacheInput = document.getElementById("cacheInput");
+    const yesterdayRadio = document.getElementById("yesterdayContribution");
+    const startingDateInput = document.getElementById("startingDate");
+    const endingDateInput = document.getElementById("endingDate");
+    const platformUsername = document.getElementById("platformUsername");
 
 		browser.storage.local
 			.get([
@@ -661,16 +690,16 @@ document.addEventListener('DOMContentLoaded', () => {
 			},
 		);
 
-		// Button setup
-		const generateBtn = document.getElementById('generateReport');
-		const copyBtn = document.getElementById('copyReport');
-		const insertBtn = document.getElementById('insertInEmail');
+    // Button setup
+    const generateBtn = document.getElementById("generateReport");
+    const copyBtn = document.getElementById("copyReport");
+    const insertBtn = document.getElementById("insertInEmail");
 
-		if (insertBtn) {
-			insertBtn.addEventListener('click', () => {
-				const scrumReport = document.getElementById('scrumReport');
-				const content = scrumReport ? scrumReport.innerHTML : '';
-				const subject = buildScrumSubjectFromPopup();
+    if (insertBtn) {
+      insertBtn.addEventListener("click", () => {
+        const scrumReport = document.getElementById("scrumReport");
+        const content = scrumReport ? scrumReport.innerHTML : "";
+        const subject = buildScrumSubjectFromPopup();
 
 				if (!content) {
 					insertBtn._triggeredByShortcut = false;
@@ -732,19 +761,19 @@ document.addEventListener('DOMContentLoaded', () => {
 			});
 		});
 
-		copyBtn.addEventListener('click', function () {
-			const scrumReport = document.getElementById('scrumReport');
-			const tempDiv = document.createElement('div');
-			tempDiv.innerHTML = scrumReport.innerHTML;
-			document.body.appendChild(tempDiv);
-			tempDiv.style.position = 'absolute';
-			tempDiv.style.left = '-9999px';
+    copyBtn.addEventListener("click", function () {
+      const scrumReport = document.getElementById("scrumReport");
+      const tempDiv = document.createElement("div");
+      tempDiv.innerHTML = scrumReport.innerHTML;
+      document.body.appendChild(tempDiv);
+      tempDiv.style.position = "absolute";
+      tempDiv.style.left = "-9999px";
 
-			const range = document.createRange();
-			range.selectNode(tempDiv);
-			const selection = window.getSelection();
-			selection.removeAllRanges();
-			selection.addRange(range);
+      const range = document.createRange();
+      range.selectNode(tempDiv);
+      const selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
 
 			try {
 				document.execCommand('copy');
@@ -768,17 +797,21 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		});
 
-		// Custom date container click handler
-		document.getElementById('customDateContainer').addEventListener('click', () => {
-			document.querySelectorAll('input[name="timeframe"]').forEach((radio) => {
-				radio.checked = false;
-				radio.dataset.wasChecked = 'false';
-			});
+    // Custom date container click handler
+    document
+      .getElementById("customDateContainer")
+      .addEventListener("click", () => {
+        document
+          .querySelectorAll('input[name="timeframe"]')
+          .forEach((radio) => {
+            radio.checked = false;
+            radio.dataset.wasChecked = "false";
+          });
 
-			const startDateInput = document.getElementById('startingDate');
-			const endDateInput = document.getElementById('endingDate');
-			startDateInput.readOnly = false;
-			endDateInput.readOnly = false;
+        const startDateInput = document.getElementById("startingDate");
+        const endDateInput = document.getElementById("endingDate");
+        startDateInput.readOnly = false;
+        endDateInput.readOnly = false;
 
 			browser.storage.local.set({
 				yesterdayContribution: false,
@@ -1013,49 +1046,167 @@ document.addEventListener('DOMContentLoaded', () => {
 		});
 	}
 
-	function showReportView() {
-		isSettingsVisible = false;
-		reportSection.classList.remove('hidden');
-		settingsSection.classList.add('hidden');
-		settingsToggle.classList.remove('active');
-	}
+  function showReportView() {
+    isSettingsVisible = false;
+    reportSection.classList.remove("hidden");
+    settingsSection.classList.add("hidden");
+    settingsToggle.classList.remove("active");
+  }
 
-	function showSettingsView() {
-		isSettingsVisible = true;
-		reportSection.classList.add('hidden');
-		settingsSection.classList.remove('hidden');
-		settingsToggle.classList.add('active');
-	}
+  function showSettingsView() {
+    isSettingsVisible = true;
+    reportSection.classList.add("hidden");
+    settingsSection.classList.remove("hidden");
+    settingsToggle.classList.add("active");
+  }
 
-	if (settingsToggle) {
-		settingsToggle.addEventListener('click', () => {
-			if (isSettingsVisible) {
-				showReportView();
-			} else {
-				showSettingsView();
-			}
-		});
-	}
+  if (settingsToggle) {
+    settingsToggle.addEventListener("click", () => {
+      if (isSettingsVisible) {
+        showReportView();
+      } else {
+        showSettingsView();
+      }
+    });
+  }
 
-	if (homeButton) {
-		homeButton.addEventListener('click', showReportView);
-	}
-	if (scrumHelperHeading) {
-		scrumHelperHeading.addEventListener('click', showReportView);
-	}
+  if (homeButton) {
+    homeButton.addEventListener("click", showReportView);
+  }
+  if (scrumHelperHeading) {
+    scrumHelperHeading.addEventListener("click", showReportView);
+  }
 
-	showReportView();
+  // ── Rate Limit Warning Banner Handlers ──
 
-	//report filter
-	const repoSearch = document.getElementById('repoSearch');
-	const repoDropdown = document.getElementById('repoDropdown');
-	const selectedReposDiv = document.getElementById('selectedRepos');
-	const repoTags = document.getElementById('repoTags');
-	const repoPlaceholder = document.getElementById('repoPlaceholder');
-	const repoCount = document.getElementById('repoCount');
-	const repoStatus = document.getElementById('repoStatus');
-	const useRepoFilter = document.getElementById('useRepoFilter');
-	const repoFilterContainer = document.getElementById('repoFilterContainer');
+  /**
+   * Show the rate-limit warning banner.
+   * Called from scrumHelper.js / gitlabHelper.js when a RateLimitError is caught.
+   * Exposed globally so other scripts can call it.
+   * @param {Error} error — must have .name === "RateLimitError", .platform, .resetAt, .retryAfter
+   */
+  window.showRateLimitWarning = function (error) {
+    const isGithub = error.platform === "github";
+    const warningEl = document.getElementById(
+      isGithub ? "rateLimitWarning" : "rateLimitWarningGitlab",
+    );
+    const messageEl = document.getElementById(
+      isGithub ? "rateLimitMessage" : "rateLimitMessageGitlab",
+    );
+    const retryInfoEl = document.getElementById(
+      isGithub ? "rateLimitRetryInfo" : "rateLimitRetryInfoGitlab",
+    );
+
+    if (!warningEl) return;
+
+    // Check whether the user already has a token set
+    const tokenInput = document.getElementById(
+      isGithub ? "githubToken" : "gitlabToken",
+    );
+    const hasToken = tokenInput && tokenInput.value.trim().length > 0;
+
+    if (hasToken) {
+      messageEl.textContent =
+        `You've exceeded the ${isGithub ? "GitHub" : "GitLab"} API rate limit even with a token. ` +
+        "Please wait for the limit to reset and try again.";
+    } else {
+      messageEl.textContent =
+        `You've hit the ${isGithub ? "GitHub" : "GitLab"} API rate limit for unauthenticated requests. ` +
+        "Adding a Personal Access Token increases your limit significantly and enables access to private repositories.";
+    }
+
+    // Show reset countdown
+    if (error.resetAt) {
+      const resetDate = new Date(error.resetAt);
+      const minutes = Math.max(
+        1,
+        Math.ceil((error.resetAt - Date.now()) / 60000),
+      );
+      retryInfoEl.textContent = `Rate limit resets at ${resetDate.toLocaleTimeString()} (~${minutes} min).`;
+    } else {
+      retryInfoEl.textContent = `Try again in about ${error.retryAfter || 60} seconds.`;
+    }
+
+    warningEl.classList.remove("hidden");
+    warningEl.scrollIntoView({ behavior: "smooth", block: "center" });
+
+    // Reset the Generate button so the user can try again later
+    const generateBtn = document.getElementById("generateReport");
+    if (generateBtn) {
+      generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
+      generateBtn.disabled = false;
+    }
+  };
+
+  // GitHub — "Add GitHub Token" → navigate to settings, focus token input
+  const rateLimitAddTokenBtn = document.getElementById("rateLimitAddToken");
+  if (rateLimitAddTokenBtn) {
+    rateLimitAddTokenBtn.addEventListener("click", () => {
+      showSettingsView();
+      const tokenInput = document.getElementById("githubToken");
+      if (tokenInput) {
+        setTimeout(() => {
+          tokenInput.scrollIntoView({ behavior: "smooth", block: "center" });
+          tokenInput.focus();
+          tokenInput.style.borderColor = "#ca8a04";
+          tokenInput.style.boxShadow = "0 0 0 2px #fde047";
+          setTimeout(() => {
+            tokenInput.style.borderColor = "";
+            tokenInput.style.boxShadow = "";
+          }, 3000);
+        }, 100);
+      }
+    });
+  }
+
+  // Dismiss buttons — hide their closest rate-limit banner
+  document
+    .querySelectorAll("#rateLimitDismiss, #rateLimitDismissGitlab")
+    .forEach((btn) => {
+      btn.addEventListener("click", () => {
+        btn.closest(".rate-limit-banner").classList.add("hidden");
+      });
+    });
+
+  // GitLab — "Add GitLab Token" → navigate to settings, focus token input
+  const rateLimitAddTokenGitlabBtn = document.getElementById(
+    "rateLimitAddTokenGitlab",
+  );
+  if (rateLimitAddTokenGitlabBtn) {
+    rateLimitAddTokenGitlabBtn.addEventListener("click", () => {
+      showSettingsView();
+      // Ensure the GitLab section is visible
+      const gitlabSection = document.querySelector(".gitlabOnlySection");
+      if (gitlabSection) gitlabSection.classList.remove("hidden");
+
+      const tokenInput = document.getElementById("gitlabToken");
+      if (tokenInput) {
+        setTimeout(() => {
+          tokenInput.scrollIntoView({ behavior: "smooth", block: "center" });
+          tokenInput.focus();
+          tokenInput.style.borderColor = "#ea580c";
+          tokenInput.style.boxShadow = "0 0 0 2px #fdba74";
+          setTimeout(() => {
+            tokenInput.style.borderColor = "";
+            tokenInput.style.boxShadow = "";
+          }, 3000);
+        }, 100);
+      }
+    });
+  }
+
+  showReportView();
+
+  //report filter
+  const repoSearch = document.getElementById("repoSearch");
+  const repoDropdown = document.getElementById("repoDropdown");
+  const selectedReposDiv = document.getElementById("selectedRepos");
+  const repoTags = document.getElementById("repoTags");
+  const repoPlaceholder = document.getElementById("repoPlaceholder");
+  const repoCount = document.getElementById("repoCount");
+  const repoStatus = document.getElementById("repoStatus");
+  const useRepoFilter = document.getElementById("useRepoFilter");
+  const repoFilterContainer = document.getElementById("repoFilterContainer");
 
 	if (repoSearch && useRepoFilter && repoFilterContainer) {
 		repoSearch.addEventListener('click', () => {
@@ -1067,12 +1218,12 @@ document.addEventListener('DOMContentLoaded', () => {
 		});
 	}
 
-	if (!repoSearch || !useRepoFilter) {
-		console.log('Repository, filter elements not found in DOM');
-	} else {
-		let availableRepos = [];
-		let selectedRepos = [];
-		let highlightedIndex = -1;
+  if (!repoSearch || !useRepoFilter) {
+    console.log("Repository, filter elements not found in DOM");
+  } else {
+    let availableRepos = [];
+    let selectedRepos = [];
+    let highlightedIndex = -1;
 
 		async function triggerRepoFetchIfEnabled() {
 			// --- PLATFORM CHECK: Only run for GitHub ---
@@ -1104,9 +1255,9 @@ document.addEventListener('DOMContentLoaded', () => {
 					'orgName',
 				]);
 
-				const platform = items.platform || 'github';
-				const platformUsernameKey = `${platform}Username`;
-				const username = items[platformUsernameKey];
+        const platform = items.platform || "github";
+        const platformUsernameKey = `${platform}Username`;
+        const username = items[platformUsernameKey];
 
 				if (!username) {
 					if (repoStatus) {
@@ -1115,10 +1266,14 @@ document.addEventListener('DOMContentLoaded', () => {
 					return;
 				}
 
-				if (window.fetchUserRepositories) {
-					const repos = await window.fetchUserRepositories(username, items.githubToken, items.orgName || '');
+        if (window.fetchUserRepositories) {
+          const repos = await window.fetchUserRepositories(
+            username,
+            items.githubToken,
+            items.orgName || "",
+          );
 
-					availableRepos = repos;
+          availableRepos = repos;
 
 					if (repoStatus) {
 						repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [repos.length]);
@@ -1148,7 +1303,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		}
 
-		window.triggerRepoFetchIfEnabled = triggerRepoFetchIfEnabled;
+    window.triggerRepoFetchIfEnabled = triggerRepoFetchIfEnabled;
 
 		browser.storage.local.get(['selectedRepos', 'useRepoFilter']).then((items) => {
 			if (items.selectedRepos) {
@@ -1214,37 +1369,37 @@ document.addEventListener('DOMContentLoaded', () => {
 							'orgName',
 						]);
 
-						const platform = items.platform || 'github';
-						const platformUsernameKey = `${platform}Username`;
-						const username = items[platformUsernameKey];
+            const platform = items.platform || "github";
+            const platformUsernameKey = `${platform}Username`;
+            const username = items[platformUsernameKey];
 
 						if (!username) {
 							repoStatus.textContent = chrome?.i18n.getMessage('usernameMissingError') || 'Username required';
 							return;
 						}
 
-						const repoCacheKey = `repos-${username}-${items.orgName || ''}`;
+            const repoCacheKey = `repos-${username}-${items.orgName || ""}`;
 
-						const now = Date.now();
-						const cacheAge = cacheData.repoCache?.timestamp
-							? now - cacheData.repoCache.timestamp
-							: Number.POSITIVE_INFINITY;
-						const cacheTTL = 10 * 60 * 1000; // 10 minutes
+            const now = Date.now();
+            const cacheAge = cacheData.repoCache?.timestamp
+              ? now - cacheData.repoCache.timestamp
+              : Number.POSITIVE_INFINITY;
+            const cacheTTL = 10 * 60 * 1000; // 10 minutes
 
 						if (cacheData.repoCache && cacheData.repoCache.cacheKey === repoCacheKey && cacheAge < cacheTTL) {
 							console.log('Using cached repositories');
 							availableRepos = cacheData.repoCache.data;
 							repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [availableRepos.length]);
 
-							if (document.activeElement === repoSearch) {
-								filterAndDisplayRepos(repoSearch.value.toLowerCase());
-							}
-							return;
-						}
+              if (document.activeElement === repoSearch) {
+                filterAndDisplayRepos(repoSearch.value.toLowerCase());
+              }
+              return;
+            }
 
-						if (window.fetchUserRepositories) {
-							const repos = await window.fetchUserRepositories(
-								username,
+            if (window.fetchUserRepositories) {
+              const repos = await window.fetchUserRepositories(
+                username,
 
 								items.githubToken,
 								items.orgName || '',
@@ -1260,12 +1415,12 @@ document.addEventListener('DOMContentLoaded', () => {
 								},
 							});
 
-							if (document.activeElement === repoSearch) {
-								filterAndDisplayRepos(repoSearch.value.toLowerCase());
-							}
-						}
-					} catch (err) {
-						console.error('Auto load repos failed', err);
+              if (document.activeElement === repoSearch) {
+                filterAndDisplayRepos(repoSearch.value.toLowerCase());
+              }
+            }
+          } catch (err) {
+            console.error("Auto load repos failed", err);
 
 						if (err.message?.includes('401')) {
 							repoStatus.textContent = browser.i18n.getMessage('repoTokenPrivate');
@@ -1284,51 +1439,54 @@ document.addEventListener('DOMContentLoaded', () => {
 			}, 300),
 		);
 
-		repoSearch.addEventListener('keydown', (e) => {
-			const items = repoDropdown.querySelectorAll('.repository-dropdown-item');
+    repoSearch.addEventListener("keydown", (e) => {
+      const items = repoDropdown.querySelectorAll(".repository-dropdown-item");
 
-			switch (e.key) {
-				case 'ArrowDown':
-					e.preventDefault();
-					highlightedIndex = Math.min(highlightedIndex + 1, items.length - 1);
-					updateHighlight(items);
-					break;
-				case 'ArrowUp':
-					e.preventDefault();
-					highlightedIndex = Math.max(highlightedIndex - 1, 0);
-					updateHighlight(items);
-					break;
-				case 'Enter':
-					e.preventDefault();
-					if (highlightedIndex >= 0 && items[highlightedIndex]) {
-						fnSelectedRepos(items[highlightedIndex].dataset.repoName);
-					}
-					break;
-				case 'Escape':
-					hideDropdown();
-					break;
-			}
-		});
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          highlightedIndex = Math.min(highlightedIndex + 1, items.length - 1);
+          updateHighlight(items);
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          highlightedIndex = Math.max(highlightedIndex - 1, 0);
+          updateHighlight(items);
+          break;
+        case "Enter":
+          e.preventDefault();
+          if (highlightedIndex >= 0 && items[highlightedIndex]) {
+            fnSelectedRepos(items[highlightedIndex].dataset.repoName);
+          }
+          break;
+        case "Escape":
+          hideDropdown();
+          break;
+      }
+    });
 
-		repoSearch.addEventListener('input', (e) => {
-			const query = e.target.value.toLowerCase();
-			filterAndDisplayRepos(query);
-		});
-		let programmaticFocus = false;
-		repoSearch.addEventListener('focus', () => {
-			if (programmaticFocus) {
-				programmaticFocus = false;
-				return;
-			}
-			const searchTerm = repoSearch.value.toLowerCase();
-			filterAndDisplayRepos(searchTerm);
-		});
+    repoSearch.addEventListener("input", (e) => {
+      const query = e.target.value.toLowerCase();
+      filterAndDisplayRepos(query);
+    });
+    let programmaticFocus = false;
+    repoSearch.addEventListener("focus", () => {
+      if (programmaticFocus) {
+        programmaticFocus = false;
+        return;
+      }
+      const searchTerm = repoSearch.value.toLowerCase();
+      filterAndDisplayRepos(searchTerm);
+    });
 
-		document.addEventListener('click', (e) => {
-			if (!e.target.closest('#repoSearch') && !e.target.closest('#repoDropdown')) {
-				hideDropdown();
-			}
-		});
+    document.addEventListener("click", (e) => {
+      if (
+        !e.target.closest("#repoSearch") &&
+        !e.target.closest("#repoDropdown")
+      ) {
+        hideDropdown();
+      }
+    });
 
 		function debugRepoFetch() {
 			browser.storage.local.get(['platform', 'githubUsername', 'githubToken', 'orgName']).then((items) => {
@@ -1360,10 +1518,10 @@ document.addEventListener('DOMContentLoaded', () => {
 				Object.keys(window).filter((key) => key.includes('fetch')),
 			);
 
-			if (!window.fetchUserRepositories) {
-				repoStatus.textContent = 'Repository fetching not available';
-				return;
-			}
+      if (!window.fetchUserRepositories) {
+        repoStatus.textContent = "Repository fetching not available";
+        return;
+      }
 
 			browser.storage.local.get(['platform', 'githubUsername', 'githubToken']).then((items) => {
 				const platform = items.platform || 'github';
@@ -1380,9 +1538,10 @@ document.addEventListener('DOMContentLoaded', () => {
 					return;
 				}
 
-				performRepoFetch();
-			});
-		}
+          performRepoFetch();
+        },
+      );
+    }
 
 		async function performRepoFetch() {
 			let platform = 'github';
@@ -1417,27 +1576,27 @@ document.addEventListener('DOMContentLoaded', () => {
 					: Number.POSITIVE_INFINITY;
 				const cacheTTL = 10 * 60 * 1000; // 10 minutes
 
-				console.log('[POPUP-DEBUG] Repo cache check:', {
-					key: repoCacheKey,
-					cacheKeyInCache: cacheData.repoCache?.cacheKey,
-					isMatch: cacheData.repoCache?.cacheKey === repoCacheKey,
-					age: cacheAge,
-					isFresh: cacheAge < cacheTTL,
-				});
+        console.log("[POPUP-DEBUG] Repo cache check:", {
+          key: repoCacheKey,
+          cacheKeyInCache: cacheData.repoCache?.cacheKey,
+          isMatch: cacheData.repoCache?.cacheKey === repoCacheKey,
+          age: cacheAge,
+          isFresh: cacheAge < cacheTTL,
+        });
 
 				if (cacheData.repoCache && cacheData.repoCache.cacheKey === repoCacheKey && cacheAge < cacheTTL) {
 					console.log('[POPUP-DEBUG] Using cached repositories in manual fetch');
 					availableRepos = cacheData.repoCache.data;
 					repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [availableRepos.length]);
 
-					if (document.activeElement === repoSearch) {
-						filterAndDisplayRepos(repoSearch.value.toLowerCase());
-					}
-					return;
-				}
-				console.log('[POPUP-DEBUG] No valid cache. Fetching from network.');
-				availableRepos = await window.fetchUserRepositories(
-					username,
+          if (document.activeElement === repoSearch) {
+            filterAndDisplayRepos(repoSearch.value.toLowerCase());
+          }
+          return;
+        }
+        console.log("[POPUP-DEBUG] No valid cache. Fetching from network.");
+        availableRepos = await window.fetchUserRepositories(
+          username,
 
 					storageItems.githubToken,
 					storageItems.orgName || '',
@@ -1453,11 +1612,11 @@ document.addEventListener('DOMContentLoaded', () => {
 					},
 				});
 
-				if (document.activeElement === repoSearch) {
-					filterAndDisplayRepos(repoSearch.value.toLowerCase());
-				}
-			} catch (err) {
-				console.error(`Failed to load repos:`, err);
+        if (document.activeElement === repoSearch) {
+          filterAndDisplayRepos(repoSearch.value.toLowerCase());
+        }
+      } catch (err) {
+        console.error(`Failed to load repos:`, err);
 
 				if (err.message && err.message.includes('401')) {
 					repoStatus.textContent = browser.i18n.getMessage('repoTokenPrivate');
@@ -1478,15 +1637,18 @@ document.addEventListener('DOMContentLoaded', () => {
 				return;
 			}
 
-			const filtered = availableRepos.filter((repo) => {
-				if (selectedRepos.includes(repo.fullName)) {
-					return false;
-				}
-				if (!query) {
-					return true;
-				}
-				return repo.name.toLowerCase().includes(query) || repo.description?.toLowerCase().includes(query);
-			});
+      const filtered = availableRepos.filter((repo) => {
+        if (selectedRepos.includes(repo.fullName)) {
+          return false;
+        }
+        if (!query) {
+          return true;
+        }
+        return (
+          repo.name.toLowerCase().includes(query) ||
+          repo.description?.toLowerCase().includes(query)
+        );
+      });
 
 			if (filtered.length === 0) {
 				repoDropdown.innerHTML = `<div class="p-3 text-center text-gray-500 text-sm" style="padding-left: 10px; ">${browser.i18n.getMessage('repoNotFound')}</div>`;
@@ -1498,50 +1660,52 @@ document.addEventListener('DOMContentLoaded', () => {
                     <div class="repository-dropdown-item" data-repo-name="${repo.fullName}">
                         <div class="repo-name">
                             <span>${repo.name}</span>
-                            ${repo.language ? `<span class="repo-language">${repo.language}</span>` : ''}
-                            ${repo.stars ? `<span class="repo-stars"><i class="fa fa-star"></i> ${repo.stars}</span>` : ''}
+                            ${repo.language ? `<span class="repo-language">${repo.language}</span>` : ""}
+                            ${repo.stars ? `<span class="repo-stars"><i class="fa fa-star"></i> ${repo.stars}</span>` : ""}
                         </div>
                         <div class="repo-info">
-                            ${repo.description ? `<span class="repo-desc">${repo.description.substring(0, 50)}${repo.description.length > 50 ? '...' : ''}</span>` : ''}
+                            ${repo.description ? `<span class="repo-desc">${repo.description.substring(0, 50)}${repo.description.length > 50 ? "..." : ""}</span>` : ""}
                         </div>
                     </div>
                 `,
-					)
-					.join('');
+          )
+          .join("");
 
-				repoDropdown.querySelectorAll('.repository-dropdown-item').forEach((item) => {
-					item.addEventListener('click', (e) => {
-						e.stopPropagation();
-						fnSelectedRepos(item.dataset.repoName);
-					});
-				});
-			}
-			highlightedIndex = -1;
-			showDropdown();
-		}
+        repoDropdown
+          .querySelectorAll(".repository-dropdown-item")
+          .forEach((item) => {
+            item.addEventListener("click", (e) => {
+              e.stopPropagation();
+              fnSelectedRepos(item.dataset.repoName);
+            });
+          });
+      }
+      highlightedIndex = -1;
+      showDropdown();
+    }
 
-		function fnSelectedRepos(repoFullName) {
-			if (!selectedRepos.includes(repoFullName)) {
-				selectedRepos.push(repoFullName);
-				updateRepoDisplay();
-				saveRepoSelection();
-			}
+    function fnSelectedRepos(repoFullName) {
+      if (!selectedRepos.includes(repoFullName)) {
+        selectedRepos.push(repoFullName);
+        updateRepoDisplay();
+        saveRepoSelection();
+      }
 
-			repoSearch.value = '';
-			filterAndDisplayRepos('');
-			programmaticFocus = true;
-			repoSearch.focus();
-		}
+      repoSearch.value = "";
+      filterAndDisplayRepos("");
+      programmaticFocus = true;
+      repoSearch.focus();
+    }
 
-		function removeRepo(repoFullName) {
-			selectedRepos = selectedRepos.filter((name) => name !== repoFullName);
-			updateRepoDisplay();
-			saveRepoSelection();
+    function removeRepo(repoFullName) {
+      selectedRepos = selectedRepos.filter((name) => name !== repoFullName);
+      updateRepoDisplay();
+      saveRepoSelection();
 
-			if (repoSearch.value) {
-				filterAndDisplayRepos(repoSearch.value.toLowerCase());
-			}
-		}
+      if (repoSearch.value) {
+        filterAndDisplayRepos(repoSearch.value.toLowerCase());
+      }
+    }
 
 		function updateRepoDisplay() {
 			if (selectedRepos.length === 0) {
@@ -1580,26 +1744,26 @@ document.addEventListener('DOMContentLoaded', () => {
 			});
 		}
 
-		function showDropdown() {
-			repoDropdown.classList.remove('hidden');
-		}
+    function showDropdown() {
+      repoDropdown.classList.remove("hidden");
+    }
 
-		function hideDropdown() {
-			repoDropdown.classList.add('hidden');
-			highlightedIndex = -1;
-		}
+    function hideDropdown() {
+      repoDropdown.classList.add("hidden");
+      highlightedIndex = -1;
+    }
 
-		function updateHighlight(items) {
-			items.forEach((item, index) => {
-				item.classList.toggle('highlighted', index === highlightedIndex);
-			});
+    function updateHighlight(items) {
+      items.forEach((item, index) => {
+        item.classList.toggle("highlighted", index === highlightedIndex);
+      });
 
-			if (highlightedIndex >= 0 && items[highlightedIndex]) {
-				items[highlightedIndex].scrollIntoView({ block: 'nearest' });
-			}
-		}
+      if (highlightedIndex >= 0 && items[highlightedIndex]) {
+        items[highlightedIndex].scrollIntoView({ block: "nearest" });
+      }
+    }
 
-		window.removeRepo = removeRepo;
+    window.removeRepo = removeRepo;
 
 		browser.storage.local.get(['platform', 'githubUsername']).then((items) => {
 			const platform = items.platform || 'github';
@@ -1612,7 +1776,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 });
 
-const cacheInput = document.getElementById('cacheInput');
+const cacheInput = document.getElementById("cacheInput");
 if (cacheInput) {
 	browser.storage.local.get(['cacheInput']).then((result) => {
 		if (result.cacheInput) {
@@ -1622,19 +1786,19 @@ if (cacheInput) {
 		}
 	});
 
-	cacheInput.addEventListener('blur', function () {
-		let ttlValue = Number.parseInt(this.value, 10);
-		if (Number.isNaN(ttlValue) || ttlValue <= 0 || this.value.trim() === '') {
-			ttlValue = 10;
-			this.value = ttlValue;
-			this.style.borderColor = '#ef4444';
-		} else if (ttlValue > 1440) {
-			ttlValue = 1440;
-			this.value = ttlValue;
-			this.style.borderColor = '#f59e0b';
-		} else {
-			this.style.borderColor = '#10b981';
-		}
+  cacheInput.addEventListener("blur", function () {
+    let ttlValue = Number.parseInt(this.value, 10);
+    if (Number.isNaN(ttlValue) || ttlValue <= 0 || this.value.trim() === "") {
+      ttlValue = 10;
+      this.value = ttlValue;
+      this.style.borderColor = "#ef4444";
+    } else if (ttlValue > 1440) {
+      ttlValue = 1440;
+      this.value = ttlValue;
+      this.style.borderColor = "#f59e0b";
+    } else {
+      this.style.borderColor = "#10b981";
+    }
 
 		browser.storage.local.set({ cacheInput: ttlValue }).then(() => {
 			console.log('Cache TTL saved:', ttlValue, 'minutes');
@@ -1664,30 +1828,30 @@ function updatePlatformUI(platform) {
 		}
 	}
 
-	const orgSection = document.querySelector('.orgSection');
-	if (orgSection) {
-		if (platform === 'gitlab') {
-			orgSection.classList.add('hidden');
-		} else {
-			orgSection.classList.remove('hidden');
-		}
-	}
-	const githubOnlySections = document.querySelectorAll('.githubOnlySection');
-	githubOnlySections.forEach((el) => {
-		if (platform === 'gitlab') {
-			el.classList.add('hidden');
-		} else {
-			el.classList.remove('hidden');
-		}
-	});
-	const gitlabOnlySections = document.querySelectorAll('.gitlabOnlySection');
-	gitlabOnlySections.forEach((el) => {
-		if (platform === 'github') {
-			el.classList.add('hidden');
-		} else {
-			el.classList.remove('hidden');
-		}
-	});
+  const orgSection = document.querySelector(".orgSection");
+  if (orgSection) {
+    if (platform === "gitlab") {
+      orgSection.classList.add("hidden");
+    } else {
+      orgSection.classList.remove("hidden");
+    }
+  }
+  const githubOnlySections = document.querySelectorAll(".githubOnlySection");
+  githubOnlySections.forEach((el) => {
+    if (platform === "gitlab") {
+      el.classList.add("hidden");
+    } else {
+      el.classList.remove("hidden");
+    }
+  });
+  const gitlabOnlySections = document.querySelectorAll(".gitlabOnlySection");
+  gitlabOnlySections.forEach((el) => {
+    if (platform === "github") {
+      el.classList.add("hidden");
+    } else {
+      el.classList.remove("hidden");
+    }
+  });
 }
 
 platformSelect.addEventListener('change', () => {
@@ -1717,30 +1881,33 @@ platformSelect.addEventListener('change', () => {
 		}
 	});
 
-	updatePlatformUI(platform);
+  updatePlatformUI(platform);
 });
 
-const customDropdown = document.getElementById('customPlatformDropdown');
-const dropdownBtn = document.getElementById('platformDropdownBtn');
-const dropdownList = document.getElementById('platformDropdownList');
-const dropdownSelected = document.getElementById('platformDropdownSelected');
-const platformSelectHidden = document.getElementById('platformSelect');
+const customDropdown = document.getElementById("customPlatformDropdown");
+const dropdownBtn = document.getElementById("platformDropdownBtn");
+const dropdownList = document.getElementById("platformDropdownList");
+const dropdownSelected = document.getElementById("platformDropdownSelected");
+const platformSelectHidden = document.getElementById("platformSelect");
 
 function buildScrumSubjectFromPopup() {
-	const projectName = document.getElementById('projectName')?.value?.trim() || '';
-	const now = new Date();
-	const dateCode =
-		String(now.getFullYear()) + String(now.getMonth() + 1).padStart(2, '0') + String(now.getDate()).padStart(2, '0');
+  const projectName =
+    document.getElementById("projectName")?.value?.trim() || "";
+  const now = new Date();
+  const dateCode =
+    String(now.getFullYear()) +
+    String(now.getMonth() + 1).padStart(2, "0") +
+    String(now.getDate()).padStart(2, "0");
 
-	return `[Scrum]${projectName ? ' - ' + projectName : ''} - ${dateCode}`;
+  return `[Scrum]${projectName ? " - " + projectName : ""} - ${dateCode}`;
 }
 
 function setPlatformDropdown(value) {
-	if (value === 'gitlab') {
-		dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
-	} else {
-		dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
-	}
+  if (value === "gitlab") {
+    dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
+  } else {
+    dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
+  }
 
 	const platformUsername = document.getElementById('platformUsername');
 	if (platformUsername) {
@@ -1768,19 +1935,19 @@ function setPlatformDropdown(value) {
 		}
 	});
 
-	updatePlatformUI(value);
+  updatePlatformUI(value);
 }
 
-dropdownBtn.addEventListener('click', (e) => {
-	e.stopPropagation();
-	customDropdown.classList.toggle('open');
-	dropdownList.classList.toggle('hidden');
+dropdownBtn.addEventListener("click", (e) => {
+  e.stopPropagation();
+  customDropdown.classList.toggle("open");
+  dropdownList.classList.toggle("hidden");
 });
 
-dropdownList.querySelectorAll('li').forEach((item) => {
-	item.addEventListener('click', function (e) {
-		const newPlatform = this.getAttribute('data-value');
-		const currentPlatform = platformSelectHidden.value;
+dropdownList.querySelectorAll("li").forEach((item) => {
+  item.addEventListener("click", function (e) {
+    const newPlatform = this.getAttribute("data-value");
+    const currentPlatform = platformSelectHidden.value;
 
 		if (newPlatform !== currentPlatform) {
 			const platformUsername = document.getElementById('platformUsername');
@@ -1792,41 +1959,41 @@ dropdownList.querySelectorAll('li').forEach((item) => {
 			}
 		}
 
-		setPlatformDropdown(newPlatform);
-		customDropdown.classList.remove('open');
-		dropdownList.classList.add('hidden');
-	});
+    setPlatformDropdown(newPlatform);
+    customDropdown.classList.remove("open");
+    dropdownList.classList.add("hidden");
+  });
 });
 
-document.addEventListener('click', (e) => {
-	if (!customDropdown.contains(e.target)) {
-		customDropdown.classList.remove('open');
-		dropdownList.classList.add('hidden');
-	}
+document.addEventListener("click", (e) => {
+  if (!customDropdown.contains(e.target)) {
+    customDropdown.classList.remove("open");
+    dropdownList.classList.add("hidden");
+  }
 });
 
 // Keyboard navigation
-platformDropdownBtn.addEventListener('keydown', (e) => {
-	if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
-		e.preventDefault();
-		customDropdown.classList.add('open');
-		dropdownList.classList.remove('hidden');
-		dropdownList.querySelector('li').focus();
-	}
+platformDropdownBtn.addEventListener("keydown", (e) => {
+  if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+    e.preventDefault();
+    customDropdown.classList.add("open");
+    dropdownList.classList.remove("hidden");
+    dropdownList.querySelector("li").focus();
+  }
 });
-dropdownList.querySelectorAll('li').forEach((item, idx, arr) => {
-	item.setAttribute('tabindex', '0');
-	item.addEventListener('keydown', function (e) {
-		if (e.key === 'ArrowDown') {
-			e.preventDefault();
-			(arr[idx + 1] || arr[0]).focus();
-		} else if (e.key === 'ArrowUp') {
-			e.preventDefault();
-			(arr[idx - 1] || arr[arr.length - 1]).focus();
-		} else if (e.key === 'Enter' || e.key === ' ') {
-			e.preventDefault();
-			const newPlatform = this.getAttribute('data-value');
-			const currentPlatform = platformSelectHidden.value;
+dropdownList.querySelectorAll("li").forEach((item, idx, arr) => {
+  item.setAttribute("tabindex", "0");
+  item.addEventListener("keydown", function (e) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      (arr[idx + 1] || arr[0]).focus();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      (arr[idx - 1] || arr[arr.length - 1]).focus();
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      const newPlatform = this.getAttribute("data-value");
+      const currentPlatform = platformSelectHidden.value;
 
 			// Save current username for current platform before switching
 			if (newPlatform !== currentPlatform) {
@@ -1839,12 +2006,12 @@ dropdownList.querySelectorAll('li').forEach((item, idx, arr) => {
 				}
 			}
 
-			setPlatformDropdown(newPlatform);
-			customDropdown.classList.remove('open');
-			dropdownList.classList.add('hidden');
-			dropdownBtn.focus();
-		}
-	});
+      setPlatformDropdown(newPlatform);
+      customDropdown.classList.remove("open");
+      dropdownList.classList.add("hidden");
+      dropdownBtn.focus();
+    }
+  });
 });
 
 // On load, restore platform from storage
@@ -1861,56 +2028,56 @@ browser.storage.local.get(['platform']).then((result) => {
 });
 
 // Tooltip bubble
-document.querySelectorAll('.tooltip-container').forEach((container) => {
-	const bubble = container.querySelector('.tooltip-bubble');
-	if (!bubble) return;
+document.querySelectorAll(".tooltip-container").forEach((container) => {
+  const bubble = container.querySelector(".tooltip-bubble");
+  if (!bubble) return;
 
-	function positionTooltip() {
-		const icon = container.querySelector('.question-icon') || container;
-		const rect = icon.getBoundingClientRect();
-		const bubbleRect = bubble.getBoundingClientRect();
-		const padding = 8;
+  function positionTooltip() {
+    const icon = container.querySelector(".question-icon") || container;
+    const rect = icon.getBoundingClientRect();
+    const bubbleRect = bubble.getBoundingClientRect();
+    const padding = 8;
 
-		let top = rect.top + window.scrollY;
-		let left = rect.right + padding + window.scrollX;
+    let top = rect.top + window.scrollY;
+    let left = rect.right + padding + window.scrollX;
 
-		if (left + bubbleRect.width > window.innerWidth - 10) {
-			left = rect.left - bubbleRect.width - padding + window.scrollX;
-		}
-		if (left < 8) left = 8;
-		if (top + bubbleRect.height > window.innerHeight - 10) {
-			top = rect.top - bubbleRect.height - padding + window.scrollY;
-		}
-		if (top < 8) top = 8;
+    if (left + bubbleRect.width > window.innerWidth - 10) {
+      left = rect.left - bubbleRect.width - padding + window.scrollX;
+    }
+    if (left < 8) left = 8;
+    if (top + bubbleRect.height > window.innerHeight - 10) {
+      top = rect.top - bubbleRect.height - padding + window.scrollY;
+    }
+    if (top < 8) top = 8;
 
-		bubble.style.left = left + 'px';
-		bubble.style.top = top + 'px';
-	}
+    bubble.style.left = left + "px";
+    bubble.style.top = top + "px";
+  }
 
-	container.addEventListener('mouseenter', positionTooltip);
-	container.addEventListener('focusin', positionTooltip);
-	container.addEventListener('mousemove', positionTooltip);
-	container.addEventListener('mouseleave', () => {
-		bubble.style.left = '';
-		bubble.style.top = '';
-	});
-	container.addEventListener('focusout', () => {
-		bubble.style.left = '';
-		bubble.style.top = '';
-	});
+  container.addEventListener("mouseenter", positionTooltip);
+  container.addEventListener("focusin", positionTooltip);
+  container.addEventListener("mousemove", positionTooltip);
+  container.addEventListener("mouseleave", () => {
+    bubble.style.left = "";
+    bubble.style.top = "";
+  });
+  container.addEventListener("focusout", () => {
+    bubble.style.left = "";
+    bubble.style.top = "";
+  });
 });
 
 // Radio button click handlers with toggle functionality
 document.querySelectorAll('input[name="timeframe"]').forEach((radio) => {
-	radio.addEventListener('click', function () {
-		if (this.dataset.wasChecked === 'true') {
-			this.checked = false;
-			this.dataset.wasChecked = 'false';
+  radio.addEventListener("click", function () {
+    if (this.dataset.wasChecked === "true") {
+      this.checked = false;
+      this.dataset.wasChecked = "false";
 
-			const startDateInput = document.getElementById('startingDate');
-			const endDateInput = document.getElementById('endingDate');
-			startDateInput.readOnly = false;
-			endDateInput.readOnly = false;
+      const startDateInput = document.getElementById("startingDate");
+      const endDateInput = document.getElementById("endingDate");
+      startDateInput.readOnly = false;
+      endDateInput.readOnly = false;
 
 			browser.storage.local.set({
 				yesterdayContribution: false,
@@ -1947,8 +2114,10 @@ document.querySelectorAll('input[name="timeframe"]').forEach((radio) => {
 
 // refresh cache button
 
-document.getElementById('refreshCache').addEventListener('click', async function () {
-	const originalText = this.innerHTML;
+document
+  .getElementById("refreshCache")
+  .addEventListener("click", async function () {
+    const originalText = this.innerHTML;
 
 	this.classList.add('loading');
 	this.innerHTML = `<i class="fa fa-refresh fa-spin"></i><span>${browser.i18n.getMessage('refreshingButton')}</span>`;
@@ -1972,19 +2141,19 @@ document.getElementById('refreshCache').addEventListener('click', async function
 			scrumReport.innerHTML = `<p style="text-align: center; color: #666; padding: 20px;">${browser.i18n.getMessage('cacheClearedMessage')}</p>`;
 		}
 
-		if (typeof availableRepos !== 'undefined') {
-			availableRepos = [];
-		}
+      if (typeof availableRepos !== "undefined") {
+        availableRepos = [];
+      }
 
-		const repoStatus = document.getElementById('repoStatus');
-		if (repoStatus) {
-			repoStatus.textContent = '';
-		}
+      const repoStatus = document.getElementById("repoStatus");
+      if (repoStatus) {
+        repoStatus.textContent = "";
+      }
 
 		this.innerHTML = `<i class="fa fa-check"></i><span>${browser.i18n.getMessage('cacheClearedButton')}</span>`;
 		this.classList.remove('loading');
 
-		// Do NOT trigger report generation automatically
+      // Do NOT trigger report generation automatically
 
 		setTimeout(() => {
 			this.innerHTML = originalText;
@@ -1995,25 +2164,25 @@ document.getElementById('refreshCache').addEventListener('click', async function
 		this.innerHTML = `<i class="fa fa-exclamation-triangle"></i><span>${browser.i18n.getMessage('cacheClearFailed')}</span>`;
 		this.classList.remove('loading');
 
-		setTimeout(() => {
-			this.innerHTML = originalText;
-			this.disabled = false;
-		}, 3000);
-	}
-});
+      setTimeout(() => {
+        this.innerHTML = originalText;
+        this.disabled = false;
+      }, 3000);
+    }
+  });
 
 function toggleRadio(radio) {
-	const startDateInput = document.getElementById('startingDate');
-	const endDateInput = document.getElementById('endingDate');
+  const startDateInput = document.getElementById("startingDate");
+  const endDateInput = document.getElementById("endingDate");
 
-	console.log('Toggling radio:', radio.id);
+  console.log("Toggling radio:", radio.id);
 
-	if (radio.id === 'yesterdayContribution') {
-		startDateInput.value = getYesterday();
-		endDateInput.value = getToday();
-	}
+  if (radio.id === "yesterdayContribution") {
+    startDateInput.value = getYesterday();
+    endDateInput.value = getToday();
+  }
 
-	startDateInput.readOnly = endDateInput.readOnly = true;
+  startDateInput.readOnly = endDateInput.readOnly = true;
 
 	browser.storage.local
 		.set({
@@ -2034,9 +2203,9 @@ function toggleRadio(radio) {
 }
 
 async function triggerRepoFetchIfEnabled() {
-	if (window.triggerRepoFetchIfEnabled) {
-		await window.triggerRepoFetchIfEnabled();
-	}
+  if (window.triggerRepoFetchIfEnabled) {
+    await window.triggerRepoFetchIfEnabled();
+  }
 }
 
 // Keyboard shortcuts: Ctrl+G / Cmd+G to generate, Ctrl+Shift+Y / Cmd+Shift+Y to copy, Ctrl+Shift+M / Cmd+Shift+M to insert in email

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -680,7 +680,7 @@ function allIncluded(outputTarget = 'email') {
 			await new Promise((res) => setTimeout(res, 500));
 
 			log('Validating GitHub user existence for:', platformUsernameLocal);
-			const userCheckRes = await fetch(userUrl, { headers });
+			const userCheckRes = await githubRequest(userUrl, { headers });
 
 			if (userCheckRes.status === 404) {
 				const errorMsg = chrome?.i18n.getMessage('githubUserNotFoundError', [platformUsernameLocal]) || `GitHub user "${platformUsernameLocal}" not found (404). Please check the username and try again.`;
@@ -701,8 +701,8 @@ function allIncluded(outputTarget = 'email') {
 			}
 
 			const [issuesRes, prRes, userRes] = await Promise.all([
-				fetch(issueUrl, { headers }),
-				fetch(prUrl, { headers }),
+				githubRequest(issueUrl, { headers }),
+				githubRequest(prUrl, { headers }),
 				userCheckRes, // Reuse the already validated user response
 			]);
 
@@ -804,6 +804,17 @@ function allIncluded(outputTarget = 'email') {
 			githubCache.queue = [];
 		} catch (err) {
 			logError('Fetch Failed:', err);
+
+			// Handle rate limit errors by showing the banner instead of a generic error
+			if (err.name === 'RateLimitError') {
+				if (typeof showRateLimitWarning === 'function') showRateLimitWarning(err);
+				githubCache.queue.forEach(({ reject }) => reject(err));
+				githubCache.queue = [];
+				githubCache.fetching = false;
+				scrumGenerationInProgress = false;
+				return;
+			}
+
 			// Reject queued calls on error
 			githubCache.queue.forEach(({ reject }) => {
 				reject(err);
@@ -876,7 +887,7 @@ function allIncluded(outputTarget = 'email') {
 			.join('\n');
 		const query = `query { ${queries} }`;
 		log('GraphQL query for commits:', query);
-		const res = await fetch('https://api.github.com/graphql', {
+		const res = await githubRequest('https://api.github.com/graphql', {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
@@ -1494,7 +1505,7 @@ ${blockerText}`;
 		}
 		const url = `https://api.github.com/repos/${owner}/${repo}/pulls/${number}`;
 		try {
-			const res = await fetch(url, { headers });
+			const res = await githubRequest(url, { headers });
 			if (!res.ok) return null;
 			const data = await res.json();
 			const merged = !!data.merged_at;
@@ -2068,7 +2079,7 @@ ${prs
 }`;
 
 	try {
-		const res = await fetch('https://api.github.com/graphql', {
+		const res = await githubRequest('https://api.github.com/graphql', {
 			method: 'POST',
 			headers: graphqlHeaders,
 			body: JSON.stringify({ query }),
@@ -2081,6 +2092,9 @@ ${prs
 		});
 		return results;
 	} catch (e) {
+		if (e.name === 'RateLimitError') {
+			if (typeof showRateLimitWarning === 'function') showRateLimitWarning(e);
+		}
 		return results;
 	}
 }
@@ -2209,7 +2223,7 @@ async function fetchUserRepositories(username, token, org = '') {
 		const query = `query { ${repoQueries} }`;
 
 		try {
-			const res = await fetch('https://api.github.com/graphql', {
+			const res = await githubRequest('https://api.github.com/graphql', {
 				method: 'POST',
 				headers: {
 					...headers,

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -2155,8 +2155,8 @@ async function fetchUserRepositories(username, token, org = '') {
 		console.log('Search URLs:', { issuesUrl, commentsUrl });
 
 		const [issuesRes, commentsRes] = await Promise.all([
-			fetch(issuesUrl, { headers }).catch(() => ({ ok: false, json: () => ({ items: [] }) })),
-			fetch(commentsUrl, { headers }).catch(() => ({ ok: false, json: () => ({ items: [] }) })),
+			githubRequest(issuesUrl, { headers }).catch(() => ({ ok: false, json: () => ({ items: [] }) })),
+			githubRequest(commentsUrl, { headers }).catch(() => ({ ok: false, json: () => ({ items: [] }) })),
 		]);
 
 		const repoSet = new Set();

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -26,7 +26,7 @@ function renderErrorMessage(container, key, fallback, args = []) {
 	errorDiv.style.color = '#dc2626';
 	errorDiv.style.fontWeight = 'bold';
 	errorDiv.style.padding = '10px';
-	errorDiv.textContent = message; 
+	errorDiv.textContent = message;
 	container.innerHTML = '';
 	container.appendChild(errorDiv);
 }
@@ -220,7 +220,11 @@ function allIncluded(outputTarget = 'email') {
 							const scrumReport = document.getElementById('scrumReport');
 							const generateBtn = document.getElementById('generateReport');
 							if (scrumReport) {
-								renderErrorMessage(scrumReport, 'usernameRequiredError', 'Please enter your username to generate a report.');
+								renderErrorMessage(
+									scrumReport,
+									'usernameRequiredError',
+									'Please enter your username to generate a report.',
+								);
 							}
 							if (generateBtn) {
 								generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
@@ -309,7 +313,9 @@ function allIncluded(outputTarget = 'email') {
 											if (err && typeof err.message === 'string' && err.message.trim().length > 0) {
 												errMsg = err.message;
 											} else {
-												errMsg = chrome?.i18n.getMessage('gitlabFetchingError') || 'An error occurred while fetching GitLab data.';
+												errMsg =
+													chrome?.i18n.getMessage('gitlabFetchingError') ||
+													'An error occurred while fetching GitLab data.';
 											}
 											renderErrorMessage(scrumReport, '', errMsg);
 										}
@@ -363,7 +369,9 @@ function allIncluded(outputTarget = 'email') {
 											if (err && typeof err.message === 'string' && err.message.trim().length > 0) {
 												errMsg = err.message;
 											} else {
-												errMsg = chrome?.i18n.getMessage('gitlabFetchingError') || 'An error occurred while fetching GitLab data.';
+												errMsg =
+													chrome?.i18n.getMessage('gitlabFetchingError') ||
+													'An error occurred while fetching GitLab data.';
 											}
 											renderErrorMessage(scrumReport, '', errMsg);
 										}
@@ -377,7 +385,11 @@ function allIncluded(outputTarget = 'email') {
 							const scrumReport = document.getElementById('scrumReport');
 							const generateBtn = document.getElementById('generateReport');
 							if (scrumReport) {
-								renderErrorMessage(scrumReport, 'usernameRequiredError', 'Please enter your username to generate a report.');
+								renderErrorMessage(
+									scrumReport,
+									'usernameRequiredError',
+									'Please enter your username to generate a report.',
+								);
 							}
 							if (generateBtn) {
 								generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
@@ -683,7 +695,9 @@ function allIncluded(outputTarget = 'email') {
 			const userCheckRes = await githubRequest(userUrl, { headers });
 
 			if (userCheckRes.status === 404) {
-				const errorMsg = chrome?.i18n.getMessage('githubUserNotFoundError', [platformUsernameLocal]) || `GitHub user "${platformUsernameLocal}" not found (404). Please check the username and try again.`;
+				const errorMsg =
+					chrome?.i18n.getMessage('githubUserNotFoundError', [platformUsernameLocal]) ||
+					`GitHub user "${platformUsernameLocal}" not found (404). Please check the username and try again.`;
 				logError(errorMsg);
 				throw new Error(errorMsg);
 			}
@@ -695,7 +709,9 @@ function allIncluded(outputTarget = 'email') {
 			}
 
 			if (!userCheckRes.ok) {
-				const errorMsg = chrome?.i18n.getMessage('githubUserValidationError', [userCheckRes.status, userCheckRes.statusText]) || `Error validating GitHub user: ${userCheckRes.status} ${userCheckRes.statusText}`;
+				const errorMsg =
+					chrome?.i18n.getMessage('githubUserValidationError', [userCheckRes.status, userCheckRes.statusText]) ||
+					`Error validating GitHub user: ${userCheckRes.status} ${userCheckRes.statusText}`;
 				logError(errorMsg);
 				throw new Error(errorMsg);
 			}
@@ -713,7 +729,9 @@ function allIncluded(outputTarget = 'email') {
 			}
 
 			if (issuesRes.status === 422 || prRes.status === 422) {
-				const errorMsg = chrome?.i18n.getMessage('invalidSearchQueryError') || `Invalid search query or date range. Please verify your date range format and try again.`;
+				const errorMsg =
+					chrome?.i18n.getMessage('invalidSearchQueryError') ||
+					`Invalid search query or date range. Please verify your date range format and try again.`;
 				logError(errorMsg);
 				if (outputTarget === 'popup') {
 					Materialize.toast && Materialize.toast(errorMsg, 4000);
@@ -722,7 +740,9 @@ function allIncluded(outputTarget = 'email') {
 			}
 
 			if (!issuesRes.ok) {
-				const errorMsg = chrome?.i18n.getMessage('githubIssuesFetchError', [issuesRes.status, issuesRes.statusText]) || `Error fetching GitHub issues: ${issuesRes.status} ${issuesRes.statusText}`;
+				const errorMsg =
+					chrome?.i18n.getMessage('githubIssuesFetchError', [issuesRes.status, issuesRes.statusText]) ||
+					`Error fetching GitHub issues: ${issuesRes.status} ${issuesRes.statusText}`;
 				logError(errorMsg);
 				if (outputTarget === 'popup') {
 					Materialize.toast && Materialize.toast(errorMsg, 4000);
@@ -730,7 +750,9 @@ function allIncluded(outputTarget = 'email') {
 				throw new Error(errorMsg);
 			}
 			if (!prRes.ok) {
-				const errorMsg = chrome?.i18n.getMessage('githubPRReviewFetchError', [prRes.status, prRes.statusText]) || `Error fetching GitHub PR review data: ${prRes.status} ${prRes.statusText}`;
+				const errorMsg =
+					chrome?.i18n.getMessage('githubPRReviewFetchError', [prRes.status, prRes.statusText]) ||
+					`Error fetching GitHub PR review data: ${prRes.status} ${prRes.statusText}`;
 				logError(errorMsg);
 				if (outputTarget === 'popup') {
 					Materialize.toast && Materialize.toast(errorMsg, 4000);
@@ -738,7 +760,9 @@ function allIncluded(outputTarget = 'email') {
 				throw new Error(errorMsg);
 			}
 			if (!userRes.ok) {
-				const errorMsg = chrome?.i18n.getMessage('githubUserFetchError', [userRes.status, userRes.statusText]) || `Error fetching GitHub user data: ${userRes.status} ${userRes.statusText}`;
+				const errorMsg =
+					chrome?.i18n.getMessage('githubUserFetchError', [userRes.status, userRes.statusText]) ||
+					`Error fetching GitHub user data: ${userRes.status} ${userRes.statusText}`;
 				logError(errorMsg);
 				throw new Error(errorMsg);
 			}
@@ -804,10 +828,18 @@ function allIncluded(outputTarget = 'email') {
 			githubCache.queue = [];
 		} catch (err) {
 			logError('Fetch Failed:', err);
-
+			console.log(err, "in the all included function");
+			
 			// Handle rate limit errors by showing the banner instead of a generic error
 			if (err.name === 'RateLimitError') {
-				if (typeof showRateLimitWarning === 'function') showRateLimitWarning(err);
+				if (typeof renderTokenSetupUI === 'function'){ 
+					console.log("in the  render token if condition block");	
+					document.addEventListener("DOMContentLoaded", () => {
+						console.log("dom loaded and now calling the render token setup ui");
+						
+    						window.renderTokenSetupUI(error);
+                   });
+				}
 				githubCache.queue.forEach(({ reject }) => reject(err));
 				githubCache.queue = [];
 				githubCache.fetching = false;
@@ -825,7 +857,8 @@ function allIncluded(outputTarget = 'email') {
 			if (outputTarget === 'popup') {
 				const generateBtn = document.getElementById('generateReport');
 				if (scrumReport) {
-					let errorMsg = chrome?.i18n.getMessage('reportGenerationError') || 'An error occurred while generating the report.';
+					let errorMsg =
+						chrome?.i18n.getMessage('reportGenerationError') || 'An error occurred while generating the report.';
 					if (err) {
 						if (typeof err === 'string') errorMsg = err;
 						else if (err.message) errorMsg = err.message;
@@ -1004,7 +1037,9 @@ function allIncluded(outputTarget = 'email') {
 	verifyCacheStatus();
 
 	function showInvalidTokenMessage() {
-		const errMsg = chrome?.i18n.getMessage('invalidTokenError') || 'Invalid or expired GitHub token. Please check your token in the Scrum Helper settings and try again.';
+		const errMsg =
+			chrome?.i18n.getMessage('invalidTokenError') ||
+			'Invalid or expired GitHub token. Please check your token in the Scrum Helper settings and try again.';
 		if (outputTarget === 'popup') {
 			const reportDiv = document.getElementById('scrumReport');
 			if (reportDiv) {
@@ -2092,9 +2127,7 @@ ${prs
 		});
 		return results;
 	} catch (e) {
-		if (e.name === 'RateLimitError') {
-			if (typeof showRateLimitWarning === 'function') showRateLimitWarning(e);
-		}
+		console.warn('[PRs-MERGED] Error fetching PR merged status:', e?.message);
 		return results;
 	}
 }

--- a/src/scripts/utils/githubRequest.js
+++ b/src/scripts/utils/githubRequest.js
@@ -1,0 +1,39 @@
+async function githubRequest(url, options = {}) {
+  const response = await fetch(url, options);
+
+  const remaining = Number(response.headers.get("x-ratelimit-remaining"));
+  const reset = Number(response.headers.get("x-ratelimit-reset"));
+  const resetMs = reset * 1000;
+
+  // GitHub returns 403 with remaining=0 when rate-limited
+  if (response.status === 403 && remaining === 0) {
+    const waitSeconds = Math.ceil((resetMs - Date.now()) / 1000);
+    console.warn(`GitHub rate limit hit. Resets in ${waitSeconds}s`);
+    const error = new Error(
+      `GitHub API rate limit exceeded. Resets in ${waitSeconds > 0 ? waitSeconds : 60}s.`,
+    );
+    error.name = "RateLimitError";
+    error.platform = "github";
+    error.resetAt = resetMs;
+    error.remaining = 0;
+    error.retryAfter = waitSeconds > 0 ? waitSeconds : 60;
+    throw error;
+  }
+
+  // Also handle explicit 429 Too Many Requests
+  if (response.status === 429) {
+    const retryAfter = Number(response.headers.get("retry-after") || 60);
+    console.warn(`GitHub 429 rate limit hit. Retry after ${retryAfter}s`);
+    const error = new Error(
+      `GitHub API rate limit exceeded (429). Retry after ${retryAfter}s.`,
+    );
+    error.name = "RateLimitError";
+    error.platform = "github";
+    error.resetAt = resetMs || Date.now() + retryAfter * 1000;
+    error.remaining = 0;
+    error.retryAfter = retryAfter;
+    throw error;
+  }
+
+  return response;
+}

--- a/src/scripts/utils/githubRequest.js
+++ b/src/scripts/utils/githubRequest.js
@@ -22,16 +22,22 @@ async function githubRequest(url, options = {}) {
 
   // Also handle explicit 429 Too Many Requests
   if (response.status === 429) {
-    const retryAfter = Number(response.headers.get("retry-after") || 60);
-    console.warn(`GitHub 429 rate limit hit. Retry after ${retryAfter}s`);
+    // retry-after header is a duration in seconds; x-ratelimit-reset is a Unix timestamp
+    const retryAfterHeader = Number(response.headers.get("x-ratelimit-remaining") || response.headers.get("retry-after"));
+    const waitSeconds = resetMs
+      ? Math.ceil((resetMs - Date.now()) / 1000)
+      : retryAfterHeader > 0
+        ? retryAfterHeader
+        : 60;
+    console.warn(`GitHub 429 rate limit hit. Retry after ${waitSeconds}s`);
     const error = new Error(
-      `GitHub API rate limit exceeded (429). Retry after ${retryAfter}s.`,
+      `GitHub API rate limit exceeded (429). Retry after ${waitSeconds}s.`,
     );
     error.name = "RateLimitError";
     error.platform = "github";
-    error.resetAt = resetMs || Date.now() + retryAfter * 1000;
+    error.resetAt = resetMs || Date.now() + waitSeconds * 1000;
     error.remaining = 0;
-    error.retryAfter = retryAfter;
+    error.retryAfter = waitSeconds > 0 ? waitSeconds : 60;
     throw error;
   }
 

--- a/src/scripts/utils/githubRequest.js
+++ b/src/scripts/utils/githubRequest.js
@@ -1,45 +1,43 @@
 async function githubRequest(url, options = {}) {
-  const response = await fetch(url, options);
+	const response = await fetch(url, options);
 
-  const remaining = Number(response.headers.get("x-ratelimit-remaining"));
-  const reset = Number(response.headers.get("x-ratelimit-reset"));
-  const resetMs = reset * 1000;
+	const remaining = Number(response.headers.get('x-ratelimit-remaining'));
+	const reset = Number(response.headers.get('x-ratelimit-reset'));
+	const resetMs = reset * 1000;
 
-  // GitHub returns 403 with remaining=0 when rate-limited
-  if (response.status === 403 && remaining === 0) {
-    const waitSeconds = Math.ceil((resetMs - Date.now()) / 1000);
-    console.warn(`GitHub rate limit hit. Resets in ${waitSeconds}s`);
-    const error = new Error(
-      `GitHub API rate limit exceeded. Resets in ${waitSeconds > 0 ? waitSeconds : 60}s.`,
-    );
-    error.name = "RateLimitError";
-    error.platform = "github";
-    error.resetAt = resetMs;
-    error.remaining = 0;
-    error.retryAfter = waitSeconds > 0 ? waitSeconds : 60;
-    throw error;
-  }
+	// GitHub returns 403 with remaining=0 when rate-limited
+	if (response.status === 403 && remaining === 0) {
+		const waitSeconds = Math.ceil((resetMs - Date.now()) / 1000);
+		console.warn(`GitHub rate limit hit. Resets in ${waitSeconds}s`);
+		const error = new Error(`GitHub API rate limit exceeded. Resets in ${waitSeconds > 0 ? waitSeconds : 60}s.`);
+		error.name = 'RateLimitError';
+		error.platform = 'github';
+		error.resetAt = resetMs;
+		error.remaining = 0;
+		error.retryAfter = waitSeconds > 0 ? waitSeconds : 60;
+		throw error;
+	}
 
-  // Also handle explicit 429 Too Many Requests
-  if (response.status === 429) {
-    // retry-after header is a duration in seconds; x-ratelimit-reset is a Unix timestamp
-    const retryAfterHeader = Number(response.headers.get("x-ratelimit-remaining") || response.headers.get("retry-after"));
-    const waitSeconds = resetMs
-      ? Math.ceil((resetMs - Date.now()) / 1000)
-      : retryAfterHeader > 0
-        ? retryAfterHeader
-        : 60;
-    console.warn(`GitHub 429 rate limit hit. Retry after ${waitSeconds}s`);
-    const error = new Error(
-      `GitHub API rate limit exceeded (429). Retry after ${waitSeconds}s.`,
-    );
-    error.name = "RateLimitError";
-    error.platform = "github";
-    error.resetAt = resetMs || Date.now() + waitSeconds * 1000;
-    error.remaining = 0;
-    error.retryAfter = waitSeconds > 0 ? waitSeconds : 60;
-    throw error;
-  }
+	// Also handle explicit 429 Too Many Requests
+	if (response.status === 429) {
+		// retry-after header is a duration in seconds; x-ratelimit-reset is a Unix timestamp
+		const retryAfterHeader = Number(
+			response.headers.get('x-ratelimit-remaining') || response.headers.get('retry-after'),
+		);
+		const waitSeconds = resetMs
+			? Math.ceil((resetMs - Date.now()) / 1000)
+			: retryAfterHeader > 0
+				? retryAfterHeader
+				: 60;
+		console.warn(`GitHub 429 rate limit hit. Retry after ${waitSeconds}s`);
+		const error = new Error(`GitHub API rate limit exceeded (429). Retry after ${waitSeconds}s.`);
+		error.name = 'RateLimitError';
+		error.platform = 'github';
+		error.resetAt = resetMs || Date.now() + waitSeconds * 1000;
+		error.remaining = 0;
+		error.retryAfter = waitSeconds > 0 ? waitSeconds : 60;
+		throw error;
+	}
 
-  return response;
+	return response;
 }

--- a/src/scripts/utils/gitlabRequest.js
+++ b/src/scripts/utils/gitlabRequest.js
@@ -1,15 +1,15 @@
 async function gitlabApiRequest(url, headers = {}) {
   const response = await fetch(url, { headers });
 
-  const remaining = response.headers.get("ratelimit-remaining");
-  const retryAfter = response.headers.get("retry-after");
-  const resetHeader = response.headers.get("ratelimit-reset");
+  const remaining = response.headers.get("RateLimit-Remaining");
+  const resetHeader = response.headers.get("RateLimit-Reset");
 
   if (response.status === 429) {
-    const waitSeconds = Number(retryAfter || 60);
-    const resetMs = resetHeader
-      ? Number(resetHeader) * 1000
-      : Date.now() + waitSeconds * 1000;
+    // ratelimit-reset is a Unix timestamp in seconds
+    const resetMs = resetHeader ? Number(resetHeader) * 1000 : 0;
+    const waitSeconds = resetMs
+      ? Math.max(1, Math.ceil((resetMs - Date.now()) / 1000))
+      : 60;
 
     console.warn(`GitLab rate limit hit. Retry after ${waitSeconds}s`);
     const error = new Error(

--- a/src/scripts/utils/gitlabRequest.js
+++ b/src/scripts/utils/gitlabRequest.js
@@ -1,0 +1,27 @@
+async function gitlabApiRequest(url, headers = {}) {
+  const response = await fetch(url, { headers });
+
+  const remaining = response.headers.get("ratelimit-remaining");
+  const retryAfter = response.headers.get("retry-after");
+  const resetHeader = response.headers.get("ratelimit-reset");
+
+  if (response.status === 429) {
+    const waitSeconds = Number(retryAfter || 60);
+    const resetMs = resetHeader
+      ? Number(resetHeader) * 1000
+      : Date.now() + waitSeconds * 1000;
+
+    console.warn(`GitLab rate limit hit. Retry after ${waitSeconds}s`);
+    const error = new Error(
+      `GitLab API rate limit exceeded. Retry after ${waitSeconds}s.`,
+    );
+    error.name = "RateLimitError";
+    error.platform = "gitlab";
+    error.resetAt = resetMs;
+    error.remaining = remaining !== null ? Number(remaining) : 0;
+    error.retryAfter = waitSeconds;
+    throw error;
+  }
+
+  return response;
+}

--- a/src/scripts/utils/gitlabRequest.js
+++ b/src/scripts/utils/gitlabRequest.js
@@ -1,27 +1,23 @@
 async function gitlabApiRequest(url, headers = {}) {
-  const response = await fetch(url, { headers });
+	const response = await fetch(url, { headers });
 
-  const remaining = response.headers.get("RateLimit-Remaining");
-  const resetHeader = response.headers.get("RateLimit-Reset");
+	const remaining = response.headers.get('RateLimit-Remaining');
+	const resetHeader = response.headers.get('RateLimit-Reset');
 
-  if (response.status === 429) {
-    // ratelimit-reset is a Unix timestamp in seconds
-    const resetMs = resetHeader ? Number(resetHeader) * 1000 : 0;
-    const waitSeconds = resetMs
-      ? Math.max(1, Math.ceil((resetMs - Date.now()) / 1000))
-      : 60;
+	if (response.status === 429) {
+		// ratelimit-reset is a Unix timestamp in seconds
+		const resetMs = resetHeader ? Number(resetHeader) * 1000 : 0;
+		const waitSeconds = resetMs ? Math.max(1, Math.ceil((resetMs - Date.now()) / 1000)) : 60;
 
-    console.warn(`GitLab rate limit hit. Retry after ${waitSeconds}s`);
-    const error = new Error(
-      `GitLab API rate limit exceeded. Retry after ${waitSeconds}s.`,
-    );
-    error.name = "RateLimitError";
-    error.platform = "gitlab";
-    error.resetAt = resetMs;
-    error.remaining = remaining !== null ? Number(remaining) : 0;
-    error.retryAfter = waitSeconds;
-    throw error;
-  }
+		console.warn(`GitLab rate limit hit. Retry after ${waitSeconds}s`);
+		const error = new Error(`GitLab API rate limit exceeded. Retry after ${waitSeconds}s.`);
+		error.name = 'RateLimitError';
+		error.platform = 'gitlab';
+		error.resetAt = resetMs;
+		error.remaining = remaining !== null ? Number(remaining) : 0;
+		error.retryAfter = waitSeconds;
+		throw error;
+	}
 
-  return response;
+	return response;
 }


### PR DESCRIPTION


  

### 📌 Fixes

Fixes #277

---

### 📝 Summary of Changes

- **Added rate-limit aware fetch wrappers** — githubRequest.js and gitlabRequest.js wrap all API calls, detect rate-limit responses (GitHub: `403` with `x-ratelimit-remaining: 0` or `429`; GitLab: `429` with `retry-after`), and throw a structured `RateLimitError` with `.platform`, `.resetAt`, `.remaining`, `.retryAfter` properties
- **Added rate-limit warning banners in the UI** — two styled, hidden banners in popup.html (yellow for GitHub, orange for GitLab) that display a clear message, an "Add Token" CTA button, a dismiss button, and a reset countdown
- **Added `showRateLimitWarning()` global function in popup.js** — dynamically shows the correct banner based on the error's platform, customises the message depending on whether the user already has a token, and resets the Generate button
- **"Add Token" buttons navigate to settings** — clicking scrolls to and focuses the relevant token input (`#githubToken` or `#gitlabToken`) with a temporary highlight effect
- **Unified dismiss handler** — a single listener handles both GitHub and GitLab dismiss buttons using `closest('.rate-limit-banner')`
- **Replaced all raw `fetch()` calls** — all 5 `fetch()` calls in `scrumHelper.js` replaced with `githubRequest()`, and all `fetch()` calls in `gitlabHelper.js` replaced with `gitlabApiRequest()`, with `RateLimitError` catch blocks at all appropriate error-handling points
- **Fixed existing bug** — removed a broken reference to an undefined `response` variable in the 401/403 handler in `scrumHelper.js`

---

### 📸 Screenshots / Demo (if UI-related)

_GitHub rate-limit banner (yellow) appears above the report area when the API rate limit is hit. Clicking "Add GitHub Token" navigates to settings and highlights the token input. A similar orange banner appears for GitLab rate limits._

---

https://github.com/user-attachments/assets/16c4470a-52a2-4566-826e-cae3678743ae


### ✅ Checklist

- [x] I've tested my changes locally
- [ ] I've added tests (if applicable)
- [ ] I've updated documentation (if applicable)
- [x] My code follows the project's code style guidelines

---

### 👀 Reviewer Notes

- The utility wrappers return the raw `Response` object (not `.json()`), so existing callers continue to work with `.ok`, `.status`, and `.json()` as before — only the `fetch()` call itself is replaced.
- `showRateLimitWarning` is attached to `window` so it's accessible across script files loaded separately in popup.html.
- Rate-limit errors in GitLab's per-project loops `break` the loop early and display partial results rather than silently failing.
- Banner text is currently hardcoded in English (not using `data-i18n` attributes) — i18n support can be added as a follow-up.