### PR TITLE
Fix timezone shift in report date generation

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -12,6 +12,10 @@ const userReasonElement = null;
 
 const showCommitsElement = document.getElementById('showCommits');
 
+function formatDateLocal(date) {
+	return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
 function handleBodyOnLoad() {
 	// Migration: Handle existing users with old platformUsername storage
 	chrome.storage.local.get(['platform', 'platformUsername'], (result) => {
@@ -138,11 +142,11 @@ function getYesterday() {
 	const today = new Date();
 	const yesterday = new Date(today);
 	yesterday.setDate(today.getDate() - 1);
-	return yesterday.toISOString().split('T')[0];
+	return formatDateLocal(yesterday);
 }
 function getToday() {
 	const today = new Date();
-	return today.toISOString().split('T')[0];
+	return formatDateLocal(today);
 }
 
 function handlePlatformUsernameChange() {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -6,16 +6,20 @@ function debounce(func, wait) {
 	};
 }
 
+function formatDateLocal(date) {
+	return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
 function getToday() {
 	const today = new Date();
-	return today.toISOString().split('T')[0];
+	return formatDateLocal(today);
 }
 
 function getYesterday() {
 	const today = new Date();
 	const yesterday = new Date(today);
 	yesterday.setDate(today.getDate() - 1);
-	return yesterday.toISOString().split('T')[0];
+	return formatDateLocal(yesterday);
 }
 
 function applyI18n() {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -12,6 +12,10 @@ function logError(...args) {
 	}
 }
 
+function formatDateLocal(date) {
+	return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
 let refreshButton_Placed = false;
 let hasInjectedContent = false;
 let scrumGenerationInProgress = false;
@@ -357,11 +361,11 @@ function allIncluded(outputTarget = 'email') {
 		const today = new Date();
 		const yesterday = new Date(today);
 		yesterday.setDate(today.getDate() - 1);
-		return yesterday.toISOString().split('T')[0];
+		return formatDateLocal(yesterday);
 	}
 	function getToday() {
 		const today = new Date();
-		return today.toISOString().split('T')[0];
+		return formatDateLocal(today);
 	}
 
 	// Global cache object
@@ -472,8 +476,8 @@ function allIncluded(outputTarget = 'email') {
 		if (yesterdayContribution) {
 			const today = new Date();
 			const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
-			startDateForCache = yesterday.toISOString().split('T')[0];
-			endDateForCache = today.toISOString().split('T')[0]; // Use yesterday for start and today for end
+			startDateForCache = formatDateLocal(yesterday);
+			endDateForCache = formatDateLocal(today); // Use yesterday for start and today for end
 		} else if (startingDate && endingDate) {
 			startDateForCache = startingDate;
 			endDateForCache = endingDate;
@@ -481,8 +485,8 @@ function allIncluded(outputTarget = 'email') {
 			// Default to last 7 days if no date range is set
 			const today = new Date();
 			const lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7);
-			startDateForCache = lastWeek.toISOString().split('T')[0];
-			endDateForCache = today.toISOString().split('T')[0];
+			startDateForCache = formatDateLocal(lastWeek);
+			endDateForCache = formatDateLocal(today);
 		}
 
 		const cacheKey = `${platformUsernameLocal}-${startDateForCache}-${endDateForCache}-${orgName || 'all'}`;
@@ -705,8 +709,8 @@ function allIncluded(outputTarget = 'email') {
 					if (yesterdayContribution) {
 						const today = new Date();
 						const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
-						startDateForCommits = yesterday.toISOString().split('T')[0];
-						endDateForCommits = today.toISOString().split('T')[0]; // Use yesterday for start and today for end
+						startDateForCommits = formatDateLocal(yesterday);
+						endDateForCommits = formatDateLocal(today); // Use yesterday for start and today for end
 					} else if (startingDate && endingDate) {
 						startDateForCommits = startingDate;
 						endDateForCommits = endingDate;
@@ -714,8 +718,8 @@ function allIncluded(outputTarget = 'email') {
 						// Default to last 7 days if no date range is set
 						const today = new Date();
 						const lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7);
-						startDateForCommits = lastWeek.toISOString().split('T')[0];
-						endDateForCommits = today.toISOString().split('T')[0];
+						startDateForCommits = formatDateLocal(lastWeek);
+						endDateForCommits = formatDateLocal(today);
 					}
 
 					const commitMap = await fetchCommitsForOpenPRs(openPRs, githubToken, startDateForCommits, endDateForCommits);
@@ -1198,8 +1202,8 @@ ${userReason}`;
 		if (yesterdayContribution) {
 			const today = new Date();
 			const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
-			startDate = yesterday.toISOString().split('T')[0];
-			endDate = today.toISOString().split('T')[0]; // Use yesterday for start and today for end
+			startDate = formatDateLocal(yesterday);
+			endDate = formatDateLocal(today); // Use yesterday for start and today for end
 		} else if (startingDate && endingDate) {
 			startDate = startingDate;
 			endDate = endingDate;
@@ -1207,8 +1211,8 @@ ${userReason}`;
 			// Default to last 7 days if no date range is set
 			const today = new Date();
 			const lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7);
-			startDate = lastWeek.toISOString().split('T')[0];
-			endDate = today.toISOString().split('T')[0];
+			startDate = formatDateLocal(lastWeek);
+			endDate = formatDateLocal(today);
 		}
 
 		const startDateTime = new Date(startDate + 'T00:00:00Z');
@@ -1428,8 +1432,8 @@ ${userReason}`;
 		if (yesterdayContribution) {
 			const today = new Date();
 			const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
-			startDateForRange = yesterday.toISOString().split('T')[0];
-			endDateForRange = today.toISOString().split('T')[0]; // Use yesterday for start and today for end
+			startDateForRange = formatDateLocal(yesterday);
+			endDateForRange = formatDateLocal(today); // Use yesterday for start and today for end
 		} else if (startingDate && endingDate) {
 			startDateForRange = startingDate;
 			endDateForRange = endingDate;
@@ -1437,8 +1441,8 @@ ${userReason}`;
 			// Default to last 7 days if no date range is set
 			const today = new Date();
 			const lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7);
-			startDateForRange = lastWeek.toISOString().split('T')[0];
-			endDateForRange = today.toISOString().split('T')[0];
+			startDateForRange = formatDateLocal(lastWeek);
+			endDateForRange = formatDateLocal(today);
 		}
 
 		const daysRange = getDaysBetween(startDateForRange, endDateForRange);
@@ -1537,8 +1541,8 @@ ${userReason}`;
 				if (yesterdayContribution) {
 					const today = new Date();
 					const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
-					startDateFilter = new Date(yesterday.toISOString().split('T')[0] + 'T00:00:00Z');
-					endDateFilter = new Date(today.toISOString().split('T')[0] + 'T23:59:59Z'); // Use yesterday for start and today for end
+					startDateFilter = new Date(formatDateLocal(yesterday) + 'T00:00:00Z');
+					endDateFilter = new Date(formatDateLocal(today) + 'T23:59:59Z'); // Use yesterday for start and today for end
 				} else if (startingDate && endingDate) {
 					startDateFilter = new Date(startingDate + 'T00:00:00Z');
 					endDateFilter = new Date(endingDate + 'T23:59:59Z');
@@ -1546,8 +1550,8 @@ ${userReason}`;
 					// Default to last 7 days if no date range is set
 					const today = new Date();
 					const lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7);
-					startDateFilter = new Date(lastWeek.toISOString().split('T')[0] + 'T00:00:00Z');
-					endDateFilter = new Date(today.toISOString().split('T')[0] + 'T23:59:59Z');
+					startDateFilter = new Date(formatDateLocal(lastWeek) + 'T00:00:00Z');
+					endDateFilter = new Date(formatDateLocal(today) + 'T23:59:59Z');
 				}
 
 				const today = new Date();
@@ -1966,16 +1970,16 @@ async function fetchUserRepositories(username, token, org = '') {
 			if (storageData.yesterdayContribution) {
 				const today = new Date();
 				const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
-				startDate = yesterday.toISOString().split('T')[0];
-				endDate = today.toISOString().split('T')[0];
+				startDate = formatDateLocal(yesterday);
+				endDate = formatDateLocal(today);
 			} else if (storageData.startingDate && storageData.endingDate) {
 				startDate = storageData.startingDate;
 				endDate = storageData.endingDate;
 			} else {
 				const today = new Date();
 				const lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7);
-				startDate = lastWeek.toISOString().split('T')[0];
-				endDate = today.toISOString().split('T')[0];
+				startDate = formatDateLocal(lastWeek);
+				endDate = formatDateLocal(today);
 			}
 
 			dateRange = `+created:${startDate}..${endDate}`;
@@ -1984,8 +1988,8 @@ async function fetchUserRepositories(username, token, org = '') {
 			console.warn('Could not determine date range, using last 30 days:', err);
 			const today = new Date();
 			const thirtyDaysAgo = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 30);
-			const startDate = thirtyDaysAgo.toISOString().split('T')[0];
-			const endDate = today.toISOString().split('T')[0];
+			const startDate = formatDateLocal(thirtyDaysAgo);
+			const endDate = formatDateLocal(today);
 		}
 		const orgPart = org && org !== 'all' ? `+org:${org}` : '';
 		const issuesUrl = `https://api.github.com/search/issues?q=author:${username}${orgPart}${dateRange}&per_page=100`;


### PR DESCRIPTION
### 📌 Fixes

Fixes #444 

---

### 📝 Summary of Changes

Replaced UTC-based date generation (toISOString().split('T')[0]) with local date formatting to prevent timezone shifts in report date ranges.

This ensures the generated scrum report dates match the user's local timezone.

Files updated:

- src/scripts/popup.js

- src/scripts/main.js

- src/scripts/scrumHelper.js

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

This fix prevents incorrect date ranges for users in non-UTC timezones where toISOString() can shift the date backward.

## Summary by Sourcery

Fix report date handling to use local calendar dates instead of UTC-derived dates across the extension.

Bug Fixes:
- Prevent report date ranges from shifting a day for users in non-UTC timezones by basing all generated dates on local time.
- Avoid incorrect GitHub activity ranges caused by UTC-based date filtering in API queries.

Enhancements:
- Add a reusable local-date formatting helper shared across popup, main, and scrum helper scripts.
- Display a user-facing message when no GitHub activity is found for the selected date range.