### PR TITLE
fix: invalidate repo filter cache when GitHub token auth state changes

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/src/popup.html
+++ b/src/popup.html
@@ -615,6 +615,7 @@
 	<script src="scripts/jquery-3.2.1.min.js"></script>
 	<script type="text/javascript" type="text/javascript" src="materialize/js/materialize.min.js"></script>
 	<script src="scripts/emailClientAdapter.js"></script>
+	<script src="scripts/githubTokenFingerprint.js"></script>
 	<script src="scripts/main.js"></script>
 	<script src="scripts/gitlabHelper.js"></script>
 	<script src="scripts/scrumHelper.js"></script>

--- a/src/scripts/githubTokenFingerprint.js
+++ b/src/scripts/githubTokenFingerprint.js
@@ -1,0 +1,24 @@
+/**
+ * GitHub token fingerprint helper shared by popup and scrum scripts.
+ */
+async function getGithubTokenFingerprint(token) {
+	const normalizedToken = token?.trim();
+	if (!normalizedToken) {
+		return 'noauth';
+	}
+
+	const inputBytes = new TextEncoder().encode(normalizedToken);
+	const digest = await crypto.subtle.digest('SHA-256', inputBytes);
+	const bytes = new Uint8Array(digest).slice(0, 12);
+	const hex = Array.from(bytes)
+		.map((byte) => byte.toString(16).padStart(2, '0'))
+		.join('');
+
+	return `tok-${hex}`;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = { getGithubTokenFingerprint };
+} else {
+	window.getGithubTokenFingerprint = getGithubTokenFingerprint;
+}

