### PR TITLE
Improve copy button UX by disabling it when no report is present

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -919,6 +919,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1426,6 +1427,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",

--- a/src/popup.html
+++ b/src/popup.html
@@ -437,8 +437,8 @@
 									class="mt-3 min-h-[32px] p-2 border-2 border-gray-200 bg-gray-50 rounded-xl">
 									<div class="flex flex-wrap gap-1" id="repoTags">
 										<span class="text-xs text-gray-500 select-none" id="repoPlaceholder"
-											data-i18n="repoPlaceholder">No
-											repositories selected (all will be included)</span>
+											data-i18n="repoPlaceholder">No repositories selected (all will be included).</span>
+										
 									</div>
 								</div>
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -437,8 +437,8 @@
 									class="mt-3 min-h-[32px] p-2 border-2 border-gray-200 bg-gray-50 rounded-xl">
 									<div class="flex flex-wrap gap-1" id="repoTags">
 										<span class="text-xs text-gray-500 select-none" id="repoPlaceholder"
-											data-i18n="repoPlaceholder">No repositories selected (all will be included).</span>
-										
+											data-i18n="repoPlaceholder">No
+											repositories selected (all will be included)</span>
 									</div>
 								</div>
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -673,6 +673,37 @@ document.addEventListener('DOMContentLoaded', () => {
 		const copyBtn = document.getElementById('copyReport');
 		const insertBtn = document.getElementById('insertInEmail');
 
+		function setCopyButtonEnabled(enabled) {
+			if (!copyBtn) {
+				return;
+			}
+
+			copyBtn.disabled = !enabled;
+
+			if (enabled) {
+				copyBtn.style.backgroundColor = '';
+				copyBtn.style.cursor = '';
+				copyBtn.style.opacity = '';
+				copyBtn.classList.add('bg-blue-600');
+				copyBtn.classList.add('hover:bg-blue-700');
+				return;
+			}
+
+			copyBtn.style.backgroundColor = '#2564ebc5';
+			copyBtn.style.cursor = 'not-allowed';
+			copyBtn.style.opacity = '0.8';
+			copyBtn.classList.remove('hover:bg-blue-700');
+		}
+
+		const scrumReportEl = document.getElementById('scrumReport');
+		if (scrumReportEl && copyBtn && typeof MutationObserver !== 'undefined') {
+			const updateCopyState = () => setCopyButtonEnabled(!!scrumReportEl.textContent.trim());
+			updateCopyState();
+
+			const observer = new MutationObserver(updateCopyState);
+			observer.observe(scrumReportEl, { childList: true, subtree: true, characterData: true });
+		}
+
 		if (insertBtn) {
 			insertBtn.addEventListener('click', () => {
 				const scrumReport = document.getElementById('scrumReport');
@@ -741,11 +772,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		copyBtn.addEventListener('click', function () {
 			const scrumReport = document.getElementById('scrumReport');
-			if (!scrumReport || !scrumReport.textContent.trim()) {
+			const reportContent = scrumReport?.innerHTML;
+			if (!scrumReport || !scrumReport.textContent.trim() || !reportContent || !reportContent.trim()) {
+				this._triggeredByShortcut = false;
 				return;
 			}
 			const tempDiv = document.createElement('div');
-			tempDiv.innerHTML = scrumReport.innerHTML;
+			tempDiv.innerHTML = reportContent;
 			document.body.appendChild(tempDiv);
 			tempDiv.style.position = 'absolute';
 			tempDiv.style.left = '-9999px';

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -549,6 +549,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		copyBtn.addEventListener('click', function () {
 			const scrumReport = document.getElementById('scrumReport');
+			if (!scrumReport || !scrumReport.innerText.trim()) {
+				return;
+			  }
 			const tempDiv = document.createElement('div');
 			tempDiv.innerHTML = scrumReport.innerHTML;
 			document.body.appendChild(tempDiv);

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -770,27 +770,28 @@ document.addEventListener('DOMContentLoaded', () => {
 			});
 		});
 
-		copyBtn.addEventListener('click', function () {
+		copyBtn.addEventListener('click', async function () {
 			const scrumReport = document.getElementById('scrumReport');
-			const reportContent = scrumReport?.innerHTML;
-			if (!scrumReport || !scrumReport.textContent.trim() || !reportContent || !reportContent.trim()) {
+			const reportText = scrumReport?.textContent?.trim();
+			if (!reportText) {
 				this._triggeredByShortcut = false;
 				return;
 			}
-			const tempDiv = document.createElement('div');
-			tempDiv.innerHTML = reportContent;
-			document.body.appendChild(tempDiv);
-			tempDiv.style.position = 'absolute';
-			tempDiv.style.left = '-9999px';
-
-			const range = document.createRange();
-			range.selectNode(tempDiv);
-			const selection = window.getSelection();
-			selection.removeAllRanges();
-			selection.addRange(range);
 
 			try {
-				document.execCommand('copy');
+				if (navigator?.clipboard?.writeText) {
+					await navigator.clipboard.writeText(reportText);
+				} else {
+					const textarea = document.createElement('textarea');
+					textarea.value = reportText;
+					textarea.style.position = 'absolute';
+					textarea.style.left = '-9999px';
+					document.body.appendChild(textarea);
+					textarea.select();
+					document.execCommand('copy');
+					document.body.removeChild(textarea);
+				}
+
 				if (this._triggeredByShortcut) {
 					const notificationKey =
 						browser?.i18n && browser.i18n.getMessage('copiedReportNotification')
@@ -798,16 +799,20 @@ document.addEventListener('DOMContentLoaded', () => {
 							: 'copiedButton';
 					showShortcutNotification(notificationKey);
 				}
-				this.innerHTML = `<i class="fa fa-check"></i> ${browser?.i18n.getMessage('copiedButton')}`;
+
+				const icon = this.querySelector('i');
+				const label = this.querySelector('span');
+				if (icon) icon.className = 'fa fa-check';
+				if (label) label.textContent = browser?.i18n.getMessage('copiedButton') || 'Copied!';
+
 				setTimeout(() => {
-					this.innerHTML = `<i class="fa fa-copy"></i> ${browser.i18n.getMessage('copyReportButton')}`;
+					if (icon) icon.className = 'fa fa-copy';
+					if (label) label.textContent = browser?.i18n.getMessage('copyReportButton') || 'Copy';
 				}, 2000);
 			} catch (err) {
 				console.error('Failed to copy: ', err);
 			} finally {
 				this._triggeredByShortcut = false;
-				selection.removeAllRanges();
-				document.body.removeChild(tempDiv);
 			}
 		});
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -549,7 +549,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		copyBtn.addEventListener('click', function () {
 			const scrumReport = document.getElementById('scrumReport');
-			if (!scrumReport || !scrumReport.innerText.trim()) {
+						if (!scrumReport || !scrumReport.textContent.trim()) {
 				return;
 			  }
 			const tempDiv = document.createElement('div');

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -734,9 +734,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		copyBtn.addEventListener('click', function () {
 			const scrumReport = document.getElementById('scrumReport');
-						if (!scrumReport || !scrumReport.textContent.trim()) {
+			if (!scrumReport || !scrumReport.textContent.trim()) {
 				return;
-			  }
+			}
 			const tempDiv = document.createElement('div');
 			tempDiv.innerHTML = scrumReport.innerHTML;
 			document.body.appendChild(tempDiv);


### PR DESCRIPTION
This PR enhances the fix proposed in #498 by adding visual feedback for the copy button.

While #498 prevents copying empty content, the button still appears active, which can confuse users.

This change:
- Disables the copy button when no report is present
- Adds visual feedback by greying out the button
- Re-enables the button once a report is generated

This improves UX by making the button state intuitive.