### PR TITLE
fix: prevent start date from exceeding end date

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -12,6 +12,45 @@ const userReasonElement = null;
 
 const showCommitsElement = document.getElementById('showCommits');
 
+if (!window.scrumDateRangeUtils) {
+	window.scrumDateRangeUtils = {
+		normalizeAndSync(startDateInput, endDateInput) {
+			const today = new Date().toISOString().split('T')[0];
+			const originalStartDate = startDateInput.value;
+			const originalEndDate = endDateInput.value;
+
+			let normalizedStartDate = originalStartDate;
+			let normalizedEndDate = originalEndDate;
+
+			if (normalizedStartDate && normalizedStartDate > today) {
+				normalizedStartDate = today;
+			}
+			if (normalizedEndDate && normalizedEndDate > today) {
+				normalizedEndDate = today;
+			}
+			if (normalizedStartDate && normalizedEndDate && normalizedStartDate > normalizedEndDate) {
+				normalizedEndDate = normalizedStartDate;
+			}
+
+			const didChange =
+				normalizedStartDate !== originalStartDate || normalizedEndDate !== originalEndDate;
+
+			if (didChange) {
+				startDateInput.value = normalizedStartDate;
+				endDateInput.value = normalizedEndDate;
+			}
+
+			const startDate = startDateInput.value;
+			const endDate = endDateInput.value;
+			startDateInput.max = endDate && endDate < today ? endDate : today;
+			endDateInput.min = startDate || '';
+			endDateInput.max = today;
+
+			return didChange;
+		},
+	};
+}
+
 function handleBodyOnLoad() {
 	// Migration: Handle existing users with old platformUsername storage
 	browser.storage.local.get(['platform', 'platformUsername']).then((result) => {
@@ -67,14 +106,11 @@ function handleBodyOnLoad() {
 			if (items.startingDate) {
 				startingDateElement.value = items.startingDate;
 			}
-			if (
-				startingDateElement.value &&
-				endingDateElement.value &&
-				startingDateElement.value > endingDateElement.value
-			) {
-				endingDateElement.value = startingDateElement.value;
-			}
+			const wasNormalizedOnLoad = normalizeDateRangeValues();
 			syncDateRangeConstraints();
+			if (wasNormalizedOnLoad) {
+				persistDateRange();
+			}
 			if (items.showOpenLabel) {
 				showOpenLabelElement.checked = items.showOpenLabel;
 			} else if (items.showOpenLabel !== false) {
@@ -111,42 +147,36 @@ document.getElementById('refreshCache').addEventListener('click', async (e) => {
 });
 
 function handleStartingDateChange() {
-	if (startingDateElement.value && endingDateElement.value && startingDateElement.value > endingDateElement.value) {
-		endingDateElement.value = startingDateElement.value;
-	}
+	normalizeDateRangeValues();
 	syncDateRangeConstraints();
+	persistDateRange();
+}
+function handleEndingDateChange() {
+	normalizeDateRangeValues();
+	syncDateRangeConstraints();
+	persistDateRange();
+}
+
+function persistDateRange() {
 	browser.storage.local.set({
 		startingDate: startingDateElement.value,
 		endingDate: endingDateElement.value,
 	});
 }
-function handleEndingDateChange() {
-	if (startingDateElement.value && endingDateElement.value && endingDateElement.value < startingDateElement.value) {
-		endingDateElement.value = startingDateElement.value;
-	}
-	syncDateRangeConstraints();
-	browser.storage.local.set({
-		startingDate: startingDateElement.value,
-		endingDate: endingDateElement.value,
-	});
+
+function normalizeDateRangeValues() {
+	const originalStartDate = startingDateElement.value;
+	const originalEndDate = endingDateElement.value;
+
+	window.scrumDateRangeUtils.normalizeAndSync(startingDateElement, endingDateElement);
+
+	return (
+		startingDateElement.value !== originalStartDate || endingDateElement.value !== originalEndDate
+	);
 }
 
 function syncDateRangeConstraints() {
-	const today = getToday();
-
-	if (endingDateElement.value && endingDateElement.value > today) {
-		endingDateElement.value = today;
-	}
-	if (startingDateElement.value && startingDateElement.value > today) {
-		startingDateElement.value = today;
-	}
-
-	const startDate = startingDateElement.value;
-	const endDate = endingDateElement.value;
-
-	startingDateElement.max = endDate && endDate < today ? endDate : today;
-	endingDateElement.min = startDate || '';
-	endingDateElement.max = today;
+	window.scrumDateRangeUtils.normalizeAndSync(startingDateElement, endingDateElement);
 }
 
 function handleYesterdayContributionChange() {
@@ -158,9 +188,9 @@ function handleYesterdayContributionChange() {
 		endingDateElement.readOnly = true;
 		endingDateElement.value = getToday();
 		startingDateElement.value = getYesterday();
+		normalizeDateRangeValues();
 		syncDateRangeConstraints();
-		handleEndingDateChange();
-		handleStartingDateChange();
+		persistDateRange();
 		labelElement.classList.add('selectedLabel');
 		labelElement.classList.remove('unselectedLabel');
 	} else {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -14,11 +14,21 @@ const showCommitsElement = document.getElementById('showCommits');
 
 if (!window.scrumDateRangeUtils) {
 	window.scrumDateRangeUtils = {
-		getLocalTodayString() {
-			const now = new Date();
-			const localDate = new Date(now.getTime() - now.getTimezoneOffset() * 60000);
+		formatLocalDate(date) {
+			const year = date.getFullYear();
+			const month = String(date.getMonth() + 1).padStart(2, '0');
+			const day = String(date.getDate()).padStart(2, '0');
 
-			return localDate.toISOString().split('T')[0];
+			return `${year}-${month}-${day}`;
+		},
+		getLocalTodayString() {
+			return this.formatLocalDate(new Date());
+		},
+		getLocalYesterdayString() {
+			const yesterday = new Date();
+			yesterday.setDate(yesterday.getDate() - 1);
+
+			return this.formatLocalDate(yesterday);
 		},
 		normalizeAndSync(startDateInput, endDateInput) {
 			const today = this.getLocalTodayString();
@@ -210,14 +220,10 @@ function handleYesterdayContributionChange() {
 }
 
 function getYesterday() {
-	const today = new Date();
-	const yesterday = new Date(today);
-	yesterday.setDate(today.getDate() - 1);
-	return yesterday.toISOString().split('T')[0];
+	return window.scrumDateRangeUtils.getLocalYesterdayString();
 }
 function getToday() {
-	const today = new Date();
-	return today.toISOString().split('T')[0];
+	return window.scrumDateRangeUtils.getLocalTodayString();
 }
 
 function handlePlatformUsernameChange() {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -176,7 +176,8 @@ function normalizeDateRangeValues() {
 }
 
 function syncDateRangeConstraints() {
-	window.scrumDateRangeUtils.normalizeAndSync(startingDateElement, endingDateElement);
+	endingDateElement.min = startingDateElement.value || '';
+	startingDateElement.max = endingDateElement.value || '';
 }
 
 function handleYesterdayContributionChange() {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -14,8 +14,14 @@ const showCommitsElement = document.getElementById('showCommits');
 
 if (!window.scrumDateRangeUtils) {
 	window.scrumDateRangeUtils = {
+		getLocalTodayString() {
+			const now = new Date();
+			const localDate = new Date(now.getTime() - now.getTimezoneOffset() * 60000);
+
+			return localDate.toISOString().split('T')[0];
+		},
 		normalizeAndSync(startDateInput, endDateInput) {
-			const today = new Date().toISOString().split('T')[0];
+			const today = this.getLocalTodayString();
 			const originalStartDate = startDateInput.value;
 			const originalEndDate = endDateInput.value;
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -67,6 +67,14 @@ function handleBodyOnLoad() {
 			if (items.startingDate) {
 				startingDateElement.value = items.startingDate;
 			}
+			if (
+				startingDateElement.value &&
+				endingDateElement.value &&
+				startingDateElement.value > endingDateElement.value
+			) {
+				endingDateElement.value = startingDateElement.value;
+			}
+			syncDateRangeConstraints();
 			if (items.showOpenLabel) {
 				showOpenLabelElement.checked = items.showOpenLabel;
 			} else if (items.showOpenLabel !== false) {
@@ -103,12 +111,42 @@ document.getElementById('refreshCache').addEventListener('click', async (e) => {
 });
 
 function handleStartingDateChange() {
-	const value = startingDateElement.value;
-	browser.storage.local.set({ startingDate: value });
+	if (startingDateElement.value && endingDateElement.value && startingDateElement.value > endingDateElement.value) {
+		endingDateElement.value = startingDateElement.value;
+	}
+	syncDateRangeConstraints();
+	browser.storage.local.set({
+		startingDate: startingDateElement.value,
+		endingDate: endingDateElement.value,
+	});
 }
 function handleEndingDateChange() {
-	const value = endingDateElement.value;
-	browser.storage.local.set({ endingDate: value });
+	if (startingDateElement.value && endingDateElement.value && endingDateElement.value < startingDateElement.value) {
+		endingDateElement.value = startingDateElement.value;
+	}
+	syncDateRangeConstraints();
+	browser.storage.local.set({
+		startingDate: startingDateElement.value,
+		endingDate: endingDateElement.value,
+	});
+}
+
+function syncDateRangeConstraints() {
+	const today = getToday();
+
+	if (endingDateElement.value && endingDateElement.value > today) {
+		endingDateElement.value = today;
+	}
+	if (startingDateElement.value && startingDateElement.value > today) {
+		startingDateElement.value = today;
+	}
+
+	const startDate = startingDateElement.value;
+	const endDate = endingDateElement.value;
+
+	startingDateElement.max = endDate && endDate < today ? endDate : today;
+	endingDateElement.min = startDate || '';
+	endingDateElement.max = today;
 }
 
 function handleYesterdayContributionChange() {
@@ -120,6 +158,7 @@ function handleYesterdayContributionChange() {
 		endingDateElement.readOnly = true;
 		endingDateElement.value = getToday();
 		startingDateElement.value = getYesterday();
+		syncDateRangeConstraints();
 		handleEndingDateChange();
 		handleStartingDateChange();
 		labelElement.classList.add('selectedLabel');
@@ -127,6 +166,7 @@ function handleYesterdayContributionChange() {
 	} else {
 		startingDateElement.readOnly = false;
 		endingDateElement.readOnly = false;
+		syncDateRangeConstraints();
 		labelElement.classList.add('unselectedLabel');
 		labelElement.classList.remove('selectedLabel');
 	}

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -29,7 +29,7 @@ if (!window.scrumDateRangeUtils) {
 				normalizedEndDate = today;
 			}
 			if (normalizedStartDate && normalizedEndDate && normalizedStartDate > normalizedEndDate) {
-				normalizedEndDate = normalizedStartDate;
+				normalizedEndDate = '';
 			}
 
 			const didChange =
@@ -41,8 +41,7 @@ if (!window.scrumDateRangeUtils) {
 			}
 
 			const startDate = startDateInput.value;
-			const endDate = endDateInput.value;
-			startDateInput.max = endDate && endDate < today ? endDate : today;
+			startDateInput.max = today;
 			endDateInput.min = startDate || '';
 			endDateInput.max = today;
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -48,6 +48,24 @@ if (!window.scrumDateRangeUtils) {
 
 			return didChange;
 		},
+		normalizeDateRangeValues(startDateInput, endDateInput) {
+			const originalStartDate = startDateInput.value;
+			const originalEndDate = endDateInput.value;
+
+			this.normalizeAndSync(startDateInput, endDateInput);
+
+			return startDateInput.value !== originalStartDate || endDateInput.value !== originalEndDate;
+		},
+		persistDateRange(startDateInput, endDateInput) {
+			browser.storage.local.set({
+				startingDate: startDateInput.value,
+				endingDate: endDateInput.value,
+			});
+		},
+		normalizeSyncAndPersistDateRange(startDateInput, endDateInput) {
+			this.normalizeDateRangeValues(startDateInput, endDateInput);
+			this.persistDateRange(startDateInput, endDateInput);
+		},
 	};
 }
 
@@ -106,10 +124,12 @@ function handleBodyOnLoad() {
 			if (items.startingDate) {
 				startingDateElement.value = items.startingDate;
 			}
-			const wasNormalizedOnLoad = normalizeDateRangeValues();
-			syncDateRangeConstraints();
+			const wasNormalizedOnLoad = window.scrumDateRangeUtils.normalizeDateRangeValues(
+				startingDateElement,
+				endingDateElement,
+			);
 			if (wasNormalizedOnLoad) {
-				persistDateRange();
+				window.scrumDateRangeUtils.persistDateRange(startingDateElement, endingDateElement);
 			}
 			if (items.showOpenLabel) {
 				showOpenLabelElement.checked = items.showOpenLabel;
@@ -147,37 +167,16 @@ document.getElementById('refreshCache').addEventListener('click', async (e) => {
 });
 
 function handleStartingDateChange() {
-	normalizeDateRangeValues();
-	syncDateRangeConstraints();
-	persistDateRange();
-}
-function handleEndingDateChange() {
-	normalizeDateRangeValues();
-	syncDateRangeConstraints();
-	persistDateRange();
-}
-
-function persistDateRange() {
-	browser.storage.local.set({
-		startingDate: startingDateElement.value,
-		endingDate: endingDateElement.value,
-	});
-}
-
-function normalizeDateRangeValues() {
-	const originalStartDate = startingDateElement.value;
-	const originalEndDate = endingDateElement.value;
-
-	window.scrumDateRangeUtils.normalizeAndSync(startingDateElement, endingDateElement);
-
-	return (
-		startingDateElement.value !== originalStartDate || endingDateElement.value !== originalEndDate
+	window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(
+		startingDateElement,
+		endingDateElement,
 	);
 }
-
-function syncDateRangeConstraints() {
-	endingDateElement.min = startingDateElement.value || '';
-	startingDateElement.max = endingDateElement.value || '';
+function handleEndingDateChange() {
+	window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(
+		startingDateElement,
+		endingDateElement,
+	);
 }
 
 function handleYesterdayContributionChange() {
@@ -189,15 +188,16 @@ function handleYesterdayContributionChange() {
 		endingDateElement.readOnly = true;
 		endingDateElement.value = getToday();
 		startingDateElement.value = getYesterday();
-		normalizeDateRangeValues();
-		syncDateRangeConstraints();
-		persistDateRange();
+		window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(
+			startingDateElement,
+			endingDateElement,
+		);
 		labelElement.classList.add('selectedLabel');
 		labelElement.classList.remove('unselectedLabel');
 	} else {
 		startingDateElement.readOnly = false;
 		endingDateElement.readOnly = false;
-		syncDateRangeConstraints();
+		window.scrumDateRangeUtils.normalizeDateRangeValues(startingDateElement, endingDateElement);
 		labelElement.classList.add('unselectedLabel');
 		labelElement.classList.remove('selectedLabel');
 	}

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -675,13 +675,6 @@ document.addEventListener('DOMContentLoaded', () => {
 				if (result.startingDate) startingDateInput.value = result.startingDate;
 				if (result.endingDate) endingDateInput.value = result.endingDate;
 				const wasNormalizedOnLoad = normalizeDateRangeValues();
-				if (
-					typeof window !== 'undefined' &&
-					window.scrumDateRangeUtils &&
-					typeof window.scrumDateRangeUtils.normalizeAndSync === 'function'
-				) {
-					window.scrumDateRangeUtils.normalizeAndSync(startingDateInput, endingDateInput);
-				}
 				if (wasNormalizedOnLoad) {
 					persistDateRange();
 				}

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -593,10 +593,6 @@ document.addEventListener('DOMContentLoaded', () => {
 			);
 		}
 
-		function syncDateRangeConstraints() {
-			window.scrumDateRangeUtils.normalizeAndSync(startingDateInput, endingDateInput);
-		}
-
 		function persistDateRange() {
 			browser.storage.local.set({
 				startingDate: startingDateInput.value,
@@ -606,7 +602,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		function normalizeSyncAndPersistDateRange() {
 			normalizeDateRangeValues();
-			syncDateRangeConstraints();
 			persistDateRange();
 		}
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -577,6 +577,34 @@ document.addEventListener('DOMContentLoaded', () => {
 		const endingDateInput = document.getElementById('endingDate');
 		const platformUsername = document.getElementById('platformUsername');
 
+		function normalizeDateRangeValues() {
+			const originalStartDate = startingDateInput.value;
+			const originalEndDate = endingDateInput.value;
+
+			window.scrumDateRangeUtils.normalizeAndSync(startingDateInput, endingDateInput);
+
+			return (
+				startingDateInput.value !== originalStartDate || endingDateInput.value !== originalEndDate
+			);
+		}
+
+		function syncDateRangeConstraints() {
+			window.scrumDateRangeUtils.normalizeAndSync(startingDateInput, endingDateInput);
+		}
+
+		function persistDateRange() {
+			browser.storage.local.set({
+				startingDate: startingDateInput.value,
+				endingDate: endingDateInput.value,
+			});
+		}
+
+		function normalizeSyncAndPersistDateRange() {
+			normalizeDateRangeValues();
+			syncDateRangeConstraints();
+			persistDateRange();
+		}
+
 		browser.storage.local
 			.get([
 				'projectName',
@@ -646,6 +674,11 @@ document.addEventListener('DOMContentLoaded', () => {
 				if (typeof result.yesterdayContribution !== 'undefined') yesterdayRadio.checked = result.yesterdayContribution;
 				if (result.startingDate) startingDateInput.value = result.startingDate;
 				if (result.endingDate) endingDateInput.value = result.endingDate;
+				const wasNormalizedOnLoad = normalizeDateRangeValues();
+				syncDateRangeConstraints();
+				if (wasNormalizedOnLoad) {
+					persistDateRange();
+				}
 
 				// Load platform-specific username
 				const platform = result.platform || 'github';
@@ -988,10 +1021,10 @@ document.addEventListener('DOMContentLoaded', () => {
 			browser.storage.local.set({ yesterdayContribution: yesterdayRadio.checked });
 		});
 		startingDateInput.addEventListener('input', () => {
-			browser.storage.local.set({ startingDate: startingDateInput.value });
+			normalizeSyncAndPersistDateRange();
 		});
 		endingDateInput.addEventListener('input', () => {
-			browser.storage.local.set({ endingDate: endingDateInput.value });
+			normalizeSyncAndPersistDateRange();
 		});
 
 		// Save username to storage on input

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -582,29 +582,6 @@ document.addEventListener('DOMContentLoaded', () => {
 		const endingDateInput = document.getElementById('endingDate');
 		const platformUsername = document.getElementById('platformUsername');
 
-		function normalizeDateRangeValues() {
-			const originalStartDate = startingDateInput.value;
-			const originalEndDate = endingDateInput.value;
-
-			window.scrumDateRangeUtils.normalizeAndSync(startingDateInput, endingDateInput);
-
-			return (
-				startingDateInput.value !== originalStartDate || endingDateInput.value !== originalEndDate
-			);
-		}
-
-		function persistDateRange() {
-			browser.storage.local.set({
-				startingDate: startingDateInput.value,
-				endingDate: endingDateInput.value,
-			});
-		}
-
-		function normalizeSyncAndPersistDateRange() {
-			normalizeDateRangeValues();
-			persistDateRange();
-		}
-
 		browser.storage.local
 			.get([
 				'projectName',
@@ -674,9 +651,12 @@ document.addEventListener('DOMContentLoaded', () => {
 				if (typeof result.yesterdayContribution !== 'undefined') yesterdayRadio.checked = result.yesterdayContribution;
 				if (result.startingDate) startingDateInput.value = result.startingDate;
 				if (result.endingDate) endingDateInput.value = result.endingDate;
-				const wasNormalizedOnLoad = normalizeDateRangeValues();
+				const wasNormalizedOnLoad = window.scrumDateRangeUtils.normalizeDateRangeValues(
+					startingDateInput,
+					endingDateInput,
+				);
 				if (wasNormalizedOnLoad) {
-					persistDateRange();
+					window.scrumDateRangeUtils.persistDateRange(startingDateInput, endingDateInput);
 				}
 
 				// Load platform-specific username
@@ -1020,10 +1000,16 @@ document.addEventListener('DOMContentLoaded', () => {
 			browser.storage.local.set({ yesterdayContribution: yesterdayRadio.checked });
 		});
 		startingDateInput.addEventListener('input', () => {
-			normalizeSyncAndPersistDateRange();
+			window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(
+				startingDateInput,
+				endingDateInput,
+			);
 		});
 		endingDateInput.addEventListener('input', () => {
-			normalizeSyncAndPersistDateRange();
+			window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(
+				startingDateInput,
+				endingDateInput,
+			);
 		});
 
 		// Save username to storage on input

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -675,7 +675,13 @@ document.addEventListener('DOMContentLoaded', () => {
 				if (result.startingDate) startingDateInput.value = result.startingDate;
 				if (result.endingDate) endingDateInput.value = result.endingDate;
 				const wasNormalizedOnLoad = normalizeDateRangeValues();
-				syncDateRangeConstraints();
+				if (
+					typeof window !== 'undefined' &&
+					window.scrumDateRangeUtils &&
+					typeof window.scrumDateRangeUtils.normalizeAndSync === 'function'
+				) {
+					window.scrumDateRangeUtils.normalizeAndSync(startingDateInput, endingDateInput);
+				}
 				if (wasNormalizedOnLoad) {
 					persistDateRange();
 				}


### PR DESCRIPTION
### 📌 Fixes #331 

I implement the solution based on Vedansh suggession 


### 📝 Summary of Changes

Disable the future dates and also start date must be less then end date
---

### 📸 Screenshots / Demo (if UI-related)

<img width="511" height="849" alt="image" src="https://github.com/user-attachments/assets/ec618d1d-0e31-4571-a365-60884d568e42" />


---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [x] I’ve added tests (if applicable)
- [x] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes
I reused  **_invalidSearchQueryError_** key from the translation files because it is highly relevant to the current logic. Leveraging existing strings helps maintain UI consistency and prevents redundant entries in our localization files

## Summary by Sourcery

Bug Fixes:
- Reject invalid or reversed date ranges when generating scrum reports, surface a localized error message in the popup, and reset the generation state.