--- a/src/scripts/gitlabHelper.js
+++ b/src/scripts/gitlabHelper.js
@@ -102,11 +102,16 @@ class GitLabHelper {
 			const userUrl = `${this.baseUrl}/users?username=${username}`;
 			const userRes = await fetch(userUrl, { headers });
 			if (!userRes.ok) {
-				throw new Error(chrome?.i18n.getMessage('gitlabUserFetchError', [userRes.status, userRes.statusText]) || `Error fetching GitLab user: ${userRes.status} ${userRes.statusText}`);
+				throw new Error(
+					chrome?.i18n.getMessage('gitlabUserFetchError', [userRes.status, userRes.statusText]) ||
+						`Error fetching GitLab user: ${userRes.status} ${userRes.statusText}`,
+				);
 			}
 			const users = await userRes.json();
 			if (users.length === 0) {
-				throw new Error(chrome?.i18n.getMessage('gitlabUserNotFoundError', [username]) || `GitLab user '${username}' not found`);
+				throw new Error(
+					chrome?.i18n.getMessage('gitlabUserNotFoundError', [username]) || `GitLab user '${username}' not found`,
+				);
 			}
 			const userId = users[0].id;
 
@@ -114,7 +119,13 @@ class GitLabHelper {
 			const membershipProjectsUrl = `${this.baseUrl}/users/${userId}/projects?membership=true&per_page=100&order_by=updated_at&sort=desc`;
 			const membershipProjectsRes = await fetch(membershipProjectsUrl, { headers });
 			if (!membershipProjectsRes.ok) {
-				throw new Error(chrome?.i18n.getMessage('gitlabMembershipError', [membershipProjectsRes.status, membershipProjectsRes.statusText]) || `Error fetching GitLab membership projects: ${membershipProjectsRes.status} ${membershipProjectsRes.statusText}`);
+				throw new Error(
+					chrome?.i18n.getMessage('gitlabMembershipError', [
+						membershipProjectsRes.status,
+						membershipProjectsRes.statusText,
+					]) ||
+						`Error fetching GitLab membership projects: ${membershipProjectsRes.status} ${membershipProjectsRes.statusText}`,
+				);
 			}
 			const membershipProjects = await membershipProjectsRes.json();
 
@@ -123,7 +134,11 @@ class GitLabHelper {
 			const contributedProjectsRes = await fetch(contributedProjectsUrl, { headers });
 			if (!contributedProjectsRes.ok) {
 				throw new Error(
-					chrome?.i18n.getMessage('gitlabContributedError', [contributedProjectsRes.status, contributedProjectsRes.statusText]) || `Error fetching GitLab contributed projects: ${contributedProjectsRes.status} ${contributedProjectsRes.statusText}`,
+					chrome?.i18n.getMessage('gitlabContributedError', [
+						contributedProjectsRes.status,
+						contributedProjectsRes.statusText,
+					]) ||
+						`Error fetching GitLab contributed projects: ${contributedProjectsRes.status} ${contributedProjectsRes.statusText}`,
 				);
 			}
 			const contributedProjects = await contributedProjectsRes.json();

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -358,7 +358,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				lastScrumReportUsername,
 				githubUsername,
 				gitlabUsername,
-				platformUsername
+				platformUsername,
 			} = await storageLocalGet([
 				'lastScrumReportHtml',
 				'lastScrumReportPlatform',
@@ -366,15 +366,14 @@ document.addEventListener('DOMContentLoaded', () => {
 				'lastScrumReportUsername',
 				'githubUsername',
 				'gitlabUsername',
-				'platformUsername'
+				'platformUsername',
 			]);
 
-			const expectedUsername = activePlatform === 'gitlab'
-				? (gitlabUsername || platformUsername)
-				: (githubUsername || platformUsername);
-			const isUsernameMatch = lastScrumReportUsername 
+			const expectedUsername =
+				activePlatform === 'gitlab' ? gitlabUsername || platformUsername : githubUsername || platformUsername;
+			const isUsernameMatch = lastScrumReportUsername
 				? lastScrumReportUsername === expectedUsername
-				: (lastScrumReportCacheKey && expectedUsername && lastScrumReportCacheKey.startsWith(expectedUsername + '-'));
+				: lastScrumReportCacheKey && expectedUsername && lastScrumReportCacheKey.startsWith(expectedUsername + '-');
 
 			if (age < ttlMs) {
 				const cacheKey = cache?.cacheKey ?? null;
@@ -435,6 +434,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		const startingDateInput = document.getElementById('startingDate');
 		const endingDateInput = document.getElementById('endingDate');
 		const platformUsername = document.getElementById('platformUsername');
+		let previousGithubTokenMarker = 'noauth';
 
 		browser.storage.local
 			.get([
@@ -486,6 +486,7 @@ document.addEventListener('DOMContentLoaded', () => {
 					}
 				}
 				if (result.githubToken) githubTokenInput.value = result.githubToken;
+				previousGithubTokenMarker = githubTokenInput.value.trim() ? 'auth' : 'noauth';
 				if (result.cacheInput) cacheInput.value = result.cacheInput;
 				if (typeof result.yesterdayContribution !== 'undefined') yesterdayRadio.checked = result.yesterdayContribution;
 				if (result.startingDate) startingDateInput.value = result.startingDate;
@@ -708,7 +709,15 @@ document.addEventListener('DOMContentLoaded', () => {
 			});
 		});
 		githubTokenInput.addEventListener('input', () => {
-			browser.storage.local.set({ githubToken: githubTokenInput.value });
+			const nextTokenMarker = githubTokenInput.value.trim() ? 'auth' : 'noauth';
+			const shouldInvalidateRepoCache = previousGithubTokenMarker !== nextTokenMarker;
+			previousGithubTokenMarker = nextTokenMarker;
+
+			const payload = { githubToken: githubTokenInput.value };
+			if (shouldInvalidateRepoCache) {
+				payload.repoCache = null;
+			}
+			browser.storage.local.set(payload);
 		});
 		cacheInput.addEventListener('input', () => {
 			browser.storage.local.set({ cacheInput: cacheInput.value });
@@ -750,7 +759,9 @@ document.addEventListener('DOMContentLoaded', () => {
 				// Show notice instead of applying immediately
 				const modeLabel = mode === 'popup' ? 'Popup' : 'Side Panel';
 				if (displayModeNotice && displayModeNoticeText) {
-					displayModeNoticeText.textContent = chrome?.i18n.getMessage('displayModeNotice', [modeLabel]) || `The extension will open in ${modeLabel} mode on the next launch.`;
+					displayModeNoticeText.textContent =
+						chrome?.i18n.getMessage('displayModeNotice', [modeLabel]) ||
+						`The extension will open in ${modeLabel} mode on the next launch.`;
 					displayModeNotice.classList.remove('hidden');
 				}
 			});
@@ -841,6 +852,11 @@ document.addEventListener('DOMContentLoaded', () => {
 		let selectedRepos = [];
 		let highlightedIndex = -1;
 
+		function getRepoCacheKey(username, orgName, token) {
+			const tokenMarker = token && token.trim() ? 'auth' : 'noauth';
+			return `repos-${username}-${orgName || ''}-${tokenMarker}`;
+		}
+
 		async function triggerRepoFetchIfEnabled() {
 			// --- PLATFORM CHECK: Only run for GitHub ---
 			let platform = 'github';
@@ -850,7 +866,9 @@ document.addEventListener('DOMContentLoaded', () => {
 			} catch {}
 			if (platform !== 'github') {
 				// Do not run repo fetch for non-GitHub platforms
-				if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('repoFilteringGithubOnly') || 'Repository filtering is only available for GitHub.';
+				if (repoStatus)
+					repoStatus.textContent =
+						chrome?.i18n.getMessage('repoFilteringGithubOnly') || 'Repository filtering is only available for GitHub.';
 				return;
 			}
 			if (!useRepoFilter.checked) {
@@ -891,7 +909,7 @@ document.addEventListener('DOMContentLoaded', () => {
 						repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [repos.length]);
 					}
 
-					const repoCacheKey = `repos-${username}-${items.orgName || ''}`;
+					const repoCacheKey = getRepoCacheKey(username, items.orgName, items.githubToken);
 					browser.storage.local.set({
 						repoCache: {
 							data: repos,
@@ -939,7 +957,10 @@ document.addEventListener('DOMContentLoaded', () => {
 				if (platform !== 'github') {
 					repoFilterContainer.classList.add('hidden');
 					useRepoFilter.checked = false;
-					if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('repoFilteringGithubOnly') || 'Repository filtering is only available for GitHub.';
+					if (repoStatus)
+						repoStatus.textContent =
+							chrome?.i18n.getMessage('repoFilteringGithubOnly') ||
+							'Repository filtering is only available for GitHub.';
 					return;
 				}
 				const enabled = useRepoFilter.checked;
@@ -969,7 +990,8 @@ document.addEventListener('DOMContentLoaded', () => {
 				});
 				checkTokenForFilter();
 				if (enabled) {
-					repoStatus.textContent = chrome?.i18n.getMessage('loadingReposAutomatically') || 'Loading repos automatically...';
+					repoStatus.textContent =
+						chrome?.i18n.getMessage('loadingReposAutomatically') || 'Loading repos automatically...';
 
 					try {
 						const cacheData = await browser.storage.local.get(['repoCache']);
@@ -990,7 +1012,7 @@ document.addEventListener('DOMContentLoaded', () => {
 							return;
 						}
 
-						const repoCacheKey = `repos-${username}-${items.orgName || ''}`;
+						const repoCacheKey = getRepoCacheKey(username, items.orgName, items.githubToken);
 
 						const now = Date.now();
 						const cacheAge = cacheData.repoCache?.timestamp
@@ -1118,7 +1140,9 @@ document.addEventListener('DOMContentLoaded', () => {
 				platform = items.platform || 'github';
 			} catch {}
 			if (platform !== 'github') {
-				if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('repoLoadingGithubOnly') || 'Repository loading is only available for GitHub.';
+				if (repoStatus)
+					repoStatus.textContent =
+						chrome?.i18n.getMessage('repoLoadingGithubOnly') || 'Repository loading is only available for GitHub.';
 				return;
 			}
 			console.log('window.fetchUserRepositories exists:', !!window.fetchUserRepositories);
@@ -1158,7 +1182,9 @@ document.addEventListener('DOMContentLoaded', () => {
 				platform = items.platform || 'github';
 			} catch (e) {}
 			if (platform !== 'github') {
-				if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('repoFetchingGithubOnly') || 'Repository fetching is only available for GitHub.';
+				if (repoStatus)
+					repoStatus.textContent =
+						chrome?.i18n.getMessage('repoFetchingGithubOnly') || 'Repository fetching is only available for GitHub.';
 				return;
 			}
 			console.log('[POPUP-DEBUG] performRepoFetch called.');
@@ -1177,7 +1203,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				const platform = storageItems.platform || 'github';
 				const platformUsernameKey = `${platform}Username`;
 				const username = storageItems[platformUsernameKey];
-				const repoCacheKey = `repos-${username}-${storageItems.orgName || ''}`;
+				const repoCacheKey = getRepoCacheKey(username, storageItems.orgName, storageItems.githubToken);
 				const now = Date.now();
 				const cacheAge = cacheData.repoCache?.timestamp
 					? now - cacheData.repoCache.timestamp

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -410,22 +410,6 @@ document.addEventListener('DOMContentLoaded', () => {
 		return Number.isFinite(n) && n > 0 ? n : null;
 	}
 
-	async function getGithubTokenFingerprint(token) {
-		const normalizedToken = token?.trim();
-		if (!normalizedToken) {
-			return 'noauth';
-		}
-
-		const inputBytes = new TextEncoder().encode(normalizedToken);
-		const digest = await crypto.subtle.digest('SHA-256', inputBytes);
-		const bytes = new Uint8Array(digest).slice(0, 12);
-		const hex = Array.from(bytes)
-			.map((byte) => byte.toString(16).padStart(2, '0'))
-			.join('');
-
-		return `tok-${hex}`;
-	}
-
 	function setGenerateButtonLoading(generateBtn, isLoading) {
 		if (!generateBtn) return;
 		if (!isLoading) return;
@@ -968,7 +952,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			const shouldInvalidateRepoCache = previousGithubTokenNormalized !== nextTokenNormalized;
 			previousGithubTokenNormalized = nextTokenNormalized;
 
-			const payload = { githubToken: githubTokenInput.value };
+			const payload = { githubToken: nextTokenNormalized };
 			if (shouldInvalidateRepoCache) {
 				payload.repoCache = null;
 			}

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -414,6 +414,21 @@ document.addEventListener('DOMContentLoaded', () => {
 		return Number.isFinite(n) && n > 0 ? n : null;
 	}
 
+	function getGithubTokenFingerprint(token) {
+		const normalizedToken = token?.trim();
+		if (!normalizedToken) {
+			return 'noauth';
+		}
+
+		let hash = 0x811c9dc5;
+		for (let i = 0; i < normalizedToken.length; i += 1) {
+			hash ^= normalizedToken.charCodeAt(i);
+			hash = Math.imul(hash, 0x01000193);
+		}
+
+		return `tok-${(hash >>> 0).toString(16)}`;
+	}
+
 	function setGenerateButtonLoading(generateBtn, isLoading) {
 		if (!generateBtn) return;
 		if (!isLoading) return;
@@ -660,7 +675,7 @@ document.addEventListener('DOMContentLoaded', () => {
 					browser?.storage.local.set({ onlyPRs: false });
 				}
 				if (result.githubToken) githubTokenInput.value = result.githubToken;
-				previousGithubTokenMarker = githubTokenInput.value.trim() ? 'auth' : 'noauth';
+				previousGithubTokenMarker = getGithubTokenFingerprint(githubTokenInput.value);
 				if (result.cacheInput) cacheInput.value = result.cacheInput;
 				if (typeof result.yesterdayContribution !== 'undefined') yesterdayRadio.checked = result.yesterdayContribution;
 				if (result.startingDate) startingDateInput.value = result.startingDate;
@@ -955,7 +970,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			});
 		});
 		githubTokenInput.addEventListener('input', () => {
-			const nextTokenMarker = githubTokenInput.value.trim() ? 'auth' : 'noauth';
+			const nextTokenMarker = getGithubTokenFingerprint(githubTokenInput.value);
 			const shouldInvalidateRepoCache = previousGithubTokenMarker !== nextTokenMarker;
 			previousGithubTokenMarker = nextTokenMarker;
 
@@ -1099,8 +1114,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		let highlightedIndex = -1;
 
 		function getRepoCacheKey(username, orgName, token) {
-			const tokenMarker = token && token.trim() ? 'auth' : 'noauth';
-			return `repos-${username}-${orgName || ''}-${tokenMarker}`;
+			return `repos-${username}-${orgName || ''}-${getGithubTokenFingerprint(token)}`;
 		}
 
 		async function triggerRepoFetchIfEnabled() {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -410,19 +410,20 @@ document.addEventListener('DOMContentLoaded', () => {
 		return Number.isFinite(n) && n > 0 ? n : null;
 	}
 
-	function getGithubTokenFingerprint(token) {
+	async function getGithubTokenFingerprint(token) {
 		const normalizedToken = token?.trim();
 		if (!normalizedToken) {
 			return 'noauth';
 		}
 
-		let hash = 0x811c9dc5;
-		for (let i = 0; i < normalizedToken.length; i += 1) {
-			hash ^= normalizedToken.charCodeAt(i);
-			hash = Math.imul(hash, 0x01000193);
-		}
+		const inputBytes = new TextEncoder().encode(normalizedToken);
+		const digest = await crypto.subtle.digest('SHA-256', inputBytes);
+		const bytes = new Uint8Array(digest).slice(0, 12);
+		const hex = Array.from(bytes)
+			.map((byte) => byte.toString(16).padStart(2, '0'))
+			.join('');
 
-		return `tok-${(hash >>> 0).toString(16)}`;
+		return `tok-${hex}`;
 	}
 
 	function setGenerateButtonLoading(generateBtn, isLoading) {
@@ -595,7 +596,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		const startingDateInput = document.getElementById('startingDate');
 		const endingDateInput = document.getElementById('endingDate');
 		const platformUsername = document.getElementById('platformUsername');
-		let previousGithubTokenMarker = 'noauth';
+		let previousGithubTokenNormalized = '';
 
 		browser.storage.local
 			.get([
@@ -662,7 +663,7 @@ document.addEventListener('DOMContentLoaded', () => {
 					browser?.storage.local.set({ onlyPRs: false });
 				}
 				if (result.githubToken) githubTokenInput.value = result.githubToken;
-				previousGithubTokenMarker = getGithubTokenFingerprint(githubTokenInput.value);
+				previousGithubTokenNormalized = githubTokenInput.value.trim();
 				if (result.cacheInput) cacheInput.value = result.cacheInput;
 				if (typeof result.yesterdayContribution !== 'undefined') yesterdayRadio.checked = result.yesterdayContribution;
 				if (result.startingDate) startingDateInput.value = result.startingDate;
@@ -956,9 +957,9 @@ document.addEventListener('DOMContentLoaded', () => {
 			});
 		});
 		githubTokenInput.addEventListener('input', () => {
-			const nextTokenMarker = getGithubTokenFingerprint(githubTokenInput.value);
-			const shouldInvalidateRepoCache = previousGithubTokenMarker !== nextTokenMarker;
-			previousGithubTokenMarker = nextTokenMarker;
+			const nextTokenNormalized = githubTokenInput.value.trim();
+			const shouldInvalidateRepoCache = previousGithubTokenNormalized !== nextTokenNormalized;
+			previousGithubTokenNormalized = nextTokenNormalized;
 
 			const payload = { githubToken: githubTokenInput.value };
 			if (shouldInvalidateRepoCache) {
@@ -1099,8 +1100,9 @@ document.addEventListener('DOMContentLoaded', () => {
 		let selectedRepos = [];
 		let highlightedIndex = -1;
 
-		function getRepoCacheKey(username, orgName, token) {
-			return `repos-${username}-${orgName || ''}-${getGithubTokenFingerprint(token)}`;
+		async function getRepoCacheKey(username, orgName, token) {
+			const tokenFingerprint = await getGithubTokenFingerprint(token);
+			return `repos-${username}-${orgName || ''}-${tokenFingerprint}`;
 		}
 
 		async function triggerRepoFetchIfEnabled() {
@@ -1155,7 +1157,7 @@ document.addEventListener('DOMContentLoaded', () => {
 						repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [repos.length]);
 					}
 
-					const repoCacheKey = getRepoCacheKey(username, items.orgName, items.githubToken);
+					const repoCacheKey = await getRepoCacheKey(username, items.orgName, items.githubToken);
 					browser.storage.local.set({
 						repoCache: {
 							data: repos,
@@ -1258,7 +1260,7 @@ document.addEventListener('DOMContentLoaded', () => {
 							return;
 						}
 
-						const repoCacheKey = getRepoCacheKey(username, items.orgName, items.githubToken);
+						const repoCacheKey = await getRepoCacheKey(username, items.orgName, items.githubToken);
 
 						const now = Date.now();
 						const cacheAge = cacheData.repoCache?.timestamp
@@ -1449,7 +1451,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				const platform = storageItems.platform || 'github';
 				const platformUsernameKey = `${platform}Username`;
 				const username = storageItems[platformUsernameKey];
-				const repoCacheKey = getRepoCacheKey(username, storageItems.orgName, storageItems.githubToken);
+				const repoCacheKey = await getRepoCacheKey(username, storageItems.orgName, storageItems.githubToken);
 				const now = Date.now();
 				const cacheAge = cacheData.repoCache?.timestamp
 					? now - cacheData.repoCache.timestamp

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -344,12 +344,8 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 
 	githubTokenInput.addEventListener('input', checkTokenForFilter);
-	githubTokenInput.addEventListener('input', () =>
-		checkTokenForShowCommits({ persistState: false }),
-	);
-	githubTokenInput.addEventListener('input', () =>
-		checkTokenForMergedPRs({ persistState: false }),
-	);
+	githubTokenInput.addEventListener('input', () => checkTokenForShowCommits({ persistState: false }));
+	githubTokenInput.addEventListener('input', () => checkTokenForMergedPRs({ persistState: false }));
 
 	darkModeToggle.addEventListener('click', function () {
 		body.classList.toggle('dark-mode');
@@ -506,15 +502,6 @@ document.addEventListener('DOMContentLoaded', () => {
 		if (timestamp > 0) {
 			const age = Date.now() - timestamp;
 
-			const {
-				lastScrumReportHtml,
-				lastScrumReportPlatform,
-				lastScrumReportCacheKey,
-				lastScrumReportUsername,
-				githubUsername,
-				gitlabUsername,
-				platformUsername,
-			} = await storageLocalGet([
 			const storageValues = await storageLocalGet([
 				`${activePlatform}LastScrumReportHtml`,
 				`${activePlatform}LastScrumReportCacheKey`,
@@ -528,24 +515,26 @@ document.addEventListener('DOMContentLoaded', () => {
 				'platformUsername',
 			]);
 
-			const expectedUsername =
-				activePlatform === 'gitlab' ? gitlabUsername || platformUsername : githubUsername || platformUsername;
-			const isUsernameMatch = lastScrumReportUsername
 			let lastScrumReportHtml = storageValues[`${activePlatform}LastScrumReportHtml`];
 			let lastScrumReportCacheKey = storageValues[`${activePlatform}LastScrumReportCacheKey`];
 			let lastScrumReportUsername = storageValues[`${activePlatform}LastScrumReportUsername`];
 
-			if (storageValues.lastScrumReportHtml && (!storageValues.lastScrumReportPlatform || storageValues.lastScrumReportPlatform === activePlatform) && !lastScrumReportHtml) {
+			if (
+				storageValues.lastScrumReportHtml &&
+				(!storageValues.lastScrumReportPlatform || storageValues.lastScrumReportPlatform === activePlatform) &&
+				!lastScrumReportHtml
+			) {
 				lastScrumReportHtml = storageValues.lastScrumReportHtml;
 				lastScrumReportCacheKey = storageValues.lastScrumReportCacheKey;
 				lastScrumReportUsername = storageValues.lastScrumReportUsername;
 			}
 
-			const expectedUsername = activePlatform === 'gitlab'
-				? (storageValues.gitlabUsername || storageValues.platformUsername)
-				: (storageValues.githubUsername || storageValues.platformUsername);
+			const expectedUsername =
+				activePlatform === 'gitlab'
+					? storageValues.gitlabUsername || storageValues.platformUsername
+					: storageValues.githubUsername || storageValues.platformUsername;
 
-			const isUsernameMatch = lastScrumReportUsername 
+			const isUsernameMatch = lastScrumReportUsername
 				? lastScrumReportUsername === expectedUsername
 				: lastScrumReportCacheKey && expectedUsername && lastScrumReportCacheKey.startsWith(expectedUsername + '-');
 
@@ -553,9 +542,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				const cacheKey = cache?.cacheKey ?? null;
 				const reportEmpty = !scrumReport.innerHTML || !scrumReport.innerHTML.trim();
 
-				const matches =
-					(!lastScrumReportCacheKey || lastScrumReportCacheKey === cacheKey) &&
-					isUsernameMatch;
+				const matches = (!lastScrumReportCacheKey || lastScrumReportCacheKey === cacheKey) && isUsernameMatch;
 
 				if (reportEmpty && lastScrumReportHtml && matches) {
 					scrumReport.innerHTML = lastScrumReportHtml;
@@ -687,8 +674,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				platformUsername.value = result[platformUsernameKey] || '';
 				checkTokenForShowCommits();
 				checkTokenForMergedPRs();
-			},
-		);
+			});
 
 		// Button setup
 		const generateBtn = document.getElementById('generateReport');
@@ -1747,11 +1733,11 @@ platformSelect.addEventListener('change', () => {
 	const platform = platformSelect.value;
 	browser.storage.local.set({ platform }).then(() => {
 		const scrumReport = document.getElementById('scrumReport');
-		if(scrumReport){
+		if (scrumReport) {
 			scrumReport.innerHTML = '';
 		}
 		const generateBtn = document.getElementById('generateReport');
-		if(typeof bootstrapScrumReportOnPopupLoad === 'function'){
+		if (typeof bootstrapScrumReportOnPopupLoad === 'function') {
 			bootstrapScrumReportOnPopupLoad(generateBtn);
 		}
 	});
@@ -1807,10 +1793,10 @@ function setPlatformDropdown(value) {
 	platformSelectHidden.value = value;
 	browser.storage.local.set({ platform: value }).then(() => {
 		const scrumReport = document.getElementById('scrumReport');
-		if(scrumReport) scrumReport.innerHTML = '';
+		if (scrumReport) scrumReport.innerHTML = '';
 
 		const generateBtn = document.getElementById('generateReport');
-		if(typeof bootstrapScrumReportOnPopupLoad === 'function'){
+		if (typeof bootstrapScrumReportOnPopupLoad === 'function') {
 			bootstrapScrumReportOnPopupLoad(generateBtn);
 		}
 	});

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -31,22 +31,6 @@ function renderErrorMessage(container, key, fallback, args = []) {
 	container.appendChild(errorDiv);
 }
 
-async function getGithubTokenFingerprint(token) {
-	const normalizedToken = token?.trim();
-	if (!normalizedToken) {
-		return 'noauth';
-	}
-
-	const inputBytes = new TextEncoder().encode(normalizedToken);
-	const digest = await crypto.subtle.digest('SHA-256', inputBytes);
-	const bytes = new Uint8Array(digest).slice(0, 12);
-	const hex = Array.from(bytes)
-		.map((byte) => byte.toString(16).padStart(2, '0'))
-		.join('');
-
-	return `tok-${hex}`;
-}
-
 let refreshButton_Placed = false;
 let hasInjectedContent = false;
 let scrumGenerationInProgress = false;

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -26,7 +26,7 @@ function renderErrorMessage(container, key, fallback, args = []) {
 	errorDiv.style.color = '#dc2626';
 	errorDiv.style.fontWeight = 'bold';
 	errorDiv.style.padding = '10px';
-	errorDiv.textContent = message; 
+	errorDiv.textContent = message;
 	container.innerHTML = '';
 	container.appendChild(errorDiv);
 }
@@ -195,7 +195,11 @@ function allIncluded(outputTarget = 'email') {
 							const scrumReport = document.getElementById('scrumReport');
 							const generateBtn = document.getElementById('generateReport');
 							if (scrumReport) {
-								renderErrorMessage(scrumReport, 'usernameRequiredError', 'Please enter your username to generate a report.');
+								renderErrorMessage(
+									scrumReport,
+									'usernameRequiredError',
+									'Please enter your username to generate a report.',
+								);
 							}
 							if (generateBtn) {
 								generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
@@ -284,7 +288,9 @@ function allIncluded(outputTarget = 'email') {
 											if (err && typeof err.message === 'string' && err.message.trim().length > 0) {
 												errMsg = err.message;
 											} else {
-												errMsg = chrome?.i18n.getMessage('gitlabFetchingError') || 'An error occurred while fetching GitLab data.';
+												errMsg =
+													chrome?.i18n.getMessage('gitlabFetchingError') ||
+													'An error occurred while fetching GitLab data.';
 											}
 											renderErrorMessage(scrumReport, '', errMsg);
 										}
@@ -338,7 +344,9 @@ function allIncluded(outputTarget = 'email') {
 											if (err && typeof err.message === 'string' && err.message.trim().length > 0) {
 												errMsg = err.message;
 											} else {
-												errMsg = chrome?.i18n.getMessage('gitlabFetchingError') || 'An error occurred while fetching GitLab data.';
+												errMsg =
+													chrome?.i18n.getMessage('gitlabFetchingError') ||
+													'An error occurred while fetching GitLab data.';
 											}
 											renderErrorMessage(scrumReport, '', errMsg);
 										}
@@ -352,7 +360,11 @@ function allIncluded(outputTarget = 'email') {
 							const scrumReport = document.getElementById('scrumReport');
 							const generateBtn = document.getElementById('generateReport');
 							if (scrumReport) {
-								renderErrorMessage(scrumReport, 'usernameRequiredError', 'Please enter your username to generate a report.');
+								renderErrorMessage(
+									scrumReport,
+									'usernameRequiredError',
+									'Please enter your username to generate a report.',
+								);
 							}
 							if (generateBtn) {
 								generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
@@ -658,7 +670,9 @@ function allIncluded(outputTarget = 'email') {
 			const userCheckRes = await fetch(userUrl, { headers });
 
 			if (userCheckRes.status === 404) {
-				const errorMsg = chrome?.i18n.getMessage('githubUserNotFoundError', [platformUsernameLocal]) || `GitHub user "${platformUsernameLocal}" not found (404). Please check the username and try again.`;
+				const errorMsg =
+					chrome?.i18n.getMessage('githubUserNotFoundError', [platformUsernameLocal]) ||
+					`GitHub user "${platformUsernameLocal}" not found (404). Please check the username and try again.`;
 				logError(errorMsg);
 				throw new Error(errorMsg);
 			}
@@ -670,7 +684,9 @@ function allIncluded(outputTarget = 'email') {
 			}
 
 			if (!userCheckRes.ok) {
-				const errorMsg = chrome?.i18n.getMessage('githubUserValidationError', [userCheckRes.status, userCheckRes.statusText]) || `Error validating GitHub user: ${userCheckRes.status} ${userCheckRes.statusText}`;
+				const errorMsg =
+					chrome?.i18n.getMessage('githubUserValidationError', [userCheckRes.status, userCheckRes.statusText]) ||
+					`Error validating GitHub user: ${userCheckRes.status} ${userCheckRes.statusText}`;
 				logError(errorMsg);
 				throw new Error(errorMsg);
 			}
@@ -688,7 +704,9 @@ function allIncluded(outputTarget = 'email') {
 			}
 
 			if (issuesRes.status === 422 || prRes.status === 422) {
-				const errorMsg = chrome?.i18n.getMessage('invalidSearchQueryError') || `Invalid search query or date range. Please verify your date range format and try again.`;
+				const errorMsg =
+					chrome?.i18n.getMessage('invalidSearchQueryError') ||
+					`Invalid search query or date range. Please verify your date range format and try again.`;
 				logError(errorMsg);
 				if (outputTarget === 'popup') {
 					Materialize.toast && Materialize.toast(errorMsg, 4000);
@@ -697,7 +715,9 @@ function allIncluded(outputTarget = 'email') {
 			}
 
 			if (!issuesRes.ok) {
-				const errorMsg = chrome?.i18n.getMessage('githubIssuesFetchError', [issuesRes.status, issuesRes.statusText]) || `Error fetching GitHub issues: ${issuesRes.status} ${issuesRes.statusText}`;
+				const errorMsg =
+					chrome?.i18n.getMessage('githubIssuesFetchError', [issuesRes.status, issuesRes.statusText]) ||
+					`Error fetching GitHub issues: ${issuesRes.status} ${issuesRes.statusText}`;
 				logError(errorMsg);
 				if (outputTarget === 'popup') {
 					Materialize.toast && Materialize.toast(errorMsg, 4000);
@@ -705,7 +725,9 @@ function allIncluded(outputTarget = 'email') {
 				throw new Error(errorMsg);
 			}
 			if (!prRes.ok) {
-				const errorMsg = chrome?.i18n.getMessage('githubPRReviewFetchError', [prRes.status, prRes.statusText]) || `Error fetching GitHub PR review data: ${prRes.status} ${prRes.statusText}`;
+				const errorMsg =
+					chrome?.i18n.getMessage('githubPRReviewFetchError', [prRes.status, prRes.statusText]) ||
+					`Error fetching GitHub PR review data: ${prRes.status} ${prRes.statusText}`;
 				logError(errorMsg);
 				if (outputTarget === 'popup') {
 					Materialize.toast && Materialize.toast(errorMsg, 4000);
@@ -713,7 +735,9 @@ function allIncluded(outputTarget = 'email') {
 				throw new Error(errorMsg);
 			}
 			if (!userRes.ok) {
-				const errorMsg = chrome?.i18n.getMessage('githubUserFetchError', [userRes.status, userRes.statusText]) || `Error fetching GitHub user data: ${userRes.status} ${userRes.statusText}`;
+				const errorMsg =
+					chrome?.i18n.getMessage('githubUserFetchError', [userRes.status, userRes.statusText]) ||
+					`Error fetching GitHub user data: ${userRes.status} ${userRes.statusText}`;
 				logError(errorMsg);
 				throw new Error(errorMsg);
 			}
@@ -789,7 +813,8 @@ function allIncluded(outputTarget = 'email') {
 			if (outputTarget === 'popup') {
 				const generateBtn = document.getElementById('generateReport');
 				if (scrumReport) {
-					let errorMsg = chrome?.i18n.getMessage('reportGenerationError') || 'An error occurred while generating the report.';
+					let errorMsg =
+						chrome?.i18n.getMessage('reportGenerationError') || 'An error occurred while generating the report.';
 					if (err) {
 						if (typeof err === 'string') errorMsg = err;
 						else if (err.message) errorMsg = err.message;
@@ -890,7 +915,8 @@ function allIncluded(outputTarget = 'email') {
 			log('Repo fiter disabled, skipping fetch');
 			return [];
 		}
-		const repoCacheKey = `repos-${platformUsernameLocal}-${orgName}-${startDateForCache}-${endDateForCache}`;
+		const tokenMarker = githubToken ? 'auth' : 'noauth';
+		const repoCacheKey = `repos-${platformUsernameLocal}-${orgName}-${startDateForCache}-${endDateForCache}-${tokenMarker}`;
 
 		const now = Date.now();
 		const isRepoCacheFresh = now - githubCache.repoTimeStamp < githubCache.ttl;
@@ -968,7 +994,9 @@ function allIncluded(outputTarget = 'email') {
 	verifyCacheStatus();
 
 	function showInvalidTokenMessage() {
-		const errMsg = chrome?.i18n.getMessage('invalidTokenError') || 'Invalid or expired GitHub token. Please check your token in the Scrum Helper settings and try again.';
+		const errMsg =
+			chrome?.i18n.getMessage('invalidTokenError') ||
+			'Invalid or expired GitHub token. Please check your token in the Scrum Helper settings and try again.';
 		if (outputTarget === 'popup') {
 			const reportDiv = document.getElementById('scrumReport');
 			if (reportDiv) {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -31,6 +31,21 @@ function renderErrorMessage(container, key, fallback, args = []) {
 	container.appendChild(errorDiv);
 }
 
+function getGithubTokenFingerprint(token) {
+	const normalizedToken = token?.trim();
+	if (!normalizedToken) {
+		return 'noauth';
+	}
+
+	let hash = 0x811c9dc5;
+	for (let i = 0; i < normalizedToken.length; i += 1) {
+		hash ^= normalizedToken.charCodeAt(i);
+		hash = Math.imul(hash, 0x01000193);
+	}
+
+	return `tok-${(hash >>> 0).toString(16)}`;
+}
+
 let refreshButton_Placed = false;
 let hasInjectedContent = false;
 let scrumGenerationInProgress = false;
@@ -619,9 +634,10 @@ function allIncluded(outputTarget = 'email') {
 			Accept: 'application/vnd.github.v3+json',
 		};
 
-		if (githubToken) {
+		const normalizedGithubToken = githubToken?.trim();
+		if (normalizedGithubToken) {
 			log('Making authenticated requests.');
-			headers.Authorization = `token ${githubToken}`;
+			headers.Authorization = `token ${normalizedGithubToken}`;
 		} else {
 			log('Making public requests');
 		}
@@ -940,8 +956,7 @@ function allIncluded(outputTarget = 'email') {
 			log('Repo fiter disabled, skipping fetch');
 			return [];
 		}
-		const tokenMarker = githubToken ? 'auth' : 'noauth';
-		const repoCacheKey = `repos-${platformUsernameLocal}-${orgName}-${startDateForCache}-${endDateForCache}-${tokenMarker}`;
+		const repoCacheKey = `repos-${platformUsernameLocal}-${orgName}-${startDateForCache}-${endDateForCache}-${getGithubTokenFingerprint(githubToken)}`;
 
 		const now = Date.now();
 		const isRepoCacheFresh = now - githubCache.repoTimeStamp < githubCache.ttl;

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -31,19 +31,20 @@ function renderErrorMessage(container, key, fallback, args = []) {
 	container.appendChild(errorDiv);
 }
 
-function getGithubTokenFingerprint(token) {
+async function getGithubTokenFingerprint(token) {
 	const normalizedToken = token?.trim();
 	if (!normalizedToken) {
 		return 'noauth';
 	}
 
-	let hash = 0x811c9dc5;
-	for (let i = 0; i < normalizedToken.length; i += 1) {
-		hash ^= normalizedToken.charCodeAt(i);
-		hash = Math.imul(hash, 0x01000193);
-	}
+	const inputBytes = new TextEncoder().encode(normalizedToken);
+	const digest = await crypto.subtle.digest('SHA-256', inputBytes);
+	const bytes = new Uint8Array(digest).slice(0, 12);
+	const hex = Array.from(bytes)
+		.map((byte) => byte.toString(16).padStart(2, '0'))
+		.join('');
 
-	return `tok-${(hash >>> 0).toString(16)}`;
+	return `tok-${hex}`;
 }
 
 let refreshButton_Placed = false;
@@ -917,11 +918,12 @@ function allIncluded(outputTarget = 'email') {
 			.join('\n');
 		const query = `query { ${queries} }`;
 		log('GraphQL query for commits:', query);
+		const normalizedGithubToken = githubToken?.trim();
 		const res = await fetch('https://api.github.com/graphql', {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
-				...(githubToken ? { Authorization: `bearer ${githubToken}` } : {}),
+				...(normalizedGithubToken ? { Authorization: `bearer ${normalizedGithubToken}` } : {}),
 			},
 			body: JSON.stringify({ query }),
 		});
@@ -956,7 +958,8 @@ function allIncluded(outputTarget = 'email') {
 			log('Repo fiter disabled, skipping fetch');
 			return [];
 		}
-		const repoCacheKey = `repos-${platformUsernameLocal}-${orgName}-${startDateForCache}-${endDateForCache}-${getGithubTokenFingerprint(githubToken)}`;
+		const tokenFingerprint = await getGithubTokenFingerprint(githubToken);
+		const repoCacheKey = `repos-${platformUsernameLocal}-${orgName}-${startDateForCache}-${endDateForCache}-${tokenFingerprint}`;
 
 		const now = Date.now();
 		const isRepoCacheFresh = now - githubCache.repoTimeStamp < githubCache.ttl;


### PR DESCRIPTION
### 📌 Fixes

Fixes #493

---

### 📝 Summary of Changes

- Added token-aware repository cache keys for GitHub repo filtering in popup flows.
- Updated repo cache key generation to include auth state marker (`auth` / `noauth`) so cache is not reused across unauthenticated and authenticated sessions.
- Added cache invalidation when GitHub token auth mode changes (empty <-> non-empty), forcing fresh repository fetch.
- Updated internal repo-cache key in scrum generation path to include auth state for consistency.
- Updated Biome schema in `biome.json` to match installed CLI version (`2.4.9`) and formatted affected files to pass checks.

Files touched:
- `src/scripts/popup.js`
- `src/scripts/scrumHelper.js`
- `src/scripts/gitlabHelper.js` (format only)
- `biome.json`


### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

- Main bug fixed: repository filter could serve stale unauthenticated cached repos after user adds GitHub token.
- Token auth-state transitions now invalidate repo cache and generate distinct cache keys.
- Validation run:
  - `npm install`
  - `npm run check` (passes)
- `src/scripts/gitlabHelper.js` was auto-formatted to satisfy repository-wide Biome checks; no logic change intended there.

## Summary by Sourcery

Ensure GitHub repository filtering cache respects authentication state and is invalidated when the GitHub token changes.

Bug Fixes:
- Prevent stale unauthenticated GitHub repository lists from being reused after a user adds or removes a GitHub token by incorporating auth state into repo cache keys.
- Fix scrum generation repo cache reuse across different GitHub auth states by including an auth marker in the cache key.

Enhancements:
- Add a helper for building token-aware GitHub repo cache keys shared across popup repo-fetch flows.
- Improve i18n error and status message formatting consistency across popup, scrum helper, and GitLab helper scripts.

Build:
- Update Biome configuration to the installed CLI version and reformat affected scripts to satisfy style checks.