### PR TITLE
Added gitee support for generating scrum reports

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -110,6 +110,22 @@
     "message": "Why is it recommended to add a GitLab token? Scrum Helper works without a GitLab token for public projects, but adding a personal access token is recommended for a better experience.",
     "description": "Tooltip for GitLab token explaining why it's needed."
   },
+  "giteeUsernameLabel": {
+    "message": "Your Gitee Username",
+    "description": "Label for the Gitee username input field."
+  },
+  "giteeTokenLabel": {
+    "message": "Your Gitee Token",
+    "description": "Label for the Gitee token input."
+  },
+  "giteeTokenPlaceholder": {
+    "message": "Required for accessing private projects",
+    "description": "Placeholder for the Gitee token input."
+  },
+  "giteeTokenTooltip": {
+    "message": "Why is it recommended to add a Gitee token? Scrum Helper works without a Gitee token for public projects, but adding a personal access token is recommended for a better experience.",
+    "description": "Tooltip for Gitee token explaining why it's needed."
+  },
   "showCommitsLabel": {
     "message": "Show commits on open PRs/ draft PRs",
     "description": "Label for the checkbox to show commits in open PRs."

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,6 +27,7 @@
         "scripts/jquery-3.2.1.min.js",
         "scripts/emailClientAdapter.js",
         "scripts/gitlabHelper.js",
+        "scripts/giteeHelper.js",
         "scripts/scrumHelper.js"
       ]
     }
@@ -56,8 +57,9 @@
     "*://*.yahoo.com/*",
 
     "https://api.github.com/*",
-    "https://gitlab.com/*"
- ],
+    "https://gitlab.com/*",
+    "https://gitee.com/*"
+  ],
   "default_locale": "en"
 
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -105,6 +105,10 @@
 									class="hover:bg-gray-100" data-value="gitlab">
 									<i class="fab fa-gitlab" style="margin-right: 12px; font-size: 18px;"></i> GitLab
 								</li>
+								<li style="padding-left: 8px; padding-right: 16px; padding-top: 8px; padding-bottom: 8px; display: flex; align-items: center; cursor: pointer;"
+									class="hover:bg-gray-100" data-value="gitee">
+									<i class="fa fa-code" style="margin-right: 12px; font-size: 18px;"></i> Gitee
+								</li>
 							</ul>
 						</div>
 					</div>
@@ -459,6 +463,28 @@
 						</div>
 					</div>
 
+					<div class="giteeOnlySection hidden mt-3">
+						<div class="flex items-center justify-between">
+							<div class="flex">
+								<p class="text-sm font-medium" data-i18n="giteeTokenLabel">Your Gitee Token</p>
+								<span class="tooltip-container ml-2">
+									<i class="fa fa-question-circle question-icon"></i>
+									<span class="tooltip-bubble" data-i18n="giteeTokenTooltip">
+										<b>Why add a Gitee token?</b><br>
+										Works without a token for public projects, but a personal access token enables private repos and better rate limits. Get one at <a href="https://gitee.com/profile/personal_access_tokens" target="_blank" rel="noopener noreferrer" style="color:#2563eb;text-decoration:underline;">Gitee Access Tokens</a>.<br>
+										<i>Keep it secret!</i>
+									</span>
+								</span>
+							</div>
+							<button id="toggleGiteeTokenVisibility" type="button" class="focus:outline-none">
+								<i id="giteeTokenEyeIcon" class="fa fa-eye text-gray-600"></i>
+							</button>
+						</div>
+						<input id="giteeToken" type="password"
+							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2 pr-10"
+							data-i18n-placeholder="giteeTokenPlaceholder">
+					</div>
+
 					<div class="gitlabOnlySection hidden mt-3">
 						<div class="flex items-center justify-between">
 							<div class="flex">
@@ -570,6 +596,7 @@
 	<script src="scripts/emailClientAdapter.js"></script>
 	<script src="scripts/main.js"></script>
 	<script src="scripts/gitlabHelper.js"></script>
