### PR TITLE
Enhancement : improve UX for scrum report editing 

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -316,7 +316,7 @@
 					<div>
 						<div>
 							<h6 class="text-base font-semibold mt-2" data-i18n="scrumReportLabel">Scrum Report</h6>
-							<div id="scrumReport" contenteditable="true"
+							<div id="scrumReport" contenteditable="false"
 								class="min-h-[200px] overflow-y-auto whitespace-pre-wrap border-2 border-gray-200 bg-gray-100 rounded-xl text-gray-800 p-2 my-2">
 							</div>
 						</div>

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -420,7 +420,11 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 
 	function isStructuredScrumReportHtml(html) {
-		return typeof html === 'string' && html.includes('data-scrum-report="true"');
+		if (typeof html !== 'string' || !html.trim()) return false;
+
+		const wrapper = document.createElement('div');
+		wrapper.innerHTML = html;
+		return !!wrapper.querySelector('[data-scrum-report="true"]');
 	}
 
 	function syncScrumReportEditMode(scrumReport) {
@@ -486,7 +490,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		return clone.innerHTML || '';
 	}
 
-	// Change clean html from structure scrumReport before sending email
+	// Build clean HTML from structured scrum report content before sending email.
 	function buildExportableScrumHtml(scrumReport) {
 		if (!scrumReport) return '';
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -434,6 +434,35 @@ document.addEventListener('DOMContentLoaded', () => {
 		scrumReport.setAttribute('contenteditable', hasStructuredSections ? 'false' : 'true');
 	}
 
+	// Change clean html from structure scrumReport before sending email
+	function buildExportableScrumHtml(scrumReport) {
+		if (!scrumReport) return '';
+
+		const reportRoot = scrumReport.querySelector('[data-scrum-report="true"]');
+		if (!reportRoot) {
+			return scrumReport.innerHTML || '';
+		}
+
+		const sections = Array.from(reportRoot.querySelectorAll('[data-scrum-section]'));
+		if (!sections.length) {
+			return scrumReport.innerHTML || '';
+		}
+
+		const parts = [];
+		sections.forEach((section) => {
+			const headingEl = section.querySelector('[data-scrum-heading]');
+			const bodyEl = section.querySelector('[data-scrum-body]');
+			if (!headingEl || !bodyEl) return;
+
+			const headingText = headingEl.textContent ? headingEl.textContent.trim() : '';
+			if (!headingText) return;
+
+			parts.push(`<b>${headingText}</b><br>${bodyEl.innerHTML || ''}`);
+		});
+
+		return parts.join('<br>');
+	}
+
 	function showPopupMessage(message) {
 		if (!message) return;
 
@@ -701,7 +730,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		if (insertBtn) {
 			insertBtn.addEventListener('click', () => {
 				const scrumReport = document.getElementById('scrumReport');
-				const content = scrumReport ? scrumReport.innerHTML : '';
+				const content = buildExportableScrumHtml(scrumReport);
 				const subject = buildScrumSubjectFromPopup();
 
 				if (!content) {
@@ -767,7 +796,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		copyBtn.addEventListener('click', function () {
 			const scrumReport = document.getElementById('scrumReport');
 			const tempDiv = document.createElement('div');
-			tempDiv.innerHTML = scrumReport.innerHTML;
+			tempDiv.innerHTML = buildExportableScrumHtml(scrumReport);
 			document.body.appendChild(tempDiv);
 			tempDiv.style.position = 'absolute';
 			tempDiv.style.left = '-9999px';

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -344,12 +344,8 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 
 	githubTokenInput.addEventListener('input', checkTokenForFilter);
-	githubTokenInput.addEventListener('input', () =>
-		checkTokenForShowCommits({ persistState: false }),
-	);
-	githubTokenInput.addEventListener('input', () =>
-		checkTokenForMergedPRs({ persistState: false }),
-	);
+	githubTokenInput.addEventListener('input', () => checkTokenForShowCommits({ persistState: false }));
+	githubTokenInput.addEventListener('input', () => checkTokenForMergedPRs({ persistState: false }));
 
 	darkModeToggle.addEventListener('click', function () {
 		body.classList.toggle('dark-mode');
@@ -434,7 +430,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		scrumReport.setAttribute('contenteditable', hasStructuredSections ? 'false' : 'true');
 	}
 
-		function escapeHtmlForExport(value) {
+	function escapeHtmlForExport(value) {
 		return String(value || '')
 			.replace(/&/g, '&amp;')
 			.replace(/</g, '&lt;')
@@ -455,13 +451,17 @@ document.addEventListener('DOMContentLoaded', () => {
 		}
 
 		if (root.querySelectorAll) {
-			root.querySelectorAll('[contenteditable],[data-scrum-report],[data-scrum-section],[data-scrum-heading],[data-scrum-body]').forEach((el) => {
-				el.removeAttribute('contenteditable');
-				el.removeAttribute('data-scrum-report');
-				el.removeAttribute('data-scrum-section');
-				el.removeAttribute('data-scrum-heading');
-				el.removeAttribute('data-scrum-body');
-			});
+			root
+				.querySelectorAll(
+					'[contenteditable],[data-scrum-report],[data-scrum-section],[data-scrum-heading],[data-scrum-body]',
+				)
+				.forEach((el) => {
+					el.removeAttribute('contenteditable');
+					el.removeAttribute('data-scrum-report');
+					el.removeAttribute('data-scrum-section');
+					el.removeAttribute('data-scrum-heading');
+					el.removeAttribute('data-scrum-body');
+				});
 		}
 	}
 
@@ -478,10 +478,10 @@ document.addEventListener('DOMContentLoaded', () => {
 		if (!bodyEl) return '';
 
 		const clone = bodyEl.cloneNode(true);
-		stripEditAttributes(clone);
 
-		// Prevent duplicated heading blocks from leaking into section body exports.
-		clone.querySelectorAll('b[data-scrum-heading], [data-scrum-heading]').forEach((el) => el.remove());
+		// Remove any nested copied headings before stripping the edit metadata they rely on.
+		clone.querySelectorAll('[data-scrum-heading]').forEach((el) => el.remove());
+		stripEditAttributes(clone);
 
 		return clone.innerHTML || '';
 	}
@@ -509,7 +509,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			const headingText = headingEl.textContent ? headingEl.textContent.trim() : '';
 			if (!headingText) return;
 			const safeHeading = escapeHtmlForExport(headingText);
-			const safeBodyHtml=normalizeSectionBodyHtml(bodyEl);
+			const safeBodyHtml = normalizeSectionBodyHtml(bodyEl);
 
 			parts.push(`<b>${safeHeading}</b><br>${safeBodyHtml}`);
 		});
@@ -597,34 +597,37 @@ document.addEventListener('DOMContentLoaded', () => {
 				'lastScrumReportUsername',
 				'githubUsername',
 				'gitlabUsername',
-				'platformUsername'
+				'platformUsername',
 			]);
 
 			let lastScrumReportHtml = storageValues[`${activePlatform}LastScrumReportHtml`];
 			let lastScrumReportCacheKey = storageValues[`${activePlatform}LastScrumReportCacheKey`];
 			let lastScrumReportUsername = storageValues[`${activePlatform}LastScrumReportUsername`];
 
-			if (storageValues.lastScrumReportHtml && (!storageValues.lastScrumReportPlatform || storageValues.lastScrumReportPlatform === activePlatform) && !lastScrumReportHtml) {
+			if (
+				storageValues.lastScrumReportHtml &&
+				(!storageValues.lastScrumReportPlatform || storageValues.lastScrumReportPlatform === activePlatform) &&
+				!lastScrumReportHtml
+			) {
 				lastScrumReportHtml = storageValues.lastScrumReportHtml;
 				lastScrumReportCacheKey = storageValues.lastScrumReportCacheKey;
 				lastScrumReportUsername = storageValues.lastScrumReportUsername;
 			}
 
-			const expectedUsername = activePlatform === 'gitlab'
-				? (storageValues.gitlabUsername || storageValues.platformUsername)
-				: (storageValues.githubUsername || storageValues.platformUsername);
+			const expectedUsername =
+				activePlatform === 'gitlab'
+					? storageValues.gitlabUsername || storageValues.platformUsername
+					: storageValues.githubUsername || storageValues.platformUsername;
 
-			const isUsernameMatch = lastScrumReportUsername 
+			const isUsernameMatch = lastScrumReportUsername
 				? lastScrumReportUsername === expectedUsername
-				: (lastScrumReportCacheKey && expectedUsername && lastScrumReportCacheKey.startsWith(expectedUsername + '-'));
+				: lastScrumReportCacheKey && expectedUsername && lastScrumReportCacheKey.startsWith(expectedUsername + '-');
 
 			if (age < ttlMs) {
 				const cacheKey = cache?.cacheKey ?? null;
 				const reportEmpty = !scrumReport.innerHTML || !scrumReport.innerHTML.trim();
 
-				const matches =
-					(!lastScrumReportCacheKey || lastScrumReportCacheKey === cacheKey) &&
-					isUsernameMatch;
+				const matches = (!lastScrumReportCacheKey || lastScrumReportCacheKey === cacheKey) && isUsernameMatch;
 
 				if (reportEmpty && lastScrumReportHtml && matches) {
 					if (!isStructuredScrumReportHtml(lastScrumReportHtml)) {
@@ -762,8 +765,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				platformUsername.value = result[platformUsernameKey] || '';
 				checkTokenForShowCommits();
 				checkTokenForMergedPRs();
-			},
-		);
+			});
 
 		// Button setup
 		const generateBtn = document.getElementById('generateReport');
@@ -1098,7 +1100,9 @@ document.addEventListener('DOMContentLoaded', () => {
 				// Show notice instead of applying immediately
 				const modeLabel = mode === 'popup' ? 'Popup' : 'Side Panel';
 				if (displayModeNotice && displayModeNoticeText) {
-					displayModeNoticeText.textContent = chrome?.i18n.getMessage('displayModeNotice', [modeLabel]) || `The extension will open in ${modeLabel} mode on the next launch.`;
+					displayModeNoticeText.textContent =
+						chrome?.i18n.getMessage('displayModeNotice', [modeLabel]) ||
+						`The extension will open in ${modeLabel} mode on the next launch.`;
 					displayModeNotice.classList.remove('hidden');
 				}
 			});
@@ -1198,7 +1202,9 @@ document.addEventListener('DOMContentLoaded', () => {
 			} catch {}
 			if (platform !== 'github') {
 				// Do not run repo fetch for non-GitHub platforms
-				if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('repoFilteringGithubOnly') || 'Repository filtering is only available for GitHub.';
+				if (repoStatus)
+					repoStatus.textContent =
+						chrome?.i18n.getMessage('repoFilteringGithubOnly') || 'Repository filtering is only available for GitHub.';
 				return;
 			}
 			if (!useRepoFilter.checked) {
@@ -1287,7 +1293,10 @@ document.addEventListener('DOMContentLoaded', () => {
 				if (platform !== 'github') {
 					repoFilterContainer.classList.add('hidden');
 					useRepoFilter.checked = false;
-					if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('repoFilteringGithubOnly') || 'Repository filtering is only available for GitHub.';
+					if (repoStatus)
+						repoStatus.textContent =
+							chrome?.i18n.getMessage('repoFilteringGithubOnly') ||
+							'Repository filtering is only available for GitHub.';
 					return;
 				}
 				const enabled = useRepoFilter.checked;
@@ -1317,7 +1326,8 @@ document.addEventListener('DOMContentLoaded', () => {
 				});
 				checkTokenForFilter();
 				if (enabled) {
-					repoStatus.textContent = chrome?.i18n.getMessage('loadingReposAutomatically') || 'Loading repos automatically...';
+					repoStatus.textContent =
+						chrome?.i18n.getMessage('loadingReposAutomatically') || 'Loading repos automatically...';
 
 					try {
 						const cacheData = await browser.storage.local.get(['repoCache']);
@@ -1466,7 +1476,9 @@ document.addEventListener('DOMContentLoaded', () => {
 				platform = items.platform || 'github';
 			} catch {}
 			if (platform !== 'github') {
-				if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('repoLoadingGithubOnly') || 'Repository loading is only available for GitHub.';
+				if (repoStatus)
+					repoStatus.textContent =
+						chrome?.i18n.getMessage('repoLoadingGithubOnly') || 'Repository loading is only available for GitHub.';
 				return;
 			}
 			console.log('window.fetchUserRepositories exists:', !!window.fetchUserRepositories);
@@ -1506,7 +1518,9 @@ document.addEventListener('DOMContentLoaded', () => {
 				platform = items.platform || 'github';
 			} catch (e) {}
 			if (platform !== 'github') {
-				if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('repoFetchingGithubOnly') || 'Repository fetching is only available for GitHub.';
+				if (repoStatus)
+					repoStatus.textContent =
+						chrome?.i18n.getMessage('repoFetchingGithubOnly') || 'Repository fetching is only available for GitHub.';
 				return;
 			}
 			console.log('[POPUP-DEBUG] performRepoFetch called.');
@@ -1809,11 +1823,11 @@ platformSelect.addEventListener('change', () => {
 	const platform = platformSelect.value;
 	browser.storage.local.set({ platform }).then(() => {
 		const scrumReport = document.getElementById('scrumReport');
-		if(scrumReport){
+		if (scrumReport) {
 			scrumReport.innerHTML = '';
 		}
 		const generateBtn = document.getElementById('generateReport');
-		if(typeof bootstrapScrumReportOnPopupLoad === 'function'){
+		if (typeof bootstrapScrumReportOnPopupLoad === 'function') {
 			bootstrapScrumReportOnPopupLoad(generateBtn);
 		}
 	});
@@ -1869,10 +1883,10 @@ function setPlatformDropdown(value) {
 	platformSelectHidden.value = value;
 	browser.storage.local.set({ platform: value }).then(() => {
 		const scrumReport = document.getElementById('scrumReport');
-		if(scrumReport) scrumReport.innerHTML = '';
+		if (scrumReport) scrumReport.innerHTML = '';
 
 		const generateBtn = document.getElementById('generateReport');
-		if(typeof bootstrapScrumReportOnPopupLoad === 'function'){
+		if (typeof bootstrapScrumReportOnPopupLoad === 'function') {
 			bootstrapScrumReportOnPopupLoad(generateBtn);
 		}
 	});

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -434,18 +434,70 @@ document.addEventListener('DOMContentLoaded', () => {
 		scrumReport.setAttribute('contenteditable', hasStructuredSections ? 'false' : 'true');
 	}
 
+		function escapeHtmlForExport(value) {
+		return String(value || '')
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#39;');
+	}
+
+	function stripEditAttributes(root) {
+		if (!root) return;
+
+		if (root.removeAttribute) {
+			root.removeAttribute('contenteditable');
+			root.removeAttribute('data-scrum-report');
+			root.removeAttribute('data-scrum-section');
+			root.removeAttribute('data-scrum-heading');
+			root.removeAttribute('data-scrum-body');
+		}
+
+		if (root.querySelectorAll) {
+			root.querySelectorAll('[contenteditable],[data-scrum-report],[data-scrum-section],[data-scrum-heading],[data-scrum-body]').forEach((el) => {
+				el.removeAttribute('contenteditable');
+				el.removeAttribute('data-scrum-report');
+				el.removeAttribute('data-scrum-section');
+				el.removeAttribute('data-scrum-heading');
+				el.removeAttribute('data-scrum-body');
+			});
+		}
+	}
+
+	function normalizeLegacyReportHtml(html) {
+		if (!html || typeof html !== 'string') return '';
+
+		const wrapper = document.createElement('div');
+		wrapper.innerHTML = html;
+		stripEditAttributes(wrapper);
+		return wrapper.innerHTML;
+	}
+
+	function normalizeSectionBodyHtml(bodyEl) {
+		if (!bodyEl) return '';
+
+		const clone = bodyEl.cloneNode(true);
+		stripEditAttributes(clone);
+
+		// Prevent duplicated heading blocks from leaking into section body exports.
+		clone.querySelectorAll('b[data-scrum-heading], [data-scrum-heading]').forEach((el) => el.remove());
+
+		return clone.innerHTML || '';
+	}
+
 	// Change clean html from structure scrumReport before sending email
 	function buildExportableScrumHtml(scrumReport) {
 		if (!scrumReport) return '';
 
 		const reportRoot = scrumReport.querySelector('[data-scrum-report="true"]');
 		if (!reportRoot) {
-			return scrumReport.innerHTML || '';
+			return normalizeLegacyReportHtml(scrumReport.innerHTML || '');
 		}
 
 		const sections = Array.from(reportRoot.querySelectorAll('[data-scrum-section]'));
 		if (!sections.length) {
-			return scrumReport.innerHTML || '';
+			return normalizeLegacyReportHtml(scrumReport.innerHTML || '');
 		}
 
 		const parts = [];
@@ -456,8 +508,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			const headingText = headingEl.textContent ? headingEl.textContent.trim() : '';
 			if (!headingText) return;
+			const safeHeading = escapeHtmlForExport(headingText);
+			const safeBodyHtml=normalizeSectionBodyHtml(bodyEl);
 
-			parts.push(`<b>${headingText}</b><br>${bodyEl.innerHTML || ''}`);
+			parts.push(`<b>${safeHeading}</b><br>${safeBodyHtml}`);
 		});
 
 		return parts.join('<br>');

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -423,6 +423,17 @@ document.addEventListener('DOMContentLoaded', () => {
 		generateBtn.disabled = true;
 	}
 
+	function isStructuredScrumReportHtml(html) {
+		return typeof html === 'string' && html.includes('data-scrum-report="true"');
+	}
+
+	function syncScrumReportEditMode(scrumReport) {
+		if (!scrumReport) return;
+
+		const hasStructuredSections = !!scrumReport.querySelector('[data-scrum-report="true"]');
+		scrumReport.setAttribute('contenteditable', hasStructuredSections ? 'false' : 'true');
+	}
+
 	function showPopupMessage(message) {
 		if (!message) return;
 
@@ -465,6 +476,8 @@ document.addEventListener('DOMContentLoaded', () => {
 		if (!scrumReport) {
 			return;
 		}
+
+		syncScrumReportEditMode(scrumReport);
 
 		const { platform, cacheInput, githubCache, gitlabCache } = await storageLocalGet([
 			'platform',
@@ -531,7 +544,14 @@ document.addEventListener('DOMContentLoaded', () => {
 					isUsernameMatch;
 
 				if (reportEmpty && lastScrumReportHtml && matches) {
+					if (!isStructuredScrumReportHtml(lastScrumReportHtml)) {
+						setGenerateButtonLoading(generateBtn, true);
+						window.generateScrumReport();
+						return;
+					}
+
 					scrumReport.innerHTML = lastScrumReportHtml;
+					syncScrumReportEditMode(scrumReport);
 					if (generateBtn) generateBtn.disabled = false;
 					return;
 				}
@@ -544,6 +564,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			// If cache is expired, still only show the old HTML if it was for the current username
 			if ((!scrumReport.innerHTML || !scrumReport.innerHTML.trim()) && lastScrumReportHtml && isUsernameMatch) {
 				scrumReport.innerHTML = lastScrumReportHtml;
+				syncScrumReportEditMode(scrumReport);
 			}
 
 			if (generateBtn) generateBtn.disabled = false;
@@ -665,6 +686,17 @@ document.addEventListener('DOMContentLoaded', () => {
 		const generateBtn = document.getElementById('generateReport');
 		const copyBtn = document.getElementById('copyReport');
 		const insertBtn = document.getElementById('insertInEmail');
+		const scrumReport = document.getElementById('scrumReport');
+
+		if (scrumReport) {
+			syncScrumReportEditMode(scrumReport);
+
+			const reportObserver = new MutationObserver(() => {
+				syncScrumReportEditMode(scrumReport);
+			});
+
+			reportObserver.observe(scrumReport, { childList: true, subtree: true });
+		}
 
 		if (insertBtn) {
 			insertBtn.addEventListener('click', () => {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1160,42 +1160,66 @@ function allIncluded(outputTarget = 'email') {
 		return wrapCompactText(userReason);
 	}
 
+	// Heading Texts
+	function buildScrumSectionHeadings() {
+		const weekOrDay = yesterdayContribution ? 'yesterday' : 'the period';
+		const weekOrDay2 = 'today';
+
+		if (yesterdayContribution) {
+			return {
+				heading1: `1. What did I do ${weekOrDay}?`,
+				heading2: `2. What do I plan to do ${weekOrDay2}?`,
+				heading3: '3. What is blocking me from making progress?',
+			};
+		}
+
+		return {
+			heading1: `1. What did I do from ${formatDate(startingDate)} to ${formatDate(endingDate)}?`,
+			heading2: `2. What do I plan to do ${weekOrDay2}?`,
+			heading3: '3. What is blocking me from making progress?',
+		};
+	}
+
 	function writeScrumBody() {
 		const lastWeekUl = buildActivityListHtml();
 		const nextWeekUl = buildNextWeekListHtml();
 		const blockerText = buildBlockerTextHtml();
+		const { heading1, heading2, heading3 } = buildScrumSectionHeadings();
 
-		const weekOrDay = yesterdayContribution ? 'yesterday' : 'the period';
-		const weekOrDay2 = 'today';
+		// sturcture sections with locked headings and editable bodies
+		const popupContent = `<div data-scrum-report="true">
+<div data-scrum-section="1">
+<div data-scrum-heading="1" contenteditable="false"><b>${heading1}</b></div>
+<div data-scrum-body="1" contenteditable="true">${lastWeekUl}</div>
+</div>
+<div data-scrum-section="2">
+<div data-scrum-heading="2" contenteditable="false"><b>${heading2}</b></div>
+<div data-scrum-body="2" contenteditable="true">${nextWeekUl}</div>
+</div>
+<div data-scrum-section="3">
+<div data-scrum-heading="3" contenteditable="false"><b>${heading3}</b></div>
+<div data-scrum-body="3" contenteditable="true">${blockerText}</div>
+</div>
+</div>`;
 
-		let content;
-		if (yesterdayContribution) {
-			content = `<b>1. What did I do ${weekOrDay}?</b><br>
+		const emailContent = `<b>${heading1}</b><br>
 ${lastWeekUl}<br>
-<b>2. What do I plan to do ${weekOrDay2}?</b><br>
+<b>${heading2}</b><br>
 ${nextWeekUl}<br>
-<b>3. What is blocking me from making progress?</b><br>
+<b>${heading3}</b><br>
 ${blockerText}`;
-		} else {
-			content = `<b>1. What did I do from ${formatDate(startingDate)} to ${formatDate(endingDate)}?</b><br>
-${lastWeekUl}<br>
-<b>2. What do I plan to do ${weekOrDay2}?</b><br>
-${nextWeekUl}<br>
-<b>3. What is blocking me from making progress?</b><br>
-${blockerText}`;
-		}
 
 		if (outputTarget === 'popup') {
 			const scrumReport = document.getElementById('scrumReport');
 			if (scrumReport) {
 				log('Found popup div, updating content');
-				scrumReport.innerHTML = content;
+				scrumReport.innerHTML = popupContent;
 				try {
 					const cacheKey =
 						platform === 'gitlab' ? (gitlabHelper?.cache?.cacheKey ?? null) : (githubCache?.cacheKey ?? null);
 
 					browser.storage.local.set({
-						[`${platform}LastScrumReportHtml`]: content,
+						[`${platform}LastScrumReportHtml`]: popupContent,
 						[`${platform}LastScrumReportCacheKey`]: cacheKey,
 						[`${platform}LastScrumReportUsername`]: platformUsername,
 					});
@@ -1228,7 +1252,7 @@ ${blockerText}`;
 					if (elements && elements.body) {
 						obs.disconnect();
 						log('MutationObserver found the editor body. Injecting scrum content.');
-						window.emailClientAdapter.injectContent(elements.body, content, elements.eventTypes.contentChange);
+						window.emailClientAdapter.injectContent(elements.body, emailContent, elements.eventTypes.contentChange);
 						hasInjectedContent = true;
 						scrumGenerationInProgress = false;
 					}

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1162,12 +1162,11 @@ function allIncluded(outputTarget = 'email') {
 
 	// Heading Texts
 	function buildScrumSectionHeadings() {
-		const weekOrDay = yesterdayContribution ? 'yesterday' : 'the period';
 		const weekOrDay2 = 'today';
 
 		if (yesterdayContribution) {
 			return {
-				heading1: `1. What did I do ${weekOrDay}?`,
+				heading1: '1. What did I do yesterday?',
 				heading2: `2. What do I plan to do ${weekOrDay2}?`,
 				heading3: '3. What is blocking me from making progress?',
 			};
@@ -1186,7 +1185,7 @@ function allIncluded(outputTarget = 'email') {
 		const blockerText = buildBlockerTextHtml();
 		const { heading1, heading2, heading3 } = buildScrumSectionHeadings();
 
-		// sturcture sections with locked headings and editable bodies
+		// Structure sections with locked headings and editable bodies
 		const popupContent = `<div data-scrum-report="true">
 <div data-scrum-section="1">
 <div data-scrum-heading="1" contenteditable="false"><b>${heading1}</b></div>


### PR DESCRIPTION
### 📌 Fixes

Fixes #557 

---

### 📝 Summary of Changes

- Restructured generated scrum reports into separate sections with locked headings and editable bodies
- Updated the popup report container to work correctly with structured scrum report content
- Added structured export handling so `Copy` and `Insert in Email` generate clean HTML instead of popup-specific markup
- Preserved compatibility with legacy scrum report HTML through a fallback export path
- Sanitized exported section content by stripping edit-related attributes and normalizing heading/body content
- Fixed the heading-removal order during export so duplicated nested heading blocks are removed correctly before copy/email output is built


---

### 📸 Screenshots / Demo (if UI-related)

<h4>Editable report body with fixed headings </h4>

https://github.com/user-attachments/assets/744f6025-44d7-49b4-92ad-6da799cc8ddd

<h4>Testing the update report to check sanitizing when report insert into email </h4>

https://github.com/user-attachments/assets/ded234dc-6edc-43b3-887d-1fc151e93ae0


---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes


This PR is intended as a focused UX enhancement for scrum report editing rather than a broad refactor.

## Summary by Sourcery

Improve the scrum report editing UX by structuring generated reports into locked-heading sections while ensuring clean HTML export for email and copy actions.

New Features:
- Structure generated scrum reports into distinct sections with fixed headings and editable bodies in the popup.

Bug Fixes:
- Ensure copied and emailed scrum reports export clean, sanitized HTML instead of popup-specific markup and attributes.
- Preserve compatibility with previously stored legacy scrum report HTML while still supporting the new structured format.
- Avoid stale unstructured reports by regenerating when cached content is not in the new structured format.

Enhancements:
- Toggle scrum report editability automatically based on whether structured sections are present, keeping headings non-editable.
- Normalize section body content on export by stripping edit-related attributes and removing duplicated nested headings.
- Reuse username and cache-based logic for restoring last scrum reports while integrating the new structured report handling.