### PR TITLE
chore: firefox specific guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,21 @@
 
    **For Firefox (Gecko):**
 
-   - after you have built the extension run the following:
+   - after you have built the extension, run the following:
+   - on Linux/Mac OS
      ```
      cd dist/firefox
      zip -r extension.zip *
      mv extension.zip extension.xpi
      ```
+   - Windows (PowerShell):
+     ```
+     cd dist/firefox
+     Compress-Archive -Path * -DestinationPath extension.zip -Force
+     Rename-Item extension.zip extension.xpi -Force
+     ```
    - Navigate to `about:config` in Firefox and set xpinstall.signatures.required = false.
-   - go to extensions & themes from right hand side hamburger menu
+   - go to extensions & themes from the right-hand side hamburger menu
    - Click on settings under manage your extensions
    - Click "Load Temporary Add-on...".
    - Select the `extension.xpi` file inside the `dist/firefox` folder.

--- a/README.md
+++ b/README.md
@@ -52,12 +52,19 @@
     -   Enable "Developer Mode" (toggle in the top-right).
     -   Click "Load unpacked" and select the `dist/chrome` folder inside the cloned repository.
 
-    **For Firefox (Gecko):**
-    -   Navigate to `about:debugging` in Firefox.
-    -   Click on "This Firefox" in the left sidebar.
-    -   Click "Load Temporary Add-on...".
-    -   Select the `manifest.json` file inside the `dist/firefox` folder.
-    -   *Note: The extension will remain active only for the current browser session. If you need persistence, consider using Firefox Developer Edition.*
+   **For Firefox (Gecko):**
+
+   - after you have built the extension run the following:
+     ```
+     cd dist/firefox
+     zip -r extension.zip *
+     mv extension.zip extension.xpi
+     ```
+   - Navigate to `about:config` in Firefox and set xpinstall.signatures.required = false.
+   - go to extensions & themes from right hand side hamburger menu
+   - Click on settings under manage your extenisions
+   - Click "Load Temporary Add-on...".
+   - Select the `extension.xpi` file inside the `dist/firefox` folder.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
      ```
    - Navigate to `about:config` in Firefox and set xpinstall.signatures.required = false.
    - go to extensions & themes from right hand side hamburger menu
-   - Click on settings under manage your extenisions
+   - Click on settings under manage your extensions
    - Click "Load Temporary Add-on...".
    - Select the `extension.xpi` file inside the `dist/firefox` folder.
 

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -36,6 +36,12 @@ browser.storage.onChanged.addListener((changes, area) => {
 
 browser.action.onClicked.addListener((tab) => {
 	try {
+		// Firefox uses sidebarAction API; sidePanel is Chrome-only
+		if (typeof browser.sidebarAction?.toggle === 'function') {
+			browser.sidebarAction.toggle();
+			return;
+		}
+
 		if (!browser.sidePanel?.open) {
 			console.warn('Side panel API not available.');
 			return;


### PR DESCRIPTION
Enhances Firefox guide with a guide to a preserved session, and a fix for split-based browsers like zen should be enough to provide a workable base

## Summary by Sourcery

Improve Firefox extension installation guidance and add Firefox sidebar fallback handling when the Chrome side panel API is unavailable.

Enhancements:
- Add fallback logic to toggle the Firefox sidebar when the Chrome-specific side panel API is not available.

Documentation:
- Update Firefox installation instructions to cover creating a signed-like XPI and configuring persistent loading via about:config and the extensions UI.