### PR TITLE
fixed UI Bug

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -313,10 +313,6 @@ document.addEventListener('DOMContentLoaded', () => {
 				scrumReport.innerHTML = lastScrumReportHtml;
 			}
 
-			showPopupMessage(
-				chrome?.i18n.getMessage('cacheExpiredMessage') || 'Cache expired. Click "Generate" to fetch fresh data.',
-			);
-
 			if (generateBtn) generateBtn.disabled = false;
 			return;
 		}


### PR DESCRIPTION
<img width="138" height="137" alt="image" src="https://github.com/user-attachments/assets/dc65497e-cfa6-4af1-b0f7-3d4064e02497" />

On reload this bug was noticed. Fixed this.

## Summary by Sourcery

Bug Fixes:
- Stop showing the cache expired message popup on reload while keeping the generate button re-enabled.