+	<script src="scripts/giteeHelper.js"></script>
 	<script src="scripts/scrumHelper.js"></script>
 	<script src="scripts/popup.js"></script>
 </body>

--- a/src/scripts/giteeHelper.js
+++ b/src/scripts/giteeHelper.js
@@ -1,0 +1,238 @@
+class GiteeHelper {
+    constructor() {
+        this.baseUrl = 'https://gitee.com/api/v5';
+        this.cache = {
+            data: null,
+            cacheKey: null,
+            timestamp: 0,
+            ttl: 10 * 60 * 1000,
+            fetching: false,
+            queue: [],
+        };
+    }
+
+    async getCacheTTL() {
+        return new Promise((resolve) => {
+            chrome.storage.local.get(['cacheInput'], (items) => {
+                const ttl = items.cacheInput ? Number.parseInt(items.cacheInput, 10) * 60 * 1000 : 10 * 60 * 1000;
+                resolve(ttl);
+            });
+        });
+    }
+
+    appendToken(url, token) {
+        if (!token || !token.trim()) return url;
+        const sep = url.includes('?') ? '&' : '?';
+        return `${url}${sep}access_token=${encodeURIComponent(token.trim())}`;
+    }
+
+    async saveToStorage(data) {
+        return new Promise((resolve) => {
+            chrome.storage.local.set(
+                {
+                    giteeCache: {
+                        data: data,
+                        cacheKey: this.cache.cacheKey,
+                        timestamp: this.cache.timestamp,
+                    },
+                },
+                resolve,
+            );
+        });
+    }
+
+    async loadFromStorage() {
+        return new Promise((resolve) => {
+            chrome.storage.local.get(['giteeCache'], (items) => {
+                if (items.giteeCache) {
+                    this.cache.data = items.giteeCache.data;
+                    this.cache.cacheKey = items.giteeCache.cacheKey;
+                    this.cache.timestamp = items.giteeCache.timestamp;
+                }
+                resolve();
+            });
+        });
+    }
+
+    clearCache() {
+        this.cache.data = null;
+        this.cache.cacheKey = null;
+        this.cache.timestamp = 0;
+        this.cache.fetching = false;
+        this.cache.queue = [];
+    }
+
+    async fetchGiteeData(username, startDate, endDate, token = null) {
+        const tokenMarker = token ? 'auth' : 'noauth';
+        const cacheKey = `gitee-${username}-${startDate}-${endDate}-${tokenMarker}`;
+
+        if (this.cache.fetching || (this.cache.cacheKey === cacheKey && this.cache.data)) {
+            return this.cache.data;
+        }
+
+        if (!this.cache.data && !this.cache.fetching) {
+            await this.loadFromStorage();
+        }
+
+        const currentTTL = await this.getCacheTTL();
+        this.cache.ttl = currentTTL;
+
+        const now = Date.now();
+        const isCacheFresh = now - this.cache.timestamp < this.cache.ttl;
+        const isCacheKeyMatch = this.cache.cacheKey === cacheKey;
+
+        if (this.cache.data && isCacheFresh && isCacheKeyMatch) {
+            return this.cache.data;
+        }
+
+        if (!isCacheKeyMatch) {
+            this.cache.data = null;
+        }
+
+        if (this.cache.fetching) {
+            return new Promise((resolve, reject) => {
+                this.cache.queue.push({ resolve, reject });
+            });
+        }
+
+        this.cache.fetching = true;
+        this.cache.cacheKey = cacheKey;
+
+        const startDateTime = new Date(startDate + 'T00:00:00Z').getTime();
+        const endDateTime = new Date(endDate + 'T23:59:59Z').getTime();
+
+        try {
+            await new Promise((res) => setTimeout(res, 500));
+
+            const userUrl = this.appendToken(`${this.baseUrl}/users/${encodeURIComponent(username)}`, token);
+            const userRes = await fetch(userUrl);
+            if (userRes.status === 404) {
+                throw new Error(`Gitee user '${username}' not found`);
+            }
+            if (!userRes.ok) {
+                throw new Error(`Error fetching Gitee user: ${userRes.status} ${userRes.statusText}`);
+            }
+            const user = await userRes.json();
+
+            const reposUrl = this.appendToken(`${this.baseUrl}/users/${encodeURIComponent(username)}/repos?per_page=100&sort=updated`, token);
+            const reposRes = await fetch(reposUrl);
+            if (!reposRes.ok) {
+                throw new Error(`Error fetching Gitee repos: ${reposRes.status} ${reposRes.statusText}`);
+            }
+            const repos = await reposRes.json();
+
+            const fullName = (r) => r.full_name || (r.namespace ? `${r.namespace.path || r.namespace.full_name}/${r.path || r.name}` : `${username}/${r.path || r.name}`);
+            const owner = (r) => (r.owner && r.owner.login) || (r.namespace && (r.namespace.path || r.namespace.full_name)) || username;
+            const repoName = (r) => r.path || r.name || (r.full_name ? r.full_name.split('/')[1] : '');
+
+            let allIssues = [];
+            let allPulls = [];
+
+            for (const repo of repos) {
+                const o = owner(repo);
+                const r = repoName(repo);
+                try {
+                    const issuesUrl = this.appendToken(`${this.baseUrl}/repos/${encodeURIComponent(o)}/${encodeURIComponent(r)}/issues?state=all&sort=updated&direction=desc&per_page=100`, token);
+                    const issuesRes = await fetch(issuesUrl);
+                    if (issuesRes.ok) {
+                        const issues = await issuesRes.json();
+                        for (const i of issues) {
+                            if (i.pull_request) continue;
+                            const updated = new Date(i.updated_at || i.created_at).getTime();
+                            if (updated >= startDateTime && updated <= endDateTime) {
+                                const creator = i.user?.login || i.user?.login || i.assignee?.login;
+                                if (creator === username) {
+                                    allIssues.push({ ...i, _owner: o, _repo: r, _fullName: `${o}/${r}` });
+                                }
+                            }
+                        }
+                    }
+                    await new Promise((resolve) => setTimeout(resolve, 100));
+                } catch (e) {
+                    console.error(`[Gitee] Error fetching issues for ${o}/${r}:`, e);
+                }
+
+                try {
+                    const pullsUrl = this.appendToken(`${this.baseUrl}/repos/${encodeURIComponent(o)}/${encodeURIComponent(r)}/pulls?state=all&sort=updated&direction=desc&per_page=100`, token);
+                    const pullsRes = await fetch(pullsUrl);
+                    if (pullsRes.ok) {
+                        const pulls = await pullsRes.json();
+                        for (const p of pulls) {
+                            const updated = new Date(p.updated_at || p.created_at).getTime();
+                            if (updated >= startDateTime && updated <= endDateTime) {
+                                const author = p.user?.login || p.head?.user?.login;
+                                if (author === username) {
+                                    allPulls.push({ ...p, _owner: o, _repo: r, _fullName: `${o}/${r}` });
+                                }
+                            }
+                        }
+                    }
+                    await new Promise((resolve) => setTimeout(resolve, 100));
+                } catch (e) {
+                    console.error(`[Gitee] Error fetching pulls for ${o}/${r}:`, e);
+                }
+            }
+
+            const mapToGitHubFormat = (item, isPull) => {
+                const o = item._owner || item.base?.repo?.owner?.login || username;
+                const r = item._repo || item.base?.repo?.name || item.head?.repo?.name;
+                const fn = item._fullName || `${o}/${r}`;
+                const htmlUrl = item.html_url || item.url || `https://gitee.com/${fn}/${isPull ? 'pulls' : 'issues'}/${item.number}`;
+                const repoUrl = `https://gitee.com/api/v5/repos/${fn}`;
+                let state = (item.state || 'open').toLowerCase();
+                if (state === 'opened') state = 'open';
+
+                return {
+                    ...item,
+                    html_url: htmlUrl,
+                    repository_url: repoUrl,
+                    number: item.number || item.iid,
+                    title: item.title,
+                    state: state,
+                    pull_request: isPull,
+                    user: item.user ? { login: item.user.login || username } : { login: username },
+                    created_at: item.created_at,
+                    updated_at: item.updated_at,
+                    body: item.body,
+                    state_reason: item.state_reason,
+                    project: r,
+                };
+            };
+
+            const mappedIssues = allIssues.map((i) => mapToGitHubFormat(i, false));
+            const mappedPulls = allPulls.map((p) => mapToGitHubFormat(p, true));
+
+            const giteeData = {
+                user: {
+                    login: user.login || username,
+                    name: user.name || user.login || username,
+                    html_url: user.html_url,
+                },
+                projects: repos,
+                issues: mappedIssues,
+                mergeRequests: mappedPulls,
+            };
+
+            this.cache.data = giteeData;
+            this.cache.timestamp = Date.now();
+            await this.saveToStorage(giteeData);
+
+            this.cache.queue.forEach(({ resolve }) => resolve(giteeData));
+            this.cache.queue = [];
+            return giteeData;
+        } catch (err) {
+            console.error('Gitee Fetch Failed:', err);
+            this.cache.queue.forEach(({ reject }) => reject(err));
+            this.cache.queue = [];
+            throw err;
+        } finally {
+            this.cache.fetching = false;
+        }
+    }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = GiteeHelper;
+} else {
+    window.GiteeHelper = GiteeHelper;
+}

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -2,6 +2,7 @@ const enableToggleElement = document.getElementById('enable');
 const platformUsernameElement = document.getElementById('platformUsername');
 const githubTokenElement = document.getElementById('githubToken');
 const gitlabTokenElement = document.getElementById('gitlabToken');
