### PR TITLE
fix: remove duplicate type attribute on script tag

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -613,7 +613,7 @@
 	<!-- WebExtensions Polyfill for Cross-Browser compatibility (Chrome, Firefox, Edge, etc.) -->
 	<script src="scripts/browser-polyfill.min.js"></script>
 	<script src="scripts/jquery-3.2.1.min.js"></script>
-	<script type="text/javascript" type="text/javascript" src="materialize/js/materialize.min.js"></script>
+	<script type="text/javascript" src="materialize/js/materialize.min.js"></script>
 	<script src="scripts/emailClientAdapter.js"></script>
 	<script src="scripts/main.js"></script>
 	<script src="scripts/gitlabHelper.js"></script>


### PR DESCRIPTION
### 📌 Fixes

Fixes #549

---

### 📝 Summary of Changes

- Removed the duplicate `type="text/javascript"` attribute from the `<script>` tag importing `materialize.min.js` in `src/popup.html`.
- This resolves a minor HTML validation issue caused by invalid attribute duplication.

---

### 📸 Screenshots / Demo (if UI-related)

_N/A - This is an internal HTML syntax fix and does not affect the UI._

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

_A straightforward HTML cleanup to ensure standard compliance. No functional changes to the extension._

## Summary by Sourcery

Bug Fixes:
- Resolve an HTML validation issue caused by a duplicated type attribute on the Materialize script tag in the popup.