### PR TITLE
fix: add validation for invalid date range (start date after end date)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -919,6 +919,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1426,6 +1427,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -432,5 +432,9 @@
   "insertedInEmailNotification": {
     "message": "Report inserted into email!",
     "description": "Notification shown when report is successfully inserted into email."
+  },
+  "invalidDateRangeError": {
+    "message": "Please enter a valid date range. Start date cannot be after end date.",
+    "description": "Error shown when the selected start date is after the end date."
   }
 }

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -212,22 +212,26 @@ function allIncluded(outputTarget = 'email') {
 				}
 
 				// Validate date range: start date must not be after end date
-				if (startingDate && endingDate && new Date(startingDate) > new Date(endingDate)) {
-					const scrumReport = document.getElementById('scrumReport');
-					const generateBtn = document.getElementById('generateReport');
-					if (scrumReport) {
-						renderErrorMessage(
-							scrumReport,
-							'invalidDateRangeError',
-							'Please enter a valid date range. Start date cannot be after end date.',
-						);
+				if (startingDate && endingDate) {
+					const parsedStart = new Date(startingDate);
+					const parsedEnd = new Date(endingDate);
+					if (isNaN(parsedStart) || isNaN(parsedEnd) || parsedStart > parsedEnd) {
+						const scrumReport = document.getElementById('scrumReport');
+						const generateBtn = document.getElementById('generateReport');
+						if (scrumReport) {
+							renderErrorMessage(
+								scrumReport,
+								'invalidDateRangeError',
+								'Please enter a valid date range. Start date cannot be after end date.',
+							);
+						}
+						if (generateBtn) {
+							generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
+							generateBtn.disabled = false;
+						}
+						scrumGenerationInProgress = false;
+						return;
 					}
-					if (generateBtn) {
-						generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
-						generateBtn.disabled = false;
-					}
-					scrumGenerationInProgress = false;
-					return;
 				}
 
 				if (platform === 'github') {
@@ -2301,8 +2305,12 @@ async function fetchUserRepositories(username, token, org = '') {
 				}));
 
 			return repos.sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
-		} catch (err) { }
-	} catch (err) { }
+		} catch (err) {
+			logError('GraphQL request for repositories failed:', err);
+		}
+	} catch (err) {
+		logError('Failed to fetch user repositories:', err);
+	}
 }
 
 function filterDataByRepos(data, selectedRepos) {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -211,6 +211,25 @@ function allIncluded(outputTarget = 'email') {
 					}
 				}
 
+				// Validate date range: start date must not be after end date
+				if (startingDate && endingDate && new Date(startingDate) > new Date(endingDate)) {
+					const scrumReport = document.getElementById('scrumReport');
+					const generateBtn = document.getElementById('generateReport');
+					if (scrumReport) {
+						renderErrorMessage(
+							scrumReport,
+							'invalidDateRangeError',
+							'Please enter a valid date range. Start date cannot be after end date.',
+						);
+					}
+					if (generateBtn) {
+						generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
+						generateBtn.disabled = false;
+					}
+					scrumGenerationInProgress = false;
+					return;
+				}
+
 				if (platform === 'github') {
 					if (platformUsernameLocal) {
 						fetchGithubData();
@@ -2100,12 +2119,12 @@ async function fetchPrsMergedStatusBatch(prs, headers) {
 
 	const query = `query {
 ${prs
-	.map(
-		(pr, i) => `	repo${i}: repository(owner: "${pr.owner}", name: "${pr.repo}") {
+			.map(
+				(pr, i) => `	repo${i}: repository(owner: "${pr.owner}", name: "${pr.repo}") {
 		pr${i}: pullRequest(number: ${pr.number}) { merged }
 	}`,
-	)
-	.join('\n')}
+			)
+			.join('\n')}
 }`;
 
 	try {
@@ -2282,8 +2301,8 @@ async function fetchUserRepositories(username, token, org = '') {
 				}));
 
 			return repos.sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
-		} catch (err) {}
-	} catch (err) {}
+		} catch (err) { }
+	} catch (err) { }
 }
 
 function filterDataByRepos(data, selectedRepos) {


### PR DESCRIPTION
### 📌 Fixes

Fixes #<572> (Fixes)

---

### 📝 Summary of Changes

Added date validation before generating scrum report
Shows proper error message "Invalid date range. Please select a valid date range." when start date is after end date
Prevents misleading "No activity to report" message for invalid date ranges
---

### 📸 Screenshots / Demo (if UI-related)
<img width="1420" height="2400" alt="Screenshot (249)" src="https://github.com/user-attachments/assets/e80d649f-8245-4105-a52d-6a06c19dd88f" />
after
<img width="1601" height="2400" alt="Screenshot (250)" src="https://github.com/user-attachments/assets/7eb755f5-28b2-45a5-b92d-dbf992e9d83c" />

### ✅ Checklist

 I've tested my changes locally
 I've added tests (if applicable)
 I've updated documentation (if applicable)
 My code follows the project's code style guidelines

---

## Summary by Sourcery

Validate scrum report date range and show a clear error when the start date is after the end date.

Bug Fixes:
- Prevent generating scrum reports when the selected start date is after the end date, avoiding misleading empty-report messages.

Enhancements:
- Display a user-facing error message on the scrum report view when an invalid date range is selected and restore the generate button state accordingly.