+const giteeTokenElement = document.getElementById('giteeToken');
 const cacheInputElement = document.getElementById('cacheInput');
 const projectNameElement = document.getElementById('projectName');
 const yesterdayContributionElement = document.getElementById('yesterdayContribution');
@@ -31,6 +32,7 @@ function handleBodyOnLoad() {
 			'platform',
 			'githubUsername',
 			'gitlabUsername',
+			'giteeUsername',
 			'projectName',
 			'enableToggle',
 			'startingDate',
@@ -43,6 +45,7 @@ function handleBodyOnLoad() {
 			'cacheInput',
 			'githubToken',
 			'gitlabToken',
+			'giteeToken',
 			'showCommits',
 		],
 		(items) => {
@@ -58,6 +61,9 @@ function handleBodyOnLoad() {
 			}
 			if (items.gitlabToken && gitlabTokenElement) {
 				gitlabTokenElement.value = items.gitlabToken;
+			}
+			if (items.giteeToken && giteeTokenElement) {
+				giteeTokenElement.value = items.giteeToken;
 			}
 			if (items.projectName) {
 				projectNameElement.value = items.projectName;
@@ -176,6 +182,10 @@ function handleGitlabTokenChange() {
 	const value = gitlabTokenElement.value;
 	chrome.storage.local.set({ gitlabToken: value });
 }
+function handleGiteeTokenChange() {
+	const value = giteeTokenElement ? giteeTokenElement.value : '';
+	chrome.storage.local.set({ giteeToken: value });
+}
 function handleProjectNameChange() {
 	const value = projectNameElement.value;
 	chrome.storage.local.set({ projectName: value });
@@ -211,6 +221,9 @@ if (githubTokenElement) {
 }
 if (gitlabTokenElement) {
 	gitlabTokenElement.addEventListener('keyup', handleGitlabTokenChange);
+}
+if (giteeTokenElement) {
+	giteeTokenElement.addEventListener('keyup', handleGiteeTokenChange);
 }
 cacheInputElement.addEventListener('keyup', handleCacheInputChange);
 projectNameElement.addEventListener('keyup', handleProjectNameChange);

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -138,6 +138,30 @@ document.addEventListener('DOMContentLoaded', function () {
         setTimeout(() => githubTokenInput.classList.remove('token-animating'), 300);
     });
 
+    const giteeTokenInput = document.getElementById('giteeToken');
+    const toggleGiteeTokenBtn = document.getElementById('toggleGiteeTokenVisibility');
+    const giteeTokenEyeIcon = document.getElementById('giteeTokenEyeIcon');
+    if (giteeTokenInput && toggleGiteeTokenBtn && giteeTokenEyeIcon) {
+        let giteeTokenVisible = false;
+        toggleGiteeTokenBtn.addEventListener('click', function () {
+            giteeTokenVisible = !giteeTokenVisible;
+            giteeTokenInput.type = giteeTokenVisible ? 'text' : 'password';
+            giteeTokenEyeIcon.className = giteeTokenVisible ? 'fa fa-eye-slash text-gray-600' : 'fa fa-eye text-gray-600';
+        });
+    }
+
+    const gitlabTokenInput = document.getElementById('gitlabToken');
+    const toggleGitlabTokenBtn = document.getElementById('toggleGitlabTokenVisibility');
+    const gitlabTokenEyeIcon = document.getElementById('gitlabTokenEyeIcon');
+    if (gitlabTokenInput && toggleGitlabTokenBtn && gitlabTokenEyeIcon) {
+        let gitlabTokenVisible = false;
+        toggleGitlabTokenBtn.addEventListener('click', function () {
+            gitlabTokenVisible = !gitlabTokenVisible;
+            gitlabTokenInput.type = gitlabTokenVisible ? 'text' : 'password';
+            gitlabTokenEyeIcon.className = gitlabTokenVisible ? 'fa fa-eye-slash text-gray-600' : 'fa fa-eye text-gray-600';
+        });
+    }
+
     githubTokenInput.addEventListener('input', checkTokenForFilter);
 
     darkModeToggle.addEventListener('click', function () {
@@ -403,8 +427,8 @@ document.addEventListener('DOMContentLoaded', function () {
         const platformUsername = document.getElementById('platformUsername');
 
         chrome.storage.local.get([
-            'projectName', 'orgName', 'userReason', 'showOpenLabel', 'showCommits', 'githubToken', 'cacheInput', 'onlyIssues', 'onlyPRs',
-            'enableToggle', 'yesterdayContribution', 'startingDate', 'endingDate', 'selectedTimeframe', 'platform', 'githubUsername', 'gitlabUsername',
+            'projectName', 'orgName', 'userReason', 'showOpenLabel', 'showCommits', 'githubToken', 'gitlabToken', 'giteeToken', 'cacheInput', 'onlyIssues', 'onlyPRs',
+            'enableToggle', 'yesterdayContribution', 'startingDate', 'endingDate', 'selectedTimeframe', 'platform', 'githubUsername', 'gitlabUsername', 'giteeUsername',
             'includeIssuesSection', 'includePRsSection', 'includeReviewedPRsSection', 'includeTasksSection', 'includeBlockersSection',
         ], function (result) {
 
@@ -1439,6 +1463,8 @@ function updatePlatformUI(platform) {
 	if (usernameLabel) {
 		if (platform === 'gitlab') {
 			usernameLabel.setAttribute('data-i18n', 'gitlabUsernameLabel');
+		} else if (platform === 'gitee') {
+			usernameLabel.setAttribute('data-i18n', 'giteeUsernameLabel');
 		} else {
 			usernameLabel.setAttribute('data-i18n', 'githubUsernameLabel');
 		}
@@ -1451,7 +1477,7 @@ function updatePlatformUI(platform) {
 
 	const orgSection = document.querySelector('.orgSection');
 	if (orgSection) {
-		if (platform === 'gitlab') {
+		if (platform === 'gitlab' || platform === 'gitee') {
 			orgSection.classList.add('hidden');
 		} else {
 			orgSection.classList.remove('hidden');
@@ -1459,7 +1485,7 @@ function updatePlatformUI(platform) {
 	}
 	const githubOnlySections = document.querySelectorAll('.githubOnlySection');
 	githubOnlySections.forEach((el) => {
-		if (platform === 'gitlab') {
+		if (platform === 'gitlab' || platform === 'gitee') {
 			el.classList.add('hidden');
 		} else {
 			el.classList.remove('hidden');
@@ -1467,7 +1493,15 @@ function updatePlatformUI(platform) {
 	});
 	const gitlabOnlySections = document.querySelectorAll('.gitlabOnlySection');
 	gitlabOnlySections.forEach((el) => {
-		if (platform === 'github') {
+		if (platform === 'github' || platform === 'gitee') {
+			el.classList.add('hidden');
+		} else {
+			el.classList.remove('hidden');
+		}
+	});
+	const giteeOnlySections = document.querySelectorAll('.giteeOnlySection');
+	giteeOnlySections.forEach((el) => {
+		if (platform === 'github' || platform === 'gitlab') {
 			el.classList.add('hidden');
 		} else {
 			el.classList.remove('hidden');
@@ -1479,20 +1513,11 @@ platformSelect.addEventListener('change', () => {
 	const platform = platformSelect.value;
 	chrome.storage.local.set({ platform });
 	const platformUsername = document.getElementById('platformUsername');
-	if (platformUsername) {
-		const currentPlatform = platformSelect.value === 'github' ? 'gitlab' : 'github'; // Get the platform we're switching from
-		const currentUsername = platformUsername.value;
-		if (currentUsername.trim()) {
-			chrome.storage.local.set({ [`${currentPlatform}Username`]: currentUsername });
-		}
-	}
-
 	chrome.storage.local.get([`${platform}Username`], (result) => {
 		if (platformUsername) {
 			platformUsername.value = result[`${platform}Username`] || '';
 		}
 	});
-
 	updatePlatformUI(platform);
 });
 
@@ -1505,6 +1530,8 @@ const platformSelectHidden = document.getElementById('platformSelect');
 function setPlatformDropdown(value) {
 	if (value === 'gitlab') {
 		dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
+	} else if (value === 'gitee') {
+		dropdownSelected.innerHTML = '<i class="fa fa-code mr-2"></i> Gitee';
 	} else {
 		dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
 	}
@@ -1609,9 +1636,10 @@ dropdownList.querySelectorAll('li').forEach((item, idx, arr) => {
 // On load, restore platform from storage
 chrome.storage.local.get(['platform'], (result) => {
 	const platform = result.platform || 'github';
-	// Just update the UI without clearing username when restoring from storage
 	if (platform === 'gitlab') {
 		dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
+	} else if (platform === 'gitee') {
+		dropdownSelected.innerHTML = '<i class="fa fa-code mr-2"></i> Gitee';
 	} else {
 		dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
 	}

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -89,6 +89,8 @@ function allIncluded(outputTarget = 'email') {
                 'platform',
                 'githubUsername',
                 'gitlabUsername',
+                'giteeUsername',
+                'giteeToken',
                 'githubToken',
                 'projectName',
                 'enableToggle',
@@ -334,6 +336,62 @@ function allIncluded(outputTarget = 'email') {
                             }
                             if (generateBtn) {
                                 generateBtn.innerHTML = '<i class=\"fa fa-refresh\"></i> Generate Report';
+                                generateBtn.disabled = false;
+                            }
+                        }
+                        scrumGenerationInProgress = false;
+                    }
+                } else if (platform === 'gitee') {
+                    if (!window.GiteeHelper) {
+                        if (outputTarget === 'popup') {
+                            const scrumReport = document.getElementById('scrumReport');
+                            if (scrumReport) scrumReport.innerHTML = '<div class="error-message" style="color: #dc2626; font-weight: bold; padding: 10px;">Gitee helper not loaded.</div>';
+                        }
+                        scrumGenerationInProgress = false;
+                        return;
+                    }
+                    const giteeHelper = new window.GiteeHelper();
+                    const giteeToken = items.giteeToken || (outputTarget === 'popup' ? document.getElementById('giteeToken')?.value : null);
+                    if (platformUsernameLocal) {
+                        const generateBtn = document.getElementById('generateReport');
+                        if (generateBtn && outputTarget === 'popup') {
+                            generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
+                            generateBtn.disabled = true;
+                        }
+                        const doFetch = async () => {
+                            try {
+                                const data = await giteeHelper.fetchGiteeData(platformUsernameLocal, startingDate, endingDate, giteeToken);
+                                const mappedData = {
+                                    githubIssuesData: { items: [...(data.issues || []), ...(data.mergeRequests || [])] },
+                                    githubPrsReviewData: { items: [] },
+                                    githubUserData: data.user || {},
+                                };
+                                await processGithubData(mappedData);
+                            } catch (err) {
+                                console.error('Gitee fetch failed:', err);
+                                if (outputTarget === 'popup') {
+                                    if (generateBtn) {
+                                        generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate Report';
+                                        generateBtn.disabled = false;
+                                    }
+                                    const scrumReport = document.getElementById('scrumReport');
+                                    if (scrumReport) scrumReport.innerHTML = `<div class="error-message" style="color: #dc2626; font-weight: bold; padding: 10px;">${err.message || 'An error occurred while fetching Gitee data.'}</div>`;
+                                }
+                            }
+                            scrumGenerationInProgress = false;
+                        };
+                        if (outputTarget === 'email') {
+                            doFetch();
+                        } else {
+                            doFetch();
+                        }
+                    } else {
+                        if (outputTarget === 'popup') {
+                            const scrumReport = document.getElementById('scrumReport');
+                            const generateBtn = document.getElementById('generateReport');
+                            if (scrumReport) scrumReport.innerHTML = '<div class="error-message" style="color: #dc2626; font-weight: bold; padding: 10px;">Please enter your Gitee username to generate a report.</div>';
+                            if (generateBtn) {
+                                generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate Report';
                                 generateBtn.disabled = false;
                             }
                         }
@@ -1219,6 +1277,8 @@ function allIncluded(outputTarget = 'email') {
                 isAuthoredByUser = item.user && item.user.login === platformUsernameLocal;
             } else if (platform === 'gitlab') {
                 isAuthoredByUser = item.author && (item.author.username === platformUsername);
+            } else if (platform === 'gitee') {
+                isAuthoredByUser = item.user && item.user.login === platformUsernameLocal;
             }
 
             if (isAuthoredByUser || !item.pull_request) continue;
@@ -1505,7 +1565,7 @@ function allIncluded(outputTarget = 'email') {
             let html_url = item.html_url;
             let repository_url = item.repository_url;
             // Use project name for GitLab, repo extraction for GitHub
-            let project = (platform === 'gitlab' && item.project) ? item.project : (repository_url ? repository_url.substr(repository_url.lastIndexOf('/') + 1) : '');
+            let project = ((platform === 'gitlab' || platform === 'gitee') && item.project) ? item.project : (repository_url ? repository_url.substr(repository_url.lastIndexOf('/') + 1) : '');
             let title = item.title;
             let number = item.number;
             let li = '';
@@ -1575,11 +1635,8 @@ function allIncluded(outputTarget = 'email') {
                     }
                 } else if (platform === 'gitlab') {
                     prAction = isNewPR ? 'Made Merge Request' : 'Updated Merge Request';
-                    if (isCreatedToday && item.State === 'open') {
-                        prAction = 'Made Merge Request';
-                    } else {
-                        prAction = 'Updated Merge Request';
-                    }
+                } else if (platform === 'gitee') {
+                    prAction = isNewPR ? 'Made Pull Request' : 'Updated Pull Request';
                 }
 
                 if (isDraft) {
@@ -1606,7 +1663,7 @@ function allIncluded(outputTarget = 'email') {
                         li += '</ul>';
                     }
                     li += `</li>`;
-                } else if (platform === 'gitlab' && item.state === 'closed') {
+                } else if ((platform === 'gitlab' || platform === 'gitee') && item.state === 'closed') {
                     li = `<li><i>(${project})</i> - ${prAction} <a href='${html_url}' target='_blank' rel='noopener noreferrer' contenteditable='false'>(#${number})</a> - <a href='${html_url}' target='_blank' rel='noopener noreferrer' contenteditable='false'>${title}</a>${showOpenLabel ? ' ' + pr_closed_button : ''}</li>`;
                 } else {
                     let merged = null;
@@ -1693,7 +1750,7 @@ function allIncluded(outputTarget = 'email') {
 
 
     let intervalSubject = setInterval(() => {
-        const userData = platform === 'gitlab' ? (githubUserData || platformUsername) : githubUserData;
+        const userData = (platform === 'gitlab' || platform === 'gitee') ? (githubUserData || platformUsername) : githubUserData;
         if (!userData || !window.emailClientAdapter) return;
 
 
@@ -1720,7 +1777,7 @@ function allIncluded(outputTarget = 'email') {
         if (outputTarget === 'popup') {
             return;
         } else {
-            const username = platform === 'gitlab' ? platformUsername : platformUsernameLocal;
+            const username = (platform === 'gitlab' || platform === 'gitee') ? platformUsername : platformUsernameLocal;
             if (scrumBody && username && githubIssuesData && githubPrsReviewData) {
                 clearInterval(intervalWriteGithubIssues);
                 clearInterval(intervalWriteGithubPrs);
@@ -1732,7 +1789,7 @@ function allIncluded(outputTarget = 'email') {
         if (outputTarget === 'popup') {
             return;
         } else {
-            const username = platform === 'gitlab' ? platformUsername : platformUsernameLocal;
+            const username = (platform === 'gitlab' || platform === 'gitee') ? platformUsername : platformUsernameLocal;
             if (scrumBody && username && githubPrsReviewData && githubIssuesData) {
                 clearInterval(intervalWriteGithubPrs);
                 clearInterval(intervalWriteGithubIssues);
@@ -1823,6 +1880,14 @@ async function forceGitlabDataRefresh() {
     return { success: true };
 }
 
+async function forceGiteeDataRefresh() {
+    await new Promise(resolve => {
+        chrome.storage.local.remove('giteeCache', resolve);
+    });
+    hasInjectedContent = false;
+    return { success: true };
+}
+
 
 if (window.location.protocol.startsWith('http')) {
     allIncluded('email');
@@ -1841,6 +1906,12 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             const platform = result.platform || 'github';
             if (platform === 'gitlab') {
                 forceGitlabDataRefresh()
+                    .then(result => sendResponse(result)).catch(err => {
+                        console.error('Force refresh failed:', err);
+                        sendResponse({ success: false, error: err.message });
+                    });
+            } else if (platform === 'gitee') {
+                forceGiteeDataRefresh()
                     .then(result => sendResponse(result)).catch(err => {
                         console.error('Force refresh failed:', err);
                         sendResponse({ success: false, error: err.message });


### PR DESCRIPTION
### 📌 Fixes #184 

---

### 📝 Summary of Changes

This PR adds gitee support to Scrum Helper so users can generate scrum reports based on their gitee activity in the same way they currently do with GitHub.

---

### 📸 Screenshots / Demo (if UI-related)
<img width="462" height="735" alt="image" src="https://github.com/user-attachments/assets/75cf4f16-56b0-4021-9ad7-9f88fffaac66" />


---
### Changes Implemented
## 1. scrumHelper.js 
-Added support for extracting project information from item.project when platform === 'gitee'
-Added Gitee handling for:
. user data
. email flow
. authored PR detection

## 2. giteeHelper.js
Added a clearCache() method.
Fixed fallback logic in mapToGitHubFormat(): `item.user.login || username`

## 3. manifest.json
Added giteeHelper.js to content scripts.


---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

References: Gitee API documentation:
https://gitee.com/api/v5/swagger
