### PR TITLE
fix: enforce advanced filter selection rules and tooltip text

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -262,7 +262,7 @@
 									</label>
 									<span class="tooltip-container">
 										<i class="fa fa-question-circle question-icon"></i>
-										<span class="tooltip-bubble" data-i18n="onlyPRsTooltip">
+										<span class="tooltip-bubble" data-i18n="onlyRevPRsTooltip">
 											If checked, the report will only include PRs reviewed by you.
 										</span>
 									</span>

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -156,6 +156,66 @@ document.addEventListener('DOMContentLoaded', () => {
 	const platformUsername = document.getElementById('platformUsername');
 	let showCommitsWarningTimeout;
 	let mergedPRsWarningTimeout;
+	const advancedFilterCheckboxes = {
+		onlyIssues: document.getElementById('onlyIssues'),
+		onlyPRs: document.getElementById('onlyPRs'),
+		onlyRevPRs: document.getElementById('onlyRevPRs'),
+		onlyMergedPRs: document.getElementById('onlyMergedPRs'),
+		showCommits: document.getElementById('showCommits'),
+	};
+	const advancedFilterConflicts = {
+		onlyIssues: ['onlyPRs', 'onlyRevPRs', 'onlyMergedPRs', 'showCommits'],
+		onlyPRs: ['onlyIssues', 'onlyRevPRs', 'onlyMergedPRs'],
+		onlyRevPRs: ['onlyIssues', 'onlyPRs', 'onlyMergedPRs', 'showCommits'],
+		onlyMergedPRs: ['onlyIssues', 'onlyPRs', 'onlyRevPRs', 'showCommits'],
+		showCommits: ['onlyIssues', 'onlyRevPRs', 'onlyMergedPRs'],
+	};
+
+	function normalizeAdvancedFilters({ selectedKey = null, persist = false } = {}) {
+		const changes = {};
+		const setCheckboxValue = (key, checked) => {
+			const checkbox = advancedFilterCheckboxes[key];
+			if (!checkbox || checkbox.checked === checked) {
+				return;
+			}
+			checkbox.checked = checked;
+			changes[key] = checked;
+		};
+
+		if (selectedKey && advancedFilterCheckboxes[selectedKey]?.checked) {
+			changes[selectedKey] = true;
+			for (const conflictKey of advancedFilterConflicts[selectedKey] || []) {
+				setCheckboxValue(conflictKey, false);
+			}
+		} else {
+			const priorityOrder = ['onlyIssues', 'onlyPRs', 'onlyRevPRs', 'onlyMergedPRs'];
+			let activePrimary = null;
+			for (const key of priorityOrder) {
+				const checkbox = advancedFilterCheckboxes[key];
+				if (!checkbox?.checked) {
+					continue;
+				}
+				if (!activePrimary) {
+					activePrimary = key;
+					continue;
+				}
+				setCheckboxValue(key, false);
+			}
+
+			if (advancedFilterCheckboxes.showCommits?.checked && activePrimary) {
+				const showCommitsConflicts = advancedFilterConflicts.showCommits || [];
+				if (showCommitsConflicts.includes(activePrimary)) {
+					setCheckboxValue('showCommits', false);
+				}
+			}
+		}
+
+		if (persist && Object.keys(changes).length) {
+			browser.storage.local.set(changes);
+		}
+
+		return changes;
+	}
 
 	function checkTokenForFilter() {
 		const useRepoFilter = document.getElementById('useRepoFilter');
@@ -344,12 +404,8 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 
 	githubTokenInput.addEventListener('input', checkTokenForFilter);
-	githubTokenInput.addEventListener('input', () =>
-		checkTokenForShowCommits({ persistState: false }),
-	);
-	githubTokenInput.addEventListener('input', () =>
-		checkTokenForMergedPRs({ persistState: false }),
-	);
+	githubTokenInput.addEventListener('input', () => checkTokenForShowCommits({ persistState: false }));
+	githubTokenInput.addEventListener('input', () => checkTokenForMergedPRs({ persistState: false }));
 
 	darkModeToggle.addEventListener('click', function () {
 		body.classList.toggle('dark-mode');
@@ -501,34 +557,37 @@ document.addEventListener('DOMContentLoaded', () => {
 				'lastScrumReportUsername',
 				'githubUsername',
 				'gitlabUsername',
-				'platformUsername'
+				'platformUsername',
 			]);
 
 			let lastScrumReportHtml = storageValues[`${activePlatform}LastScrumReportHtml`];
 			let lastScrumReportCacheKey = storageValues[`${activePlatform}LastScrumReportCacheKey`];
 			let lastScrumReportUsername = storageValues[`${activePlatform}LastScrumReportUsername`];
 
-			if (storageValues.lastScrumReportHtml && (!storageValues.lastScrumReportPlatform || storageValues.lastScrumReportPlatform === activePlatform) && !lastScrumReportHtml) {
+			if (
+				storageValues.lastScrumReportHtml &&
+				(!storageValues.lastScrumReportPlatform || storageValues.lastScrumReportPlatform === activePlatform) &&
+				!lastScrumReportHtml
+			) {
 				lastScrumReportHtml = storageValues.lastScrumReportHtml;
 				lastScrumReportCacheKey = storageValues.lastScrumReportCacheKey;
 				lastScrumReportUsername = storageValues.lastScrumReportUsername;
 			}
 
-			const expectedUsername = activePlatform === 'gitlab'
-				? (storageValues.gitlabUsername || storageValues.platformUsername)
-				: (storageValues.githubUsername || storageValues.platformUsername);
+			const expectedUsername =
+				activePlatform === 'gitlab'
+					? storageValues.gitlabUsername || storageValues.platformUsername
+					: storageValues.githubUsername || storageValues.platformUsername;
 
-			const isUsernameMatch = lastScrumReportUsername 
+			const isUsernameMatch = lastScrumReportUsername
 				? lastScrumReportUsername === expectedUsername
-				: (lastScrumReportCacheKey && expectedUsername && lastScrumReportCacheKey.startsWith(expectedUsername + '-'));
+				: lastScrumReportCacheKey && expectedUsername && lastScrumReportCacheKey.startsWith(expectedUsername + '-');
 
 			if (age < ttlMs) {
 				const cacheKey = cache?.cacheKey ?? null;
 				const reportEmpty = !scrumReport.innerHTML || !scrumReport.innerHTML.trim();
 
-				const matches =
-					(!lastScrumReportCacheKey || lastScrumReportCacheKey === cacheKey) &&
-					isUsernameMatch;
+				const matches = (!lastScrumReportCacheKey || lastScrumReportCacheKey === cacheKey) && isUsernameMatch;
 
 				if (reportEmpty && lastScrumReportHtml && matches) {
 					scrumReport.innerHTML = lastScrumReportHtml;
@@ -625,27 +684,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				if (typeof result.onlyMergedPRs !== 'undefined') {
 					onlyMergedPRsCheckbox.checked = result.onlyMergedPRs;
 				}
-
-				// Reconcile mutually exclusive "Only Issues" and "Only PRs" flags on initialization.
-				// If both are somehow true in storage (e.g., from an older version or manual edits),
-				// prefer "Only Issues" and clear "Only PRs", then persist the corrected state.
-				if (onlyIssuesCheckbox.checked && onlyPRsCheckbox.checked) {
-					onlyPRsCheckbox.checked = false;
-					browser?.storage.local.set({ onlyPRs: false });
-				}
-				if (onlyMergedPRsCheckbox.checked && onlyRevPRsCheckbox.checked) {
-					onlyRevPRsCheckbox.checked = false;
-					browser?.storage.local.set({ onlyRevPRs: false });
-				}
-				// onlyMergedPRs overrides onlyIssues and onlyPRs
-				if (onlyMergedPRsCheckbox.checked && onlyIssuesCheckbox.checked) {
-					onlyIssuesCheckbox.checked = false;
-					browser?.storage.local.set({ onlyIssues: false });
-				}
-				if (onlyMergedPRsCheckbox.checked && onlyPRsCheckbox.checked) {
-					onlyPRsCheckbox.checked = false;
-					browser?.storage.local.set({ onlyPRs: false });
-				}
+				normalizeAdvancedFilters({ persist: true });
 				if (result.githubToken) githubTokenInput.value = result.githubToken;
 				if (result.cacheInput) cacheInput.value = result.cacheInput;
 				if (typeof result.yesterdayContribution !== 'undefined') yesterdayRadio.checked = result.yesterdayContribution;
@@ -658,8 +697,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				platformUsername.value = result[platformUsernameKey] || '';
 				checkTokenForShowCommits();
 				checkTokenForMergedPRs();
-			},
-		);
+			});
 
 		// Button setup
 		const generateBtn = document.getElementById('generateReport');
@@ -866,62 +904,36 @@ document.addEventListener('DOMContentLoaded', () => {
 		if (onlyIssuesCheckbox && onlyPRsCheckbox) {
 			onlyIssuesCheckbox.addEventListener('change', () => {
 				const checked = onlyIssuesCheckbox.checked;
-				browser?.storage.local.set({ onlyIssues: checked }, () => {
-					if (checked) {
-						if (onlyPRsCheckbox.checked) {
-							onlyPRsCheckbox.checked = false;
-							browser?.storage.local.set({ onlyPRs: false });
-						}
-						if (onlyMergedPRsCheckbox && onlyMergedPRsCheckbox.checked) {
-							onlyMergedPRsCheckbox.checked = false;
-							browser?.storage.local.set({ onlyMergedPRs: false });
-						}
-					}
-				});
+				if (checked) {
+					normalizeAdvancedFilters({ selectedKey: 'onlyIssues', persist: true });
+					return;
+				}
+				browser?.storage.local.set({ onlyIssues: false });
 			});
 
 			onlyPRsCheckbox.addEventListener('change', () => {
 				const checked = onlyPRsCheckbox.checked;
-				browser?.storage.local.set({ onlyPRs: checked }, () => {
-					if (checked) {
-						if (onlyIssuesCheckbox.checked) {
-							onlyIssuesCheckbox.checked = false;
-							browser?.storage.local.set({ onlyIssues: false });
-						}
-						if (onlyMergedPRsCheckbox && onlyMergedPRsCheckbox.checked) {
-							onlyMergedPRsCheckbox.checked = false;
-							browser?.storage.local.set({ onlyMergedPRs: false });
-						}
-					}
-				});
+				if (checked) {
+					normalizeAdvancedFilters({ selectedKey: 'onlyPRs', persist: true });
+					return;
+				}
+				browser?.storage.local.set({ onlyPRs: false });
 			});
 
 			if (onlyRevPRsCheckbox) {
 				onlyRevPRsCheckbox.addEventListener('change', () => {
 					const checked = onlyRevPRsCheckbox.checked;
-					browser?.storage.local.set({ onlyRevPRs: checked }, () => {
-						if (checked && onlyMergedPRsCheckbox && onlyMergedPRsCheckbox.checked) {
-							onlyMergedPRsCheckbox.checked = false;
-							browser?.storage.local.set({ onlyMergedPRs: false });
-						}
-					});
+					if (checked) {
+						normalizeAdvancedFilters({ selectedKey: 'onlyRevPRs', persist: true });
+						return;
+					}
+					browser?.storage.local.set({ onlyRevPRs: false });
 				});
 			}
 			if (onlyMergedPRsCheckbox) {
 				onlyMergedPRsCheckbox.addEventListener('change', () => {
 					if (onlyMergedPRsCheckbox.checked) {
-						if (onlyRevPRsCheckbox && onlyRevPRsCheckbox.checked) {
-							onlyRevPRsCheckbox.checked = false;
-							browser?.storage.local.set({ onlyRevPRs: false });
-						}
-						if (onlyIssuesCheckbox && onlyIssuesCheckbox.checked) {
-							onlyIssuesCheckbox.checked = false;
-							browser?.storage.local.set({ onlyIssues: false });
-						}
-						if (onlyPRsCheckbox && onlyPRsCheckbox.checked) {
-							onlyPRsCheckbox.checked = false;
-							browser?.storage.local.set({ onlyPRs: false });
-						}
+						normalizeAdvancedFilters({ selectedKey: 'onlyMergedPRs', persist: true });
 					}
 					checkTokenForMergedPRs({
 						showWarning: true,
@@ -933,6 +945,9 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		}
 		showCommitsCheckbox.addEventListener('change', () => {
+			if (showCommitsCheckbox.checked) {
+				normalizeAdvancedFilters({ selectedKey: 'showCommits', persist: true });
+			}
 			checkTokenForShowCommits({
 				showWarning: true,
 				animateWarning: true,
@@ -983,7 +998,9 @@ document.addEventListener('DOMContentLoaded', () => {
 				// Show notice instead of applying immediately
 				const modeLabel = mode === 'popup' ? 'Popup' : 'Side Panel';
 				if (displayModeNotice && displayModeNoticeText) {
-					displayModeNoticeText.textContent = chrome?.i18n.getMessage('displayModeNotice', [modeLabel]) || `The extension will open in ${modeLabel} mode on the next launch.`;
+					displayModeNoticeText.textContent =
+						chrome?.i18n.getMessage('displayModeNotice', [modeLabel]) ||
+						`The extension will open in ${modeLabel} mode on the next launch.`;
 					displayModeNotice.classList.remove('hidden');
 				}
 			});
@@ -1083,7 +1100,9 @@ document.addEventListener('DOMContentLoaded', () => {
 			} catch {}
 			if (platform !== 'github') {
 				// Do not run repo fetch for non-GitHub platforms
-				if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('repoFilteringGithubOnly') || 'Repository filtering is only available for GitHub.';
+				if (repoStatus)
+					repoStatus.textContent =
+						chrome?.i18n.getMessage('repoFilteringGithubOnly') || 'Repository filtering is only available for GitHub.';
 				return;
 			}
 			if (!useRepoFilter.checked) {
@@ -1172,7 +1191,10 @@ document.addEventListener('DOMContentLoaded', () => {
 				if (platform !== 'github') {
 					repoFilterContainer.classList.add('hidden');
 					useRepoFilter.checked = false;
-					if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('repoFilteringGithubOnly') || 'Repository filtering is only available for GitHub.';
+					if (repoStatus)
+						repoStatus.textContent =
+							chrome?.i18n.getMessage('repoFilteringGithubOnly') ||
+							'Repository filtering is only available for GitHub.';
 					return;
 				}
 				const enabled = useRepoFilter.checked;
@@ -1202,7 +1224,8 @@ document.addEventListener('DOMContentLoaded', () => {
 				});
 				checkTokenForFilter();
 				if (enabled) {
-					repoStatus.textContent = chrome?.i18n.getMessage('loadingReposAutomatically') || 'Loading repos automatically...';
+					repoStatus.textContent =
+						chrome?.i18n.getMessage('loadingReposAutomatically') || 'Loading repos automatically...';
 
 					try {
 						const cacheData = await browser.storage.local.get(['repoCache']);
@@ -1351,7 +1374,9 @@ document.addEventListener('DOMContentLoaded', () => {
 				platform = items.platform || 'github';
 			} catch {}
 			if (platform !== 'github') {
-				if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('repoLoadingGithubOnly') || 'Repository loading is only available for GitHub.';
+				if (repoStatus)
+					repoStatus.textContent =
+						chrome?.i18n.getMessage('repoLoadingGithubOnly') || 'Repository loading is only available for GitHub.';
 				return;
 			}
 			console.log('window.fetchUserRepositories exists:', !!window.fetchUserRepositories);
@@ -1391,7 +1416,9 @@ document.addEventListener('DOMContentLoaded', () => {
 				platform = items.platform || 'github';
 			} catch (e) {}
 			if (platform !== 'github') {
-				if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('repoFetchingGithubOnly') || 'Repository fetching is only available for GitHub.';
+				if (repoStatus)
+					repoStatus.textContent =
+						chrome?.i18n.getMessage('repoFetchingGithubOnly') || 'Repository fetching is only available for GitHub.';
 				return;
 			}
 			console.log('[POPUP-DEBUG] performRepoFetch called.');
@@ -1694,11 +1721,11 @@ platformSelect.addEventListener('change', () => {
 	const platform = platformSelect.value;
 	browser.storage.local.set({ platform }).then(() => {
 		const scrumReport = document.getElementById('scrumReport');
-		if(scrumReport){
+		if (scrumReport) {
 			scrumReport.innerHTML = '';
 		}
 		const generateBtn = document.getElementById('generateReport');
-		if(typeof bootstrapScrumReportOnPopupLoad === 'function'){
+		if (typeof bootstrapScrumReportOnPopupLoad === 'function') {
 			bootstrapScrumReportOnPopupLoad(generateBtn);
 		}
 	});
@@ -1754,10 +1781,10 @@ function setPlatformDropdown(value) {
 	platformSelectHidden.value = value;
 	browser.storage.local.set({ platform: value }).then(() => {
 		const scrumReport = document.getElementById('scrumReport');
-		if(scrumReport) scrumReport.innerHTML = '';
+		if (scrumReport) scrumReport.innerHTML = '';
 
 		const generateBtn = document.getElementById('generateReport');
-		if(typeof bootstrapScrumReportOnPopupLoad === 'function'){
+		if (typeof bootstrapScrumReportOnPopupLoad === 'function') {
 			bootstrapScrumReportOnPopupLoad(generateBtn);
 		}
 	});

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -78,6 +78,42 @@ function allIncluded(outputTarget = 'email') {
 	let onlyRevPRs = false;
 	let onlyMergedPRs = false;
 
+	function normalizeAdvancedFilterState(filters) {
+		const normalized = {
+			onlyIssues: filters.onlyIssues === true,
+			onlyPRs: filters.onlyPRs === true,
+			onlyRevPRs: filters.onlyRevPRs === true,
+			onlyMergedPRs: filters.onlyMergedPRs === true,
+			showCommits: filters.showCommits === true,
+		};
+		const corrections = {};
+		const priorityOrder = ['onlyIssues', 'onlyPRs', 'onlyRevPRs', 'onlyMergedPRs'];
+		let activePrimary = null;
+
+		for (const key of priorityOrder) {
+			if (!normalized[key]) {
+				continue;
+			}
+			if (!activePrimary) {
+				activePrimary = key;
+				continue;
+			}
+			normalized[key] = false;
+			corrections[key] = false;
+		}
+
+		if (
+			normalized.showCommits &&
+			activePrimary &&
+			['onlyIssues', 'onlyRevPRs', 'onlyMergedPRs'].includes(activePrimary)
+		) {
+			normalized.showCommits = false;
+			corrections.showCommits = false;
+		}
+
+		return { normalized, corrections };
+	}
+
 	const pr_open_button =
 		'<div style="vertical-align:middle;display: inline-block;padding: 0px 4px;font-size:9px;font-weight: 600;color: #fff;text-align: center;background-color: #2cbe4e;border-radius: 3px;line-height: 12px;margin-bottom: 2px;"  class="State State--green">open</div>';
 	const pr_closed_button =
@@ -161,40 +197,15 @@ function allIncluded(outputTarget = 'email') {
 				githubToken = items.githubToken;
 				gitlabToken = items.gitlabToken || '';
 				yesterdayContribution = items.yesterdayContribution;
-
-				onlyIssues = items.onlyIssues === true;
-				onlyPRs = items.onlyPRs === true;
-				onlyRevPRs = items.onlyRevPRs === true;
-				onlyMergedPRs = items.onlyMergedPRs === true;
-				// Enforce mutual exclusivity between onlyIssues and onlyPRs to avoid filtering out everything
-				if (onlyIssues && onlyPRs) {
-					console.warn('[SCRUM-HELPER]: Detected both onlyIssues and onlyPRs enabled; normalizing to onlyIssues.');
-					onlyPRs = false;
-					chrome.storage.local.set({ onlyPRs: false });
+				const { normalized, corrections } = normalizeAdvancedFilterState(items);
+				onlyIssues = normalized.onlyIssues;
+				onlyPRs = normalized.onlyPRs;
+				onlyRevPRs = normalized.onlyRevPRs;
+				onlyMergedPRs = normalized.onlyMergedPRs;
+				showCommits = normalized.showCommits;
+				if (Object.keys(corrections).length > 0) {
+					chrome.storage.local.set(corrections);
 				}
-				// Enforce mutual exclusivity: onlyMergedPRs overrides onlyRevPRs, onlyIssues, and onlyPRs
-				if (onlyMergedPRs) {
-					const corrections = {};
-					if (onlyRevPRs) {
-						console.warn('[SCRUM-HELPER]: onlyMergedPRs and onlyRevPRs both enabled; disabling onlyRevPRs.');
-						onlyRevPRs = false;
-						corrections.onlyRevPRs = false;
-					}
-					if (onlyIssues) {
-						console.warn('[SCRUM-HELPER]: onlyMergedPRs and onlyIssues both enabled; disabling onlyIssues.');
-						onlyIssues = false;
-						corrections.onlyIssues = false;
-					}
-					if (onlyPRs) {
-						console.warn('[SCRUM-HELPER]: onlyMergedPRs and onlyPRs both enabled; disabling onlyPRs.');
-						onlyPRs = false;
-						corrections.onlyPRs = false;
-					}
-					if (Object.keys(corrections).length > 0) {
-						chrome.storage.local.set(corrections);
-					}
-				}
-				showCommits = items.showCommits || false;
 				showOpenLabel = items.showOpenLabel !== false; // Default to true if not explicitly set to false
 				orgName = items.orgName || '';
 

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -204,7 +204,7 @@ function allIncluded(outputTarget = 'email') {
 				onlyMergedPRs = normalized.onlyMergedPRs;
 				showCommits = normalized.showCommits;
 				if (Object.keys(corrections).length > 0) {
-					chrome.storage.local.set(corrections);
+					browser.storage.local.set(corrections);
 				}
 				showOpenLabel = items.showOpenLabel !== false; // Default to true if not explicitly set to false
 				orgName = items.orgName || '';


### PR DESCRIPTION
### 📌 Fixes

Fixes #578 

---

### 📝 Summary of Changes

- Added centralized advanced filter conflict normalization in the popup
- Enforced the agreed selection rules so the newly selected conflicting option wins
- Kept `Show PRs Labels` compatible with all filters
- Restricted `Show commits on open PRs / draft PRs` to valid combinations only
- Added matching normalization in report-generation state loading for older persisted invalid states
- Fixed the reviewed-PR tooltip to use the correct i18n key
---

### 📸 Screenshots / Demo (if UI-related)

<img width="401" height="233" alt="Screenshot 2026-04-20 125029" src="https://github.com/user-attachments/assets/1c2a3fe9-21d6-4ed5-8443-38d830b5a90d" />

https://github.com/user-attachments/assets/cbe53b5a-8ed1-472f-a460-8bc18e71e02d



---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

There are a few formatting-only line-wrap changes in `popup.js` alongside the functional changes.
