### PR TITLE
fix: remove extra line break in repoPlaceholder text

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -437,8 +437,8 @@
 									class="mt-3 min-h-[32px] p-2 border-2 border-gray-200 bg-gray-50 rounded-xl">
 									<div class="flex flex-wrap gap-1" id="repoTags">
 										<span class="text-xs text-gray-500 select-none" id="repoPlaceholder"
-											data-i18n="repoPlaceholder">No
-											repositories selected (all will be included)</span>
+											data-i18n="repoPlaceholder">No repositories selected (all will be included).</span>
+										
 									</div>
 								</div>
 


### PR DESCRIPTION
## Description
I have removed unnecessary line break in the repoPlaceholder span element in popup.html for consistent text rendering.

## Changes
- Fixed extra line break in popup.html line 440

## Screenshots / Demo
Before: Text was split across two lines
After: Text appears on single line

## Summary by Sourcery

Bug Fixes:
- Remove an unintended line break in the repository placeholder text so it appears as a single coherent sentence.