### PR TITLE
fix: prevent action buttons overflow and layout break with long translations (#477, #469)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -60,16 +60,13 @@ a {
 
 .scrum-actions {
     display: flex;
+    flex-wrap: wrap;
     gap: 8px;
 }
 
 .scrum-actions > button {
-    flex: 1 1 0;
+    flex: 1 1 auto;
     min-width: 0;
-}
-
-.scrum-actions > button span {
-    white-space: nowrap;
 }
 
 .btn,

--- a/src/popup.html
+++ b/src/popup.html
@@ -293,12 +293,12 @@
 
 						<div class="scrum-actions my-2">
 							<button id="generateReport"
-								class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-3 rounded">
+								class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-2 rounded">
 								<i class="fa fa-refresh"></i> <span data-i18n="generateReportButton">Generate</span>
 							</button>
 
 							<button id="insertInEmail"
-								class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded">
+								class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-2 rounded">
 								<i class="fa fa-envelope"></i> <span data-i18n="insertInEmailButton">Insert in
 									Email</span>
 							</button>


### PR DESCRIPTION
### 📌 Fixes

Fixes #477
Fixes #469

---

### 📝 Summary of Changes

- Added `flex-wrap: wrap` to `.scrum-actions` so buttons gracefully wrap to the next row when translations are too long to fit in one line
- Changed `flex: 1 1 0` to `flex: 1 1 auto` for content-aware button sizing while still distributing space evenly
- Removed `white-space: nowrap` from button text spans to allow text wrapping within buttons
- Normalized inconsistent button padding (`px-3`, `px-4`, `px-2`) to a uniform `px-2` across all three action buttons

---

### 📸 Screenshots / Demo (if UI-related)

![fix-477-469](https://github.com/user-attachments/assets/278f6565-f098-4a72-a017-2b495a6bc3e2)

---

### ✅ Checklist

- [x] I've tested my changes locally
- [ ] I've added tests (if applicable)
- [ ] I've updated documentation (if applicable)
- [x] My code follows the project's code style guidelines

---

### 👀 Reviewer Notes

This is a CSS-only fix (plus Tailwind class normalization in HTML). No JavaScript logic was changed. The fix ensures action buttons remain usable across all supported locales, especially those with longer translated strings.