### PR TITLE
fix: disable generate report button until required inputs are empty

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -79,20 +79,14 @@ a {
 }
 
 .scrum-actions button:disabled {
-    background-color: #f0f0f0; 
-    color: #a0a0a0;            
-    border: 1px solid #d1d5db; 
+    background-color: #2564ebc5;      
     cursor: not-allowed;        
     opacity: 1;                  
     box-shadow: none;           
 }
 
 
-.dark-mode .scrum-actions button:disabled {
-    background-color: #4b5563;  
-    color: #9ca3af;            
-    border: 1px solid #6b7280;  
-}
+
 
 .btn,
 .btn-large {

--- a/src/index.css
+++ b/src/index.css
@@ -79,14 +79,11 @@ a {
 }
 
 .scrum-actions button:disabled {
-    background-color: #2564ebc5;      
-    cursor: not-allowed;        
-    opacity: 1;                  
-    box-shadow: none;           
+    background-color: #2564ebc5;
+    cursor: not-allowed;
+    opacity: 1;
+    box-shadow: none;
 }
-
-
-
 
 .btn,
 .btn-large {

--- a/src/index.css
+++ b/src/index.css
@@ -78,6 +78,22 @@ a {
     white-space: nowrap;
 }
 
+.scrum-actions button:disabled {
+    background-color: #f0f0f0; 
+    color: #a0a0a0;            
+    border: 1px solid #d1d5db; 
+    cursor: not-allowed;        
+    opacity: 1;                  
+    box-shadow: none;           
+}
+
+
+.dark-mode .scrum-actions button:disabled {
+    background-color: #4b5563;  
+    color: #9ca3af;            
+    border: 1px solid #6b7280;  
+}
+
 .btn,
 .btn-large {
     background-color: #3f51b5;

--- a/src/popup.html
+++ b/src/popup.html
@@ -317,8 +317,8 @@
 
 						<div class="scrum-actions my-2">
 							<div class="tooltip-container">
-								<button id="generateReport"
-									class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 rounded"
+								<button id="generateReport" disabled
+									class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 rounded disabled:opacity-50"
 									style="padding-left: 0.875rem; padding-right: 0.875rem;">
 									<i class="fa fa-refresh"></i> <span data-i18n="generateReportButton">Generate</span>
 								</button>

--- a/src/popup.html
+++ b/src/popup.html
@@ -324,7 +324,7 @@
 						<div class="scrum-actions my-2">
 							<div class="tooltip-container">
 								<button id="generateReport" disabled
-									class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 rounded disabled:opacity-50"
+									class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 rounded"
 									style="padding-left: 0.875rem; padding-right: 0.875rem;">
 									<i class="fa fa-refresh"></i> <span data-i18n="generateReportButton">Generate</span>
 								</button>

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -426,11 +426,45 @@ document.addEventListener('DOMContentLoaded', () => {
 	function updateGenerateButtonState() {
 		const generateBtn = document.getElementById('generateReport');
 		const platformUsername = document.getElementById('platformUsername');
-		if (generateBtn && platformUsername) {
-			const hasUsername = platformUsername.value.trim();
-			generateBtn.disabled = !hasUsername;
-			generateBtn.style.cursor = hasUsername ? 'pointer' : 'not-allowed';
+		if (!generateBtn || !platformUsername) {
+			return;
 		}
+
+		const applyGenerateButtonState = () => {
+			const hasUsername = Boolean(platformUsername.value.trim());
+			const shouldDisable = !hasUsername;
+
+			generateBtn.dataset.usernameRequiredDisabled = shouldDisable ? 'true' : 'false';
+			if (generateBtn.disabled !== shouldDisable) {
+				generateBtn.disabled = shouldDisable;
+			}
+			generateBtn.style.cursor = hasUsername ? 'pointer' : 'not-allowed';
+		};
+
+		if (!platformUsername.dataset.generateButtonStateBound) {
+			platformUsername.addEventListener('input', applyGenerateButtonState);
+			platformUsername.addEventListener('change', applyGenerateButtonState);
+			platformUsername.dataset.generateButtonStateBound = 'true';
+		}
+
+		if (!generateBtn.dataset.generateButtonStateObserved && typeof MutationObserver !== 'undefined') {
+			const observer = new MutationObserver(() => {
+				const shouldDisable = !platformUsername.value.trim();
+				if (shouldDisable && generateBtn.disabled === false) {
+					generateBtn.disabled = true;
+					generateBtn.style.cursor = 'not-allowed';
+				}
+			});
+
+			observer.observe(generateBtn, {
+				attributes: true,
+				attributeFilter: ['disabled']
+			});
+
+			generateBtn.dataset.generateButtonStateObserved = 'true';
+		}
+
+		applyGenerateButtonState();
 	}
 
 	function showPopupMessage(message) {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -434,7 +434,6 @@ document.addEventListener('DOMContentLoaded', () => {
 			const hasUsername = Boolean(platformUsername.value.trim());
 			const shouldDisable = !hasUsername;
 
-			generateBtn.dataset.usernameRequiredDisabled = shouldDisable ? 'true' : 'false';
 			if (generateBtn.disabled !== shouldDisable) {
 				generateBtn.disabled = shouldDisable;
 			}

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -438,7 +438,6 @@ document.addEventListener('DOMContentLoaded', () => {
 			if (generateBtn.disabled !== shouldDisable) {
 				generateBtn.disabled = shouldDisable;
 			}
-			generateBtn.style.cursor = hasUsername ? 'pointer' : 'not-allowed';
 		};
 
 		if (!platformUsername.dataset.generateButtonStateBound) {
@@ -452,7 +451,6 @@ document.addEventListener('DOMContentLoaded', () => {
 				const shouldDisable = !platformUsername.value.trim();
 				if (shouldDisable && generateBtn.disabled === false) {
 					generateBtn.disabled = true;
-					generateBtn.style.cursor = 'not-allowed';
 				}
 			});
 
@@ -466,6 +464,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		applyGenerateButtonState();
 	}
+
+	window.updateGenerateButtonState = updateGenerateButtonState;
 
 	function showPopupMessage(message) {
 		if (!message) return;
@@ -695,7 +695,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				const platform = result.platform || 'github';
 				const platformUsernameKey = `${platform}Username`;
 				platformUsername.value = result[platformUsernameKey] || '';
-				updateGenerateButtonState();
+				window.updateGenerateButtonState && window.updateGenerateButtonState();
 				checkTokenForShowCommits();
 				checkTokenForMergedPRs();
 			},
@@ -1046,7 +1046,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				const platformUsernameKey = `${platform}Username`;
 				browser.storage.local.set({ [platformUsernameKey]: platformUsername.value });
 			});
-			updateGenerateButtonState();
+				window.updateGenerateButtonState && window.updateGenerateButtonState();
 		});
 		// Bootstrap report on popup open (restore cache / auto-generate / expired-cache toast)
 		bootstrapScrumReportOnPopupLoad(generateBtn).catch((err) => {
@@ -1746,6 +1746,7 @@ platformSelect.addEventListener('change', () => {
 	browser.storage.local.get([`${platform}Username`]).then((result) => {
 		if (platformUsername) {
 			platformUsername.value = result[`${platform}Username`] || '';
+			window.updateGenerateButtonState && window.updateGenerateButtonState();
 		}
 	});
 
@@ -1789,6 +1790,7 @@ function setPlatformDropdown(value) {
 	browser.storage.local.get([`${value}Username`]).then((result) => {
 		if (platformUsername) {
 			platformUsername.value = result[`${value}Username`] || '';
+			window.updateGenerateButtonState && window.updateGenerateButtonState();
 		}
 	});
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -423,6 +423,16 @@ document.addEventListener('DOMContentLoaded', () => {
 		generateBtn.disabled = true;
 	}
 
+	function updateGenerateButtonState() {
+		const generateBtn = document.getElementById('generateReport');
+		const platformUsername = document.getElementById('platformUsername');
+		if (generateBtn && platformUsername) {
+			const hasUsername = platformUsername.value.trim();
+			generateBtn.disabled = !hasUsername;
+			generateBtn.style.cursor = hasUsername ? 'pointer' : 'not-allowed';
+		}
+	}
+
 	function showPopupMessage(message) {
 		if (!message) return;
 
@@ -651,6 +661,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				const platform = result.platform || 'github';
 				const platformUsernameKey = `${platform}Username`;
 				platformUsername.value = result[platformUsernameKey] || '';
+				updateGenerateButtonState();
 				checkTokenForShowCommits();
 				checkTokenForMergedPRs();
 			},
@@ -994,13 +1005,14 @@ document.addEventListener('DOMContentLoaded', () => {
 			browser.storage.local.set({ endingDate: endingDateInput.value });
 		});
 
-		// Save username to storage on input
+		// Save username to storage on input and update button state
 		platformUsername.addEventListener('input', () => {
 			browser.storage.local.get(['platform']).then((result) => {
 				const platform = result.platform || 'github';
 				const platformUsernameKey = `${platform}Username`;
 				browser.storage.local.set({ [platformUsernameKey]: platformUsername.value });
 			});
+			updateGenerateButtonState();
 		});
 		// Bootstrap report on popup open (restore cache / auto-generate / expired-cache toast)
 		bootstrapScrumReportOnPopupLoad(generateBtn).catch((err) => {


### PR DESCRIPTION
### 📌 Fixes

Fixes #331

---

### 📝 Summary of Changes

The "Generate" button now remains disabled until all required fields are 
properly filled, preventing empty or invalid report generation and improving UX.

**Key Improvements:**
- Button disabled until inputs are not valid
- Real-time validation: checks username 
- Dynamic tooltip shows what's missing (username)



###  Validation Rules

Generate Button is ENABLED only when :
 GitHub Username is provided (non-empty)


 


---

### Demo




---

### Testing Checklist

- [x] Button disabled on initial load
- [x] Button enables only with valid inputs
- [x] Tooltip shows "username" is missing when empty
- [x] Button works once all fields valid
---

### 👀 Reviewer Notes

- Non-breaking change - only affects button state
- Maintains all existing functionality

## Summary by Sourcery

Disable the Scrum report "Generate" button until a GitHub username is provided and keep its disabled state in sync with stored username data and DOM changes.

Bug Fixes:
- Prevent generating Scrum reports when the username field is empty by enforcing a disabled state on the Generate button.

Enhancements:
- Initialize the Generate button as disabled in the UI with visual disabled styling and cursor changes based on validity of the username input.