### PR TITLE
fix: clear email polling intervals on popup early-exit to avoid memory leak

### DIFF
--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1871,6 +1871,8 @@ ${blockerText}`;
 		issuesDataProcessed = true;
 	}
 
+		const POLL_INTERVAL_TIMEOUT = 30000;
+
 	const intervalBody = setInterval(() => {
 		if (!window.emailClientAdapter) return;
 
@@ -1880,6 +1882,7 @@ ${blockerText}`;
 		clearInterval(intervalBody);
 		scrumBody = elements.body;
 	}, 500);
+	setTimeout(() => clearInterval(intervalBody), POLL_INTERVAL_TIMEOUT);
 
 	const intervalSubject = setInterval(() => {
 		const userData = platform === 'gitlab' ? githubUserData || platformUsername : githubUserData;
@@ -1901,6 +1904,7 @@ ${blockerText}`;
 			scrumSubjectLoaded();
 		}, 500);
 	}, 500);
+	setTimeout(() => clearInterval(intervalSubject), POLL_INTERVAL_TIMEOUT);
 
 	// check for github safe writing
 	const intervalWriteGithubIssues = setInterval(() => {
@@ -1914,6 +1918,7 @@ ${blockerText}`;
 			writeGithubIssuesPrs();
 		}
 	}, 500);
+	setTimeout(() => clearInterval(intervalWriteGithubIssues), POLL_INTERVAL_TIMEOUT);
 	const intervalWriteGithubPrs = setInterval(() => {
 		if (outputTarget === 'popup') {
 			return;
@@ -1926,6 +1931,7 @@ ${blockerText}`;
 			writeGithubPrsReviews();
 		}
 	}, 500);
+	setTimeout(() => clearInterval(intervalWriteGithubPrs), POLL_INTERVAL_TIMEOUT);
 
 	if (!refreshButton_Placed) {
 		const intervalWriteButton = setInterval(() => {
@@ -1945,6 +1951,7 @@ ${blockerText}`;
 				document.getElementById('refreshButton').addEventListener('click', handleRefresh);
 			}
 		}, 1000);
