### PR TITLE
fix: remove duplicate toast error message from popup UI

### DIFF
--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -733,9 +733,6 @@ function allIncluded(outputTarget = 'email') {
 					chrome?.i18n.getMessage('invalidSearchQueryError') ||
 					`Invalid search query or date range. Please verify your date range format and try again.`;
 				logError(errorMsg);
-				if (outputTarget === 'popup') {
-					Materialize.toast && Materialize.toast(errorMsg, 4000);
-				}
 				throw new Error(errorMsg);
 			}
 


### PR DESCRIPTION
## Fixes
Fixes #584 

## Summary of Changes
- Removed `Materialize.toast()` calls from error handling logic
- Prevented duplicate error messages from appearing in the UI
- Ensured errors are displayed only within the Scrum Report section

## Screenshots / Demo

### Before
- Error shown in Scrum Report
- Additional floating toast near scrollbar

<img width="775" height="1544" alt="image" src="https://github.com/user-attachments/assets/b502ee96-fa97-45e8-8a87-d38be8e09c5b" />


### After
- Error shown only in Scrum Report
- No floating toast message

<img width="774" height="1522" alt="image" src="https://github.com/user-attachments/assets/0d806cbb-647b-48a7-9ae3-d783f5671d5c" />


## Checklist
- [x] Code follows project guidelines
- [x] Tested locally
- [x] No console errors
- [x] UI behavior improved

## Reviewer Notes
- This is a UI cleanup fix
- No changes to core logic or API calls
- Improves user experience by removing redundant notifications

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate error messages by relying solely on the Scrum Report section instead of additional popup toast notifications.