### PR TITLE
Add informational message when repository filtering is disabled

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -458,6 +458,13 @@
 								<span data-i18n="tokenRequiredWarning">A GitHub token is required for repository
 									filtering. Please add one in the settings.</span>
 							</div>
+							<div id="filterDisabledMessage"
+							class="hidden text-xs text-blue-700 bg-blue-50 border border-blue-200 rounded-xl p-2 mt-2 flex items-center gap-2">
+
+							<i class="fa fa-info-circle"></i>
+							<span>Filtering is disabled. All repositories are included.</span>
+
+							</div>
 
 							<div id="repoFilterContainer" class="hidden">
 								<input id="repoSearch" type="text" data-i18n-placeholder="repoSearchPlaceholder"

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1159,6 +1159,15 @@ document.addEventListener('DOMContentLoaded', () => {
 				useRepoFilter.checked = items.useRepoFilter;
 				repoFilterContainer.classList.toggle('hidden', !items.useRepoFilter);
 			}
+			const disabledMsg = document.getElementById('filterDisabledMessage');
+
+			if (disabledMsg) {
+			if (!items.useRepoFilter) {
+				disabledMsg.classList.remove('hidden');
+			} else {
+				disabledMsg.classList.add('hidden');
+			}
+			}
 		});
 
 		useRepoFilter.addEventListener(
@@ -1178,6 +1187,13 @@ document.addEventListener('DOMContentLoaded', () => {
 				const enabled = useRepoFilter.checked;
 				const hasToken = githubTokenInput.value.trim() !== '';
 				repoFilterContainer.classList.toggle('hidden', !enabled);
+				const disabledMsg = document.getElementById('filterDisabledMessage');
+
+				if (!enabled) {
+				disabledMsg.classList.remove('hidden');
+				} else {
+				disabledMsg.classList.add('hidden');
+				}
 
 				if (enabled && !hasToken) {
 					useRepoFilter.checked = false;


### PR DESCRIPTION
### 📌 Fixes #543

Fixes #<issue-number>

---

### 📝 Summary of Changes

- Added an informational message when repository filtering is disabled
- Displayed the message below the filtering toggle section
- Ensured the message is shown on initial load when filtering is disabled
- Updated the message dynamically based on checkbox toggle state

---

### 📸 Screenshots 

Before:
- No indication when filtering was disabled

<img width="740" height="513" alt="image" src="https://github.com/user-attachments/assets/a93e0e5b-bd96-46d1-9ac5-c67ed1b50c81" />


After:
- Displays message: "Filtering is disabled. All repositories are included."

<img width="657" height="653" alt="image" src="https://github.com/user-attachments/assets/a26873b7-a921-48f0-b4c5-979d69d0404a" />


---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

This PR improves user experience by clearly indicating the behavior when repository filtering is disabled. It reduces confusion and provides better visual feedback to users.

## Summary by Sourcery

Add an informational UI message indicating that repository filtering is disabled and ensure it reflects the current toggle state.

New Features:
- Display a notice below the repository filtering controls when filtering is disabled, informing users that all repositories are included.

Enhancements:
- Keep the filtering-disabled message visibility in sync with the repository filter toggle on initial load and when the checkbox state changes.