### PR TITLE
Fix double scrollbar appearing in popup window

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -43,14 +43,8 @@
 
 		#popupRoot {
 			flex: 1;
-			min-width: 360px; 
-			flex-shrink: 0;
-
-			height: 100%;
-			overflow-y: auto;
-			overflow-x: hidden;
-			scrollbar-width: auto;
-            -ms-overflow-style: auto;
+			min-width: 360px;
+    		overscroll-behavior: contain; 
 		}
 		#platformSelect option {
 			font-family: 'FontAwesome', 'Arial', sans-serif;


### PR DESCRIPTION
📌 Fixes
Fixes #433 

📝 Summary of Changes
- Removed nested scroll container behavior from #popupRoot
- Allowed the browser popup window to handle scrolling
- Eliminated the double scrollbar issue
- Simplified popup layout behavior

No changes were made to:
- report generation logic
- API behavior
- extension functionality

This change focuses purely on UI behavior improvement.

📸 Screenshots / Demo

Before
<img width="770" height="1126" alt="image" src="https://github.com/user-attachments/assets/0952b964-38d8-4216-8a07-105fb03a75fc" />


After

<img width="764" height="1223" alt="image" src="https://github.com/user-attachments/assets/70eb16bc-9cd1-4000-a4e7-2b9efc7d118e" />

✅ Checklist
- [x] I have tested the changes locally
- [x] No console errors
- [x] No breaking changes introduced
- [x] Existing functionality remains unchanged
- [x] Scope limited strictly to UI behavior improvement

👀 Reviewer Notes
Previously the popup layout used a nested scroll container (#popupRoot) with overflow enabled while the browser popup window also handled scrolling.

This resulted in two visible scrollbars.

The fix removes the internal scroll container behavior so that the popup relies on the browser's scrolling mechanism, ensuring only one scrollbar is displayed.

## Summary by Sourcery

Resolve double-scrollbar behavior in the popup by letting the browser window control scrolling instead of an internal scroll container.

Bug Fixes:
- Remove the nested scroll container on #popupRoot to eliminate the extra scrollbar in the popup UI.

Enhancements:
- Constrain popup overscroll behavior to keep scrolling interactions contained within the popup window.