### PR TITLE
Fix: tooltip not disappearing after clicking Copy button

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -666,6 +666,15 @@ document.addEventListener('DOMContentLoaded', () => {
 		const copyBtn = document.getElementById('copyReport');
 		const insertBtn = document.getElementById('insertInEmail');
 
+		function dismissShortcutTooltipFocus(el) {
+			// Shortcut tooltips are shown via CSS on `:focus-within`. After clicking a button,
+			// focus can remain on it, keeping the tooltip visible until the popup loses focus.
+			// Blurring fixes the "stuck tooltip" while keeping hover/focus behavior intact.
+			try {
+				el?.blur?.();
+			} catch {}
+		}
+
 		if (insertBtn) {
 			insertBtn.addEventListener('click', () => {
 				const scrumReport = document.getElementById('scrumReport');
@@ -700,11 +709,13 @@ document.addEventListener('DOMContentLoaded', () => {
 							})
 							.finally(() => {
 								insertBtn._triggeredByShortcut = false;
+								dismissShortcutTooltipFocus(insertBtn);
 							});
 					})
 					.catch((error) => {
 						console.warn('Unable to get active tab:', error?.message || error);
 						insertBtn._triggeredByShortcut = false;
+						dismissShortcutTooltipFocus(insertBtn);
 					});
 			});
 		}
@@ -727,6 +738,7 @@ document.addEventListener('DOMContentLoaded', () => {
 							generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
 							generateBtn.disabled = true;
 							window.generateScrumReport && window.generateScrumReport();
+							dismissShortcutTooltipFocus(generateBtn);
 						});
 					});
 			});
@@ -763,6 +775,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				console.error('Failed to copy: ', err);
 			} finally {
 				this._triggeredByShortcut = false;
+				dismissShortcutTooltipFocus(this);
 				selection.removeAllRanges();
 				document.body.removeChild(tempDiv);
 			}


### PR DESCRIPTION
### 📌 Fixes

Fixes #568 

---

### 📝 Summary of Changes

-Fixed issue where the tooltip (Ctrl + Shift + Y) remained visible after clicking the copy button
-Added proper handling to hide the tooltip when cursour moves away

---

### 📸 Screenshots / Demo (if UI-related)

https://github.com/user-attachments/assets/f71e67c3-db82-4a37-8dca-f7dd0a3c3a83



---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

## Summary by Sourcery

Ensure keyboard shortcut tooltips are dismissed after using action buttons and add contributor guidelines for AI-assisted changes.

Bug Fixes:
- Fix tooltip remaining visible after clicking copy or other shortcut-enabled buttons in the popup.

Documentation:
- Add AGENTS.md with guidelines for AI-assisted contributions to the project.