### PR TITLE
fix: advence filter lable color

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -209,7 +209,7 @@
 					</div>
 
 					<details class="group mb-4" style="margin-top: 1rem;">
-						<summary class="flex items-center justify-between cursor-pointer list-none font-medium text-sm text-gray-800 outline-none select-none pr-1">
+						<summary class="flex items-center justify-between cursor-pointer list-none font-medium text-sm text-inherit outline-none select-none pr-1">
 							<span data-i18n="advancedFiltersLabel">Advanced Filters</span>
 							<i class="fa fa-chevron-down text-gray-500 w-4 text-center transition-transform duration-200 group-open:-rotate-180"></i>
 						</summary>

--- a/src/popup.html
+++ b/src/popup.html
@@ -209,7 +209,7 @@
 					</div>
 
 					<details class="group mb-4" style="margin-top: 1rem;">
-						<summary class="flex items-center justify-between cursor-pointer list-none font-medium text-sm text-inherit outline-none select-none pr-1">
+						<summary class="flex items-center justify-between cursor-pointer list-none font-medium text-sm outline-none select-none pr-1">
 							<span data-i18n="advancedFiltersLabel">Advanced Filters</span>
 							<i class="fa fa-chevron-down text-gray-500 w-4 text-center transition-transform duration-200 group-open:-rotate-180"></i>
 						</summary>


### PR DESCRIPTION
### 📌 Fixes

Fixes #559 

---

### 📝 Summary of Changes

just add the tailwind class for dark mode
---

### 📸 Screenshots / Demo (if UI-related)
Before
<img width="505" height="803" alt="image" src="https://github.com/user-attachments/assets/7529cb19-aa56-4315-bfa9-981d36a5fca4" />
After
<img width="505" height="803" alt="image" src="https://github.com/user-attachments/assets/de13a73b-0505-489e-ad23-6d0dd9c24df4" />

---

### ✅ Checklist

 [x] I’ve tested my changes locally
[x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

## Summary by Sourcery

Bug Fixes:
- Fix advanced filters label using a fixed gray color that did not adapt correctly in dark mode.