+		setTimeout(() => clearInterval(intervalWriteButton), POLL_INTERVAL_TIMEOUT);
 	}
 
 	function handleRefresh() {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1905,7 +1905,7 @@ ${blockerText}`;
 	// check for github safe writing
 	const intervalWriteGithubIssues = setInterval(() => {
 		if (outputTarget === 'popup') {
-			return;
+			clearInterval(intervalWriteGithubIssues); clearInterval(intervalWriteGithubPrs); return;
 		}
 		const username = platform === 'gitlab' ? platformUsername : platformUsernameLocal;
 		if (scrumBody && username && githubIssuesData && githubPrsReviewData) {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1907,29 +1907,41 @@ ${blockerText}`;
 	setTimeout(() => clearInterval(intervalSubject), POLL_INTERVAL_TIMEOUT);
 
 	// check for github safe writing
-	const intervalWriteGithubIssues = setInterval(() => {
+	let intervalWriteGithubIssues;
+	let intervalWriteGithubPrs;
+	intervalWriteGithubIssues = setInterval(() => {
 		if (outputTarget === 'popup') {
 			clearInterval(intervalWriteGithubIssues);
-			clearInterval(intervalWriteGithubPrs);
+			if (intervalWriteGithubPrs) {
+				clearInterval(intervalWriteGithubPrs);
+			}
 			return;
 		}
 		const username = platform === 'gitlab' ? platformUsername : platformUsernameLocal;
 		if (scrumBody && username && githubIssuesData && githubPrsReviewData) {
 			clearInterval(intervalWriteGithubIssues);
-			clearInterval(intervalWriteGithubPrs);
+			if (intervalWriteGithubPrs) {
+				clearInterval(intervalWriteGithubPrs);
+			}
 			writeGithubIssuesPrs();
 		}
 	}, 500);
 	setTimeout(() => clearInterval(intervalWriteGithubIssues), POLL_INTERVAL_TIMEOUT);
-	const intervalWriteGithubPrs = setInterval(() => {
+	intervalWriteGithubPrs = setInterval(() => {
 		if (outputTarget === 'popup') {
+			clearInterval(intervalWriteGithubPrs);
+			if (intervalWriteGithubIssues) {
+				clearInterval(intervalWriteGithubIssues);
+			}
 			return;
 		}
 
 		const username = platform === 'gitlab' ? platformUsername : platformUsernameLocal;
 		if (scrumBody && username && githubPrsReviewData && githubIssuesData) {
 			clearInterval(intervalWriteGithubPrs);
-			clearInterval(intervalWriteGithubIssues);
+			if (intervalWriteGithubIssues) {
+				clearInterval(intervalWriteGithubIssues);
+			}
 			writeGithubPrsReviews();
 		}
 	}, 500);

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1873,6 +1873,7 @@ ${blockerText}`;
 
 	const POLL_INTERVAL_TIMEOUT = 30000;
 
+	let intervalBodyTimeoutId;
 	const intervalBody = setInterval(() => {
 		if (!window.emailClientAdapter) return;
 
@@ -1880,10 +1881,12 @@ ${blockerText}`;
 		if (!elements || !elements.body) return;
 
 		clearInterval(intervalBody);
+		clearTimeout(intervalBodyTimeoutId);
 		scrumBody = elements.body;
 	}, 500);
-	setTimeout(() => clearInterval(intervalBody), POLL_INTERVAL_TIMEOUT);
+	intervalBodyTimeoutId = setTimeout(() => clearInterval(intervalBody), POLL_INTERVAL_TIMEOUT);
 
+	let intervalSubjectTimeoutId;
 	const intervalSubject = setInterval(() => {
 		const userData = platform === 'gitlab' ? githubUserData || platformUsername : githubUserData;
 		if (!userData || !window.emailClientAdapter) return;
@@ -1894,44 +1897,57 @@ ${blockerText}`;
 		if (outputTarget === 'email' && !window.emailClientAdapter.isNewConversation()) {
 			console.log('Not a new conversation, skipping subject interval');
 			clearInterval(intervalSubject);
+			clearTimeout(intervalSubjectTimeoutId);
 			return;
 		}
 
 		clearInterval(intervalSubject);
+		clearTimeout(intervalSubjectTimeoutId);
 		scrumSubject = elements.subject;
 
 		setTimeout(() => {
 			scrumSubjectLoaded();
 		}, 500);
 	}, 500);
-	setTimeout(() => clearInterval(intervalSubject), POLL_INTERVAL_TIMEOUT);
+	intervalSubjectTimeoutId = setTimeout(() => clearInterval(intervalSubject), POLL_INTERVAL_TIMEOUT);
 
 	// check for github safe writing
 	let intervalWriteGithubIssues;
 	let intervalWriteGithubPrs;
+	let intervalWriteGithubIssuesTimeoutId;
+	let intervalWriteGithubPrsTimeoutId;
 	intervalWriteGithubIssues = setInterval(() => {
 		if (outputTarget === 'popup') {
 			clearInterval(intervalWriteGithubIssues);
+			clearTimeout(intervalWriteGithubIssuesTimeoutId);
 			if (intervalWriteGithubPrs) {
 				clearInterval(intervalWriteGithubPrs);
+				clearTimeout(intervalWriteGithubPrsTimeoutId);
 			}
 			return;
 		}
 		const username = platform === 'gitlab' ? platformUsername : platformUsernameLocal;
 		if (scrumBody && username && githubIssuesData && githubPrsReviewData) {
 			clearInterval(intervalWriteGithubIssues);
+			clearTimeout(intervalWriteGithubIssuesTimeoutId);
 			if (intervalWriteGithubPrs) {
 				clearInterval(intervalWriteGithubPrs);
+				clearTimeout(intervalWriteGithubPrsTimeoutId);
 			}
-			writeGithubIssuesPrs();
+			writeGithubIssuesPrs(githubIssuesData?.items || []);
 		}
 	}, 500);
-	setTimeout(() => clearInterval(intervalWriteGithubIssues), POLL_INTERVAL_TIMEOUT);
+	intervalWriteGithubIssuesTimeoutId = setTimeout(
+		() => clearInterval(intervalWriteGithubIssues),
+		POLL_INTERVAL_TIMEOUT,
+	);
 	intervalWriteGithubPrs = setInterval(() => {
 		if (outputTarget === 'popup') {
 			clearInterval(intervalWriteGithubPrs);
+			clearTimeout(intervalWriteGithubPrsTimeoutId);
 			if (intervalWriteGithubIssues) {
 				clearInterval(intervalWriteGithubIssues);
+				clearTimeout(intervalWriteGithubIssuesTimeoutId);
 			}
 			return;
 		}
@@ -1939,19 +1955,23 @@ ${blockerText}`;
 		const username = platform === 'gitlab' ? platformUsername : platformUsernameLocal;
 		if (scrumBody && username && githubPrsReviewData && githubIssuesData) {
 			clearInterval(intervalWriteGithubPrs);
+			clearTimeout(intervalWriteGithubPrsTimeoutId);
 			if (intervalWriteGithubIssues) {
 				clearInterval(intervalWriteGithubIssues);
+				clearTimeout(intervalWriteGithubIssuesTimeoutId);
 			}
 			writeGithubPrsReviews();
 		}
 	}, 500);
-	setTimeout(() => clearInterval(intervalWriteGithubPrs), POLL_INTERVAL_TIMEOUT);
+	intervalWriteGithubPrsTimeoutId = setTimeout(() => clearInterval(intervalWriteGithubPrs), POLL_INTERVAL_TIMEOUT);
 
 	if (!refreshButton_Placed) {
+		let intervalWriteButtonTimeoutId;
 		const intervalWriteButton = setInterval(() => {
 			if (document.getElementsByClassName('F0XO1GC-x-b').length === 3 && scrumBody) {
 				refreshButton_Placed = true;
 				clearInterval(intervalWriteButton);
+				clearTimeout(intervalWriteButtonTimeoutId);
 				const td = document.createElement('td');
 				const button = document.createElement('button');
 				button.style = 'background-image:none;background-color:#3F51B5;';
@@ -1965,7 +1985,7 @@ ${blockerText}`;
 				document.getElementById('refreshButton').addEventListener('click', handleRefresh);
 			}
 		}, 1000);
-		setTimeout(() => clearInterval(intervalWriteButton), POLL_INTERVAL_TIMEOUT);
+		intervalWriteButtonTimeoutId = setTimeout(() => clearInterval(intervalWriteButton), POLL_INTERVAL_TIMEOUT);
 	}
 
 	function handleRefresh() {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1871,7 +1871,7 @@ ${blockerText}`;
 		issuesDataProcessed = true;
 	}
 
-		const POLL_INTERVAL_TIMEOUT = 30000;
+	const POLL_INTERVAL_TIMEOUT = 30000;
 
 	const intervalBody = setInterval(() => {
 		if (!window.emailClientAdapter) return;
@@ -1909,7 +1909,9 @@ ${blockerText}`;
 	// check for github safe writing
 	const intervalWriteGithubIssues = setInterval(() => {
 		if (outputTarget === 'popup') {
-			clearInterval(intervalWriteGithubIssues); clearInterval(intervalWriteGithubPrs); return;
+			clearInterval(intervalWriteGithubIssues);
+			clearInterval(intervalWriteGithubPrs);
+			return;
 		}
 		const username = platform === 'gitlab' ? platformUsername : platformUsernameLocal;
 		if (scrumBody && username && githubIssuesData && githubPrsReviewData) {


### PR DESCRIPTION
### 📌 Fixes

Fixes #427 

---

### 📝 Summary of Changes

Added a timeout safeguard to the email polling intervals in scrumHelper.js so they stop after a reasonable period if the target email elements never appear.
This avoids indefinite polling and helps prevent CPU/memory leaks when the Gmail compose flow is interrupted or unavailable.

---

### 📸 Screenshots / Demo (if UI-related)
 
 N/A

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

The fix is intentionally minimal and scoped to the interval leak in the email flow.
Verified with local build and manual browser testing using DevTools Performance monitor.

## Summary by Sourcery

Bug Fixes:
- Stop email polling intervals from continuing to run after early exit from the popup flow, preventing a potential memory leak.

## Summary by Sourcery

Prevent long-running email and GitHub polling intervals from leaking when elements never load or when the popup flow exits early.

Bug Fixes:
- Add a global timeout to clear email and GitHub polling intervals if target elements never appear.
- Ensure GitHub issues/PR polling intervals are cleared immediately when the output target is the popup to avoid lingering timers.