### PR TITLE
feat: add work-type classification for commit/PR messages

### DIFF
--- a/src/scripts/classifier.js
+++ b/src/scripts/classifier.js
@@ -39,6 +39,14 @@ function classifyBatch(messages, rules = DEFAULT_RULES) {
 }
 
 function getWorkTypeSummary(messages, rules = DEFAULT_RULES) {
+  if (!Array.isArray(messages)) return {
+    feature: 0,
+    bug: 0,
+    docs: 0,
+    refactor: 0,
+    other: 0,
+  };
+
   const summary = {
     feature: 0,
     bug: 0,
@@ -48,7 +56,8 @@ function getWorkTypeSummary(messages, rules = DEFAULT_RULES) {
   };
 
   for (const msg of messages) {
-    summary[classifyCommit(msg, rules)]++;
+    const type = classifyCommit(msg, rules);
+    summary[type] = (summary[type] ?? 0) + 1;
   }
 
   return summary;


### PR DESCRIPTION
### Fixes

Related to #458

---

### Summary of Changes

This PR introduces a small utility to classify Git activity items (commit messages and PR titles) into work types: feature, bug, docs, refactor, and other.

**What’s included:**
- Added `classifier.js` module
- Classification based on:
  - Conventional commit prefixes (e.g., feat:, fix:)
  - Keyword-based heuristics as fallback
- Helper functions for batch classification and summary counts

**Why this change:**
This is an incremental step toward adding analytics on top of Git activity (discussed in #458).

The goal is to:
- establish a reusable classification layer for activity data
- keep the logic independent of UI and sprint goal features
- make it easy to extend or refine later

**Scope:**
- No changes to existing behavior
- No UI changes
- Pure utility addition (not yet integrated into the pipeline)

---

### Screenshots / Demo (if UI-related)

Not applicable (no UI changes)

---

### Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### Reviewer Notes

- The classification is heuristic-based and simple for now
- Feedback on classification rules and approach would be appreciated

## Summary by Sourcery

Introduce a utility module for classifying Git commit/PR messages into work-type categories for later analytics use.

New Features:
- Add a classifier utility to categorize commit and PR messages into feature, bug, docs, refactor, or other.
- Provide batch classification and aggregation helpers to summarize work-type counts from message lists.