### PR TITLE
fix: load onlyMergedPRs flag from storage in getChromeData

### DIFF
--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -1,335 +1,319 @@
 {
-  "appName": {
-    "message": "Scrum Helper"
-  },
-  "appDescription": {
-    "message": "एक चयनित अवधि के लिए अपनी Git गतिविधि को स्वतः प्राप्त करके अपनी विकास प्रगति की रिपोर्ट करें।"
-  },
-  "disableLabel": {
-    "message": "अक्षम करें"
-  },
-  "enableLabel": {
-    "message": "सक्षम करें"
-  },
-  "projectNameLabel": {
-    "message": "ईमेल विषय"
-  },
-  "projectNamePlaceholder": {
-    "message": "अपनी परियोजना का नाम दर्ज करें"
-  },
-  "githubUsernameLabel": {
-    "message": "आपका GitHub उपयोगकर्ता नाम"
-  },
-  "gitlabUsernameLabel": {
-    "message": "आपका GitLab उपयोगकर्ता नाम"
-  },
-  "githubUsernamePlaceholder": {
-    "message": "आपके योगदानों को प्राप्त करने के लिए आवश्यक"
-  },
-  "contributionsLabel": {
-    "message": "इस अवधि के योगदान प्राप्त करें:"
-  },
-  "last1DayLabel": {
-    "message": "पिछला दिन"
-  },
-  "startDateLabel": {
-    "message": "प्रारंभ तिथि:"
-  },
-  "endDateLabel": {
-    "message": "अंतिम तिथि:"
-  },
-  "showOpenClosedLabel": {
-    "message": "खुला/बंद स्थिति दिखाएं"
-  },
-  "blockersLabel": {
-    "message": "आपको प्रगति करने से क्या रोक रहा है?"
-  },
-  "blockersPlaceholder": {
-    "message": "अपना कारण दर्ज करें"
-  },
-  "scrumReportLabel": {
-    "message": "स्क्रम रिपोर्ट"
-  },
-  "generateReportButton": {
-    "message": "जनरेट"
-  },
-  "copyReportButton": {
-    "message": "कॉपी"
-  },
-  "insertInEmailButton": {
-    "message": "ईमेल में डालें"
-  },
-  "insertToEmailFailedError": {
-    "message": "Open an email tab to insert report"
-  },
-  "settingsOrgNameLabel": {
-    "message": "संगठन का नाम"
-  },
-  "settingsOrgNamePlaceholder": {
-    "message": "संगठन का नाम दर्ज करें"
-  },
-  "setButton": {
-    "message": "सेट करें"
-  },
-  "githubTokenLabel": {
-    "message": "आपका GitHub टोकन"
-  },
-  "githubTokenPlaceholder": {
-    "message": "प्रमाणित अनुरोधों के लिए आवश्यक"
-  },
-  "githubTokenTooltip": {
-    "message": "GitHub टोकन जोड़ने की सिफारिश क्यों की जाती है? Scrum Helper बिना GitHub टोकन के काम करता है, लेकिन बेहतर अनुभव के लिए व्यक्तिगत एक्सेस टोकन जोड़ने की सिफारिश की जाती है।"
-  },
-  "gitlabTokenLabel": {
-    "message": "आपका GitLab टोकन"
-  },
-  "gitlabTokenPlaceholder": {
-    "message": "निजी रेपो के लिए आवश्यक"
-  },
-  "gitlabTokenTooltip": {
-    "message": "GitLab टोकन जोड़ने की सिफारिश क्यों की जाती है? Scrum Helper सार्वजनिक परियोजनाओं के लिए बिना GitLab टोकन के काम करता है, लेकिन बेहतर अनुभव के लिए व्यक्तिगत एक्सेस टोकन जोड़ने की सिफारिश की जाती है।"
-  },
-  "showCommitsLabel": {
-    "message": "खुले पीआर/ ड्राफ्ट पीआर पर कमिट दिखाएं"
-  },
-  "showCommitsTooltip": {
-    "message": "गिटहब टोकन आवश्यक है, इसे सेटिंग्स में जोड़ें।"
-  },
-  "onlyIssuesLabel": {
-    "message": "रिपोर्ट में केवल समस्याएं शामिल करें"
-  },
-  "onlyIssuesTooltip": {
-    "message": "यदि चेक किया गया है, तो रिपोर्ट में केवल उपयोगकर्ता द्वारा बनाए गए या सौंपे गए मुद्दे शामिल होंगे।"
-  },
-  "onlyPRsLabel": {
-    "message": "रिपोर्ट में केवल PRs शामिल करें"
-  },
-  "onlyPRsTooltip": {
-    "message": "चेक करने पर रिपोर्ट में केवल उपयोगकर्ता द्वारा बनाई गई PRs शामिल होंगी; समीक्षित PRs बाहर रखी जाएँगी."
-  },
-  "cacheTTLLabel": {
-    "message": "कैश टीटीएल दर्ज करें"
-  },
-  "cacheTTLUnit": {
-    "message": "(मिनटों में)"
-  },
-  "cacheTTLPlaceholder": {
-    "message": "कैश TTL मिनटों में लिखें (डिफ़ॉल्ट: 10)"
-  },
-  "refreshDataButton": {
-    "message": "डेटा रीफ्रेश करें (कैश को बायपास करें)"
-  },
-  "refreshDataInfo": {
-    "message": "ताज़ा डेटा तुरंत प्राप्त करने के लिए इस बटन का उपयोग करें।"
-  },
-  "noteTitle": {
-    "message": "ध्यान दें:"
-  },
-  "viewCodeButton": {
-    "message": "कोड देखें"
-  },
-  "reportIssueButton": {
-    "message": "समस्या की रिपोर्ट करें"
-  },
-  "repoFilterLabel": {
-    "message": "रिपॉजिटरी द्वारा फ़िल्टर करें"
-  },
-  "enableFilteringLabel": {
-    "message": "फ़िल्टरिंग सक्षम करें"
-  },
-  "tokenRequiredWarning": {
-    "message": "रिपॉजिटरी फ़िल्टरिंग के लिए एक GitHub टोकन आवश्यक है। कृपया सेटिंग्स में एक जोड़ें।"
-  },
-  "tokenRequiredShowCommitsWarning": {
-    "message": "A GitHub token is required to show commits on open or draft PRs. Please add one in the settings."
-  },
-  "repoSearchPlaceholder": {
-    "message": "जोड़ने के लिए एक रिपॉजिटरी खोजें..."
-  },
-  "repoPlaceholder": {
-    "message": "कोई रिपॉजिटरी चयनित नहीं (सभी शामिल होंगी)"
-  },
-  "repoCountNone": {
-    "message": "0 रिपॉजिटरी चयनित"
-  },
-  "repoCount": {
-    "message": "$1 रिपॉजिटरी चयनित"
-  },
-  "repoLoading": {
-    "message": "रिपॉजिटरी लोड हो रही हैं..."
-  },
-  "repoLoaded": {
-    "message": "$1 रिपॉजिटरी लोड हो गईं।"
-  },
-  "repoNotFound": {
-    "message": "कोई रिपॉजिटरी नहीं मिली"
-  },
-  "repoRefetching": {
-    "message": "रिपॉजिटरी फिर से लोड हो रही हैं..."
-  },
-  "repoLoadFailed": {
-    "message": "रिपॉजिटरी लोड करने में विफल।"
-  },
-  "repoTokenPrivate": {
-    "message": "टोकन अमान्य है या निजी रिपॉजिटरी के लिए अधिकार नहीं हैं।"
-  },
-  "repoRefetchFailed": {
-    "message": "रिपॉजिटरी फिर से लोड करने में विफल।"
-  },
-  "orgSetMessage": {
-    "message": "संगठन सफलतापूर्वक सेट हो गया।"
-  },
-  "orgClearedMessage": {
-    "message": "संगठन साफ़ हो गया। सभी गतिविधियाँ प्राप्त करने के लिए 'रिपोर्ट बनाएं' पर क्लिक करें।"
-  },
-  "orgNotFoundMessage": {
-    "message": "GitHub पर संगठन नहीं मिला।"
-  },
-  "orgValidationErrorMessage": {
-    "message": "संगठन को मान्य करने में त्रुटि।"
-  },
-  "refreshingButton": {
-    "message": "रीफ्रेश हो रहा है..."
-  },
-  "cacheClearFailed": {
-    "message": "कैश साफ़ करने में विफल।"
-  },
-  "madeWithLoveBy": {
-    "message": "Made with ❤️ by"
-  },
-  "generatingButton": {
-    "message": "बनाया जा रहा है..."
-  },
-  "copiedButton": {
-    "message": "कॉपी किया गया!"
-  },
-  "orgChangedMessage": {
-    "message": "संगठन बदल गया है। GitHub गतिविधियाँ प्राप्त करने के लिए 'रिपोर्ट बनाएं' बटन पर क्लिक करें।"
-  },
-  "cacheClearedMessage": {
-    "message": "कैश सफलतापूर्वक साफ़ हो गया। ताज़ा डेटा प्राप्त करने के लिए 'रिपोर्ट बनाएं' पर क्लिक करें।"
-  },
-  "cacheExpiredMessage": {
-    "message": "कैश समाप्त हो गया। नया डेटा प्राप्त करने के लिए \"रिपोर्ट बनाएं\" पर क्लिक करें।"
-  },
-  "cacheClearedButton": {
-    "message": "कैश साफ़ हो गया!"
-  },
-  "extensionDisabledMessage": {
-    "message": "एक्सटेंशन अक्षम है। स्क्रम रिपोर्ट बनाने के लिए इसे विकल्पों से सक्षम करें।"
-  },
-  "notePoint1": {
-    "message": "पुल रिक्वेस्ट किसी भी योगदानकर्ता की सबसे हालिया समीक्षा गतिविधि के आधार पर प्राप्त की जाती हैं, न कि केवल आपकी अपनी। कृपया साझा करने से पहले उत्पन्न SCRUM रिपोर्ट की समीक्षा करें और उसे समायोजित करें ताकि यह सुनिश्चित हो सके कि यह आपके काम को सटीक रूप से दर्शाती है।"
-  },
-  "noteSeeIssue": {
-    "message": "यह समस्या देखें"
-  },
-  "platformLabel": {
-    "message": "प्लेटफ़ॉर्म"
-  },
-  "usernameLabel": {
-    "message": "आपका उपयोगकर्ता नाम"
-  },
-  "onlyRevPRsLabel": {
-    "message": "रिपोर्ट में केवल समीक्षित PRs शामिल करें"
-  },
-  "onlyRevPRsTooltip": {
-    "message": "यदि चेक किया गया है, तो रिपोर्ट में केवल आपके द्वारा समीक्षित PRs शामिल होंगे।"
-  },
-  "onlyMergedPRsLabel": {
-    "message": "Include only merged PRs in the report"
-  },
-  "onlyMergedPRsTooltip": {
-    "message": "If checked, the report will only include PRs that have been merged. A GitHub token is required."
-  },
-  "tokenRequiredMergedPRsWarning": {
-    "message": "A GitHub token is required to filter by merged PRs. Please add one in the settings."
-  },
-  "usernameRequiredError": {
-    "message": "रिपोर्ट बनाने के लिए कृपया अपना उपयोगकर्ता नाम दर्ज करें।"
-  },
-  "unknownPlatformError": {
-    "message": "अज्ञात प्लेटफ़ॉर्म चुना गया है।"
-  },
-  "gitlabFetchingError": {
-    "message": "GitLab डेटा प्राप्त करते समय एक त्रुटि हुई।"
-  },
-  "reportGenerationError": {
-    "message": "रिपोर्ट तैयार करते समय एक त्रुटि हुई।"
-  },
-  "githubUserNotFoundError": {
-    "message": "GitHub उपयोगकर्ता \"$1\" नहीं मिला (404)। कृपया उपयोगकर्ता नाम जांचें और पुनः प्रयास करें।"
-  },
-  "githubUserValidationError": {
-    "message": "GitHub उपयोगकर्ता सत्यापित करते समय त्रुटि: $1 $2"
-  },
-  "invalidSearchQueryError": {
-    "message": "अमान्य खोज क्वेरी या दिनांक सीमा। कृपया अपनी दिनांक सीमा का प्रारूप जांचें और पुनः प्रयास करें।"
-  },
-  "githubIssuesFetchError": {
-    "message": "GitHub issues प्राप्त करते समय त्रुटि: $1 $2"
-  },
-  "githubPRReviewFetchError": {
-    "message": "GitHub PR समीक्षा डेटा प्राप्त करते समय त्रुटि: $1 $2"
-  },
-  "githubUserFetchError": {
-    "message": "GitHub उपयोगकर्ता डेटा प्राप्त करते समय त्रुटि: $1 $2"
-  },
-  "invalidTokenError": {
-    "message": "अमान्य या समाप्त हो चुका GitHub टोकन। कृपया Scrum Helper सेटिंग्स में अपना टोकन जांचें और पुनः प्रयास करें।"
-  },
-  "displayModeNotice": {
-    "message": "एक्सटेंशन अगली बार शुरू होने पर $1 मोड में खुलेगा।"
-  },
-  "repoFilteringGithubOnly": {
-    "message": "रिपॉज़िटरी फ़िल्टरिंग केवल GitHub के लिए उपलब्ध है।"
-  },
-  "repoLoadingGithubOnly": {
-    "message": "रिपॉज़िटरी लोडिंग केवल GitHub के लिए उपलब्ध है।"
-  },
-  "repoFetchingGithubOnly": {
-    "message": "रिपॉज़िटरी प्राप्त करना केवल GitHub के लिए उपलब्ध है।"
-  },
-  "loadingReposAutomatically": {
-    "message": "रिपॉज़िटरी स्वचालित रूप से लोड हो रही हैं.."
-  },
-  "gitlabUserFetchError": {
-    "message": "GitLab उपयोगकर्ता प्राप्त करते समय त्रुटि: $1 $2"
-  },
-  "gitlabUserNotFoundError": {
-    "message": "GitLab उपयोगकर्ता '$1' नहीं मिला"
-  },
-  "gitlabMembershipError": {
-    "message": "GitLab सदस्यता प्रोजेक्ट्स प्राप्त करते समय त्रुटि: $1 $2"
-  },
-  "gitlabContributedError": {
-    "message": "GitLab योगदान किए गए प्रोजेक्ट्स प्राप्त करते समय त्रुटि: $1 $2"
-  },
-  "usernameMissingError": {
-    "message": "उपयोगकर्ता नाम आवश्यक है।"
-  },
-  "generateReportTooltip": {
-    "message": "Ctrl+G"
-  },
-  "copyReportTooltip": {
-    "message": "Ctrl+Shift+Y"
-  },
-  "generatingReportNotification": {
-    "message": "रिपोर्ट तैयार हो रही है..."
-  },
-  "copyingReportNotification": {
-    "message": "रिपोर्ट कॉपी की जा रही है..."
-  },
-  "copiedReportNotification": {
-    "message": "Report copied!"
-  },
-  "insertInEmailTooltip": {
-    "message": "Ctrl+Shift+M"
-  },
-  "insertingInEmailNotification": {
-    "message": "रिपोर्ट ईमेल में डाली जा रही है..."
-  },
-  "insertedInEmailNotification": {
-    "message": "रिपोर्ट ईमेल में डाल दी गई!"
-  }
+    "appName": {
+        "message": "Scrum Helper"
+    },
+    "appDescription": {
+        "message": "एक चयनित अवधि के लिए अपनी Git गतिविधि को स्वतः प्राप्त करके अपनी विकास प्रगति की रिपोर्ट करें।"
+    },
+    "disableLabel": {
+        "message": "अक्षम करें"
+    },
+    "enableLabel": {
+        "message": "सक्षम करें"
+    },
+    "projectNameLabel": {
+        "message": "ईमेल विषय"
+    },
+    "projectNamePlaceholder": {
+        "message": "अपनी परियोजना का नाम दर्ज करें"
+    },
+    "githubUsernameLabel": {
+        "message": "आपका GitHub उपयोगकर्ता नाम"
+    },
+    "gitlabUsernameLabel": {
+        "message": "आपका GitLab उपयोगकर्ता नाम"
+    },
+    "githubUsernamePlaceholder": {
+        "message": "आपके योगदानों को प्राप्त करने के लिए आवश्यक"
+    },
+    "contributionsLabel": {
+        "message": "इस अवधि के योगदान प्राप्त करें:"
+    },
+    "last1DayLabel": {
+        "message": "पिछला दिन"
+    },
+    "startDateLabel": {
+        "message": "प्रारंभ तिथि:"
+    },
+    "endDateLabel": {
+        "message": "अंतिम तिथि:"
+    },
+    "showOpenClosedLabel": {
+        "message": "खुला/बंद स्थिति दिखाएं"
+    },
+    "blockersLabel": {
+        "message": "आपको प्रगति करने से क्या रोक रहा है?"
+    },
+    "blockersPlaceholder": {
+        "message": "अपना कारण दर्ज करें"
+    },
+    "scrumReportLabel": {
+        "message": "स्क्रम रिपोर्ट"
+    },
+    "generateReportButton": {
+        "message": "जनरेट"
+    },
+    "copyReportButton": {
+        "message": "कॉपी"
+    },
+    "insertInEmailButton": {
+        "message": "ईमेल में डालें"
+    },
+    "settingsOrgNameLabel": {
+        "message": "संगठन का नाम"
+    },
+    "settingsOrgNamePlaceholder": {
+        "message": "संगठन का नाम दर्ज करें"
+    },
+    "setButton": {
+        "message": "सेट करें"
+    },
+    "githubTokenLabel": {
+        "message": "आपका GitHub टोकन"
+    },
+    "githubTokenPlaceholder": {
+        "message": "प्रमाणित अनुरोधों के लिए आवश्यक"
+    },
+    "githubTokenTooltip": {
+        "message": "GitHub टोकन जोड़ने की सिफारिश क्यों की जाती है? Scrum Helper बिना GitHub टोकन के काम करता है, लेकिन बेहतर अनुभव के लिए व्यक्तिगत एक्सेस टोकन जोड़ने की सिफारिश की जाती है।"
+    },
+    "gitlabTokenLabel": {
+        "message": "आपका GitLab टोकन"
+    },
+    "gitlabTokenPlaceholder": {
+        "message": "निजी रेपो के लिए आवश्यक"
+    },
+    "gitlabTokenTooltip": {
+        "message": "GitLab टोकन जोड़ने की सिफारिश क्यों की जाती है? Scrum Helper सार्वजनिक परियोजनाओं के लिए बिना GitLab टोकन के काम करता है, लेकिन बेहतर अनुभव के लिए व्यक्तिगत एक्सेस टोकन जोड़ने की सिफारिश की जाती है।"
+    },
+    "showCommitsLabel": {
+        "message": "खुले पीआर/ ड्राफ्ट पीआर पर कमिट दिखाएं"
+    },
+    "showCommitsTooltip": {
+        "message": "गिटहब टोकन आवश्यक है, इसे सेटिंग्स में जोड़ें।"
+    },
+    "onlyIssuesLabel": {
+        "message": "रिपोर्ट में केवल समस्याएं शामिल करें"
+    },
+    "onlyIssuesTooltip": {
+        "message": "यदि चेक किया गया है, तो रिपोर्ट में केवल उपयोगकर्ता द्वारा बनाए गए या सौंपे गए मुद्दे शामिल होंगे।"
+    },
+    "onlyPRsLabel": {
+        "message": "रिपोर्ट में केवल PRs शामिल करें"
+    },
+    "onlyPRsTooltip": {
+        "message": "चेक करने पर रिपोर्ट में केवल उपयोगकर्ता द्वारा बनाई गई PRs शामिल होंगी; समीक्षित PRs बाहर रखी जाएँगी."
+    },
+    "cacheTTLLabel": {
+        "message": "कैश टीटीएल दर्ज करें",
+        "description": "कैश टाइम-टू-लाइव इनपुट के लिए लेबल।"
+    },
+    "cacheTTLUnit": {
+        "message": "(मिनटों में)"
+    },
+    "cacheTTLPlaceholder": {
+        "message": "कैश TTL मिनटों में लिखें (डिफ़ॉल्ट: 10)"
+    },
+    "refreshDataButton": {
+        "message": "डेटा रीफ्रेश करें (कैश को बायपास करें)"
+    },
+    "refreshDataInfo": {
+        "message": "ताज़ा डेटा तुरंत प्राप्त करने के लिए इस बटन का उपयोग करें।"
+    },
+    "noteTitle": {
+        "message": "ध्यान दें:"
+    },
+    "viewCodeButton": {
+        "message": "कोड देखें"
+    },
+    "reportIssueButton": {
+        "message": "समस्या की रिपोर्ट करें"
+    },
+    "repoFilterLabel": {
+        "message": "रिपॉजिटरी द्वारा फ़िल्टर करें"
+    },
+    "enableFilteringLabel": {
+        "message": "फ़िल्टरिंग सक्षम करें"
+    },
+    "tokenRequiredWarning": {
+        "message": "रिपॉजिटरी फ़िल्टरिंग के लिए एक GitHub टोकन आवश्यक है। कृपया सेटिंग्स में एक जोड़ें।"
+    },
+    "repoSearchPlaceholder": {
+        "message": "जोड़ने के लिए एक रिपॉजिटरी खोजें..."
+    },
+    "repoPlaceholder": {
+        "message": "कोई रिपॉजिटरी चयनित नहीं (सभी शामिल होंगी)"
+    },
+    "repoCountNone": {
+        "message": "0 रिपॉजिटरी चयनित"
+    },
+    "repoCount": {
+        "message": "$1 रिपॉजिटरी चयनित"
+    },
+    "repoLoading": {
+        "message": "रिपॉजिटरी लोड हो रही हैं..."
+    },
+    "repoLoaded": {
+        "message": "$1 रिपॉजिटरी लोड हो गईं।"
+    },
+    "repoNotFound": {
+        "message": "कोई रिपॉजिटरी नहीं मिली"
+    },
+    "repoRefetching": {
+        "message": "रिपॉजिटरी फिर से लोड हो रही हैं..."
+    },
+    "repoLoadFailed": {
+        "message": "रिपॉजिटरी लोड करने में विफल।"
+    },
+    "repoTokenPrivate": {
+        "message": "टोकन अमान्य है या निजी रिपॉजिटरी के लिए अधिकार नहीं हैं।"
+    },
+    "repoRefetchFailed": {
+        "message": "रिपॉजिटरी फिर से लोड करने में विफल।"
+    },
+    "orgSetMessage": {
+        "message": "संगठन सफलतापूर्वक सेट हो गया।"
+    },
+    "orgClearedMessage": {
+        "message": "संगठन साफ़ हो गया। सभी गतिविधियाँ प्राप्त करने के लिए 'रिपोर्ट बनाएं' पर क्लिक करें।"
+    },
+    "orgNotFoundMessage": {
+        "message": "GitHub पर संगठन नहीं मिला।"
+    },
+    "orgValidationErrorMessage": {
+        "message": "संगठन को मान्य करने में त्रुटि।"
+    },
+    "refreshingButton": {
+        "message": "रीफ्रेश हो रहा है..."
+    },
+    "cacheClearFailed": {
+        "message": "कैश साफ़ करने में विफल।"
+    },
+    "madeWithLoveBy": {
+        "message": "Made with ❤️ by"
+    },
+    "generatingButton": {
+        "message": "बनाया जा रहा है..."
+    },
+    "copiedButton": {
+        "message": "कॉपी किया गया!"
+    },
+    "orgChangedMessage": {
+        "message": "संगठन बदल गया है। GitHub गतिविधियाँ प्राप्त करने के लिए 'रिपोर्ट बनाएं' बटन पर क्लिक करें।"
+    },
+    "cacheClearedMessage": {
+        "message": "कैश सफलतापूर्वक साफ़ हो गया। ताज़ा डेटा प्राप्त करने के लिए 'रिपोर्ट बनाएं' पर क्लिक करें।"
+    },
+    "cacheExpiredMessage": {
+        "message": "कैश समाप्त हो गया। नया डेटा प्राप्त करने के लिए \"रिपोर्ट बनाएं\" पर क्लिक करें।",
+        "description": "Message shown when the cached data has expired and user needs to regenerate."
+    },
+    "cacheClearedButton": {
+        "message": "कैश साफ़ हो गया!"
+    },
+    "extensionDisabledMessage": {
+        "message": "एक्सटेंशन अक्षम है। स्क्रम रिपोर्ट बनाने के लिए इसे विकल्पों से सक्षम करें।"
+    },
+    "notePoint1": {
+        "message": "पुल रिक्वेस्ट किसी भी योगदानकर्ता की सबसे हालिया समीक्षा गतिविधि के आधार पर प्राप्त की जाती हैं, न कि केवल आपकी अपनी। कृपया साझा करने से पहले उत्पन्न SCRUM रिपोर्ट की समीक्षा करें और उसे समायोजित करें ताकि यह सुनिश्चित हो सके कि यह आपके काम को सटीक रूप से दर्शाती है।"
+    },
+    "noteSeeIssue": {
+        "message": "यह समस्या देखें"
+    },
+    "platformLabel": {
+        "message": "प्लेटफ़ॉर्म"
+    },
+    "usernameLabel": {
+        "message": "आपका उपयोगकर्ता नाम"
+    },
+    "onlyRevPRsLabel": {
+        "message": "रिपोर्ट में केवल समीक्षित PRs शामिल करें"
+    },
+    "onlyRevPRsTooltip": {
+        "message": "यदि चेक किया गया है, तो रिपोर्ट में केवल आपके द्वारा समीक्षित PRs शामिल होंगे।"
+    },
+    "usernameRequiredError": {
+		"message": "रिपोर्ट बनाने के लिए कृपया अपना उपयोगकर्ता नाम दर्ज करें।"
+	},
+	"unknownPlatformError": {
+		"message": "अज्ञात प्लेटफ़ॉर्म चुना गया है।"
+	},
+	"gitlabFetchingError": {
+		"message": "GitLab डेटा प्राप्त करते समय एक त्रुटि हुई।"
+	},
+	"reportGenerationError": {
+		"message": "रिपोर्ट तैयार करते समय एक त्रुटि हुई।"
+	},
+	"githubUserNotFoundError": {
+		"message": "GitHub उपयोगकर्ता \"$1\" नहीं मिला (404)। कृपया उपयोगकर्ता नाम जांचें और पुनः प्रयास करें।"
+	},
+	"githubUserValidationError": {
+		"message": "GitHub उपयोगकर्ता सत्यापित करते समय त्रुटि: $1 $2"
+	},
+	"invalidSearchQueryError": {
+		"message": "अमान्य खोज क्वेरी या दिनांक सीमा। कृपया अपनी दिनांक सीमा का प्रारूप जांचें और पुनः प्रयास करें।"
+	},
+	"githubIssuesFetchError": {
+		"message": "GitHub issues प्राप्त करते समय त्रुटि: $1 $2"
+	},
+	"githubPRReviewFetchError": {
+		"message": "GitHub PR समीक्षा डेटा प्राप्त करते समय त्रुटि: $1 $2"
+	},
+	"githubUserFetchError": {
+		"message": "GitHub उपयोगकर्ता डेटा प्राप्त करते समय त्रुटि: $1 $2"
+	},
+	"invalidTokenError": {
+		"message": "अमान्य या समाप्त हो चुका GitHub टोकन। कृपया Scrum Helper सेटिंग्स में अपना टोकन जांचें और पुनः प्रयास करें।"
+	},
+	"displayModeNotice": {
+		"message": "एक्सटेंशन अगली बार शुरू होने पर $1 मोड में खुलेगा।"
+	},
+	"repoFilteringGithubOnly": {
+		"message": "रिपॉज़िटरी फ़िल्टरिंग केवल GitHub के लिए उपलब्ध है।"
+	},
+	"repoLoadingGithubOnly": {
+		"message": "रिपॉज़िटरी लोडिंग केवल GitHub के लिए उपलब्ध है।"
+	},
+	"repoFetchingGithubOnly": {
+		"message": "रिपॉज़िटरी प्राप्त करना केवल GitHub के लिए उपलब्ध है।"
+	},
+	"loadingReposAutomatically": {
+		"message": "रिपॉज़िटरी स्वचालित रूप से लोड हो रही हैं.."
+	},
+	"gitlabUserFetchError": {
+		"message": "GitLab उपयोगकर्ता प्राप्त करते समय त्रुटि: $1 $2"
+	},
+	"gitlabUserNotFoundError": {
+		"message": "GitLab उपयोगकर्ता '$1' नहीं मिला"
+	},
+	"gitlabMembershipError": {
+		"message": "GitLab सदस्यता प्रोजेक्ट्स प्राप्त करते समय त्रुटि: $1 $2"
+	},
+	"gitlabContributedError": {
+		"message": "GitLab योगदान किए गए प्रोजेक्ट्स प्राप्त करते समय त्रुटि: $1 $2"
+	},
+	"usernameMissingError": {
+		"message": "उपयोगकर्ता नाम आवश्यक है।"
+	},
+    "generateReportTooltip": {
+        "message": "Ctrl+G"
+    },
+    "copyReportTooltip": {
+        "message": "Ctrl+Shift+Y"
+    },
+    "generatingReportNotification": {
+        "message": "रिपोर्ट तैयार हो रही है..."
+    },
+    "copyingReportNotification": {
+        "message": "रिपोर्ट कॉपी की जा रही है..."
+    },
+    "insertInEmailTooltip": {
+        "message": "Ctrl+Shift+M"
+    },
+    "insertingInEmailNotification": {
+        "message": "रिपोर्ट ईमेल में डाली जा रही है..."
+    },
+    "insertedInEmailNotification": {
+        "message": "रिपोर्ट ईमेल में डाल दी गई!"
+    }
 }

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -1,319 +1,335 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "एक चयनित अवधि के लिए अपनी Git गतिविधि को स्वतः प्राप्त करके अपनी विकास प्रगति की रिपोर्ट करें।"
-    },
-    "disableLabel": {
-        "message": "अक्षम करें"
-    },
-    "enableLabel": {
-        "message": "सक्षम करें"
-    },
-    "projectNameLabel": {
-        "message": "ईमेल विषय"
-    },
-    "projectNamePlaceholder": {
-        "message": "अपनी परियोजना का नाम दर्ज करें"
-    },
-    "githubUsernameLabel": {
-        "message": "आपका GitHub उपयोगकर्ता नाम"
-    },
-    "gitlabUsernameLabel": {
-        "message": "आपका GitLab उपयोगकर्ता नाम"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "आपके योगदानों को प्राप्त करने के लिए आवश्यक"
-    },
-    "contributionsLabel": {
-        "message": "इस अवधि के योगदान प्राप्त करें:"
-    },
-    "last1DayLabel": {
-        "message": "पिछला दिन"
-    },
-    "startDateLabel": {
-        "message": "प्रारंभ तिथि:"
-    },
-    "endDateLabel": {
-        "message": "अंतिम तिथि:"
-    },
-    "showOpenClosedLabel": {
-        "message": "खुला/बंद स्थिति दिखाएं"
-    },
-    "blockersLabel": {
-        "message": "आपको प्रगति करने से क्या रोक रहा है?"
-    },
-    "blockersPlaceholder": {
-        "message": "अपना कारण दर्ज करें"
-    },
-    "scrumReportLabel": {
-        "message": "स्क्रम रिपोर्ट"
-    },
-    "generateReportButton": {
-        "message": "जनरेट"
-    },
-    "copyReportButton": {
-        "message": "कॉपी"
-    },
-    "insertInEmailButton": {
-        "message": "ईमेल में डालें"
-    },
-    "settingsOrgNameLabel": {
-        "message": "संगठन का नाम"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "संगठन का नाम दर्ज करें"
-    },
-    "setButton": {
-        "message": "सेट करें"
-    },
-    "githubTokenLabel": {
-        "message": "आपका GitHub टोकन"
-    },
-    "githubTokenPlaceholder": {
-        "message": "प्रमाणित अनुरोधों के लिए आवश्यक"
-    },
-    "githubTokenTooltip": {
-        "message": "GitHub टोकन जोड़ने की सिफारिश क्यों की जाती है? Scrum Helper बिना GitHub टोकन के काम करता है, लेकिन बेहतर अनुभव के लिए व्यक्तिगत एक्सेस टोकन जोड़ने की सिफारिश की जाती है।"
-    },
-    "gitlabTokenLabel": {
-        "message": "आपका GitLab टोकन"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "निजी रेपो के लिए आवश्यक"
-    },
-    "gitlabTokenTooltip": {
-        "message": "GitLab टोकन जोड़ने की सिफारिश क्यों की जाती है? Scrum Helper सार्वजनिक परियोजनाओं के लिए बिना GitLab टोकन के काम करता है, लेकिन बेहतर अनुभव के लिए व्यक्तिगत एक्सेस टोकन जोड़ने की सिफारिश की जाती है।"
-    },
-    "showCommitsLabel": {
-        "message": "खुले पीआर/ ड्राफ्ट पीआर पर कमिट दिखाएं"
-    },
-    "showCommitsTooltip": {
-        "message": "गिटहब टोकन आवश्यक है, इसे सेटिंग्स में जोड़ें।"
-    },
-    "onlyIssuesLabel": {
-        "message": "रिपोर्ट में केवल समस्याएं शामिल करें"
-    },
-    "onlyIssuesTooltip": {
-        "message": "यदि चेक किया गया है, तो रिपोर्ट में केवल उपयोगकर्ता द्वारा बनाए गए या सौंपे गए मुद्दे शामिल होंगे।"
-    },
-    "onlyPRsLabel": {
-        "message": "रिपोर्ट में केवल PRs शामिल करें"
-    },
-    "onlyPRsTooltip": {
-        "message": "चेक करने पर रिपोर्ट में केवल उपयोगकर्ता द्वारा बनाई गई PRs शामिल होंगी; समीक्षित PRs बाहर रखी जाएँगी."
-    },
-    "cacheTTLLabel": {
-        "message": "कैश टीटीएल दर्ज करें",
-        "description": "कैश टाइम-टू-लाइव इनपुट के लिए लेबल।"
-    },
-    "cacheTTLUnit": {
-        "message": "(मिनटों में)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "कैश TTL मिनटों में लिखें (डिफ़ॉल्ट: 10)"
-    },
-    "refreshDataButton": {
-        "message": "डेटा रीफ्रेश करें (कैश को बायपास करें)"
-    },
-    "refreshDataInfo": {
-        "message": "ताज़ा डेटा तुरंत प्राप्त करने के लिए इस बटन का उपयोग करें।"
-    },
-    "noteTitle": {
-        "message": "ध्यान दें:"
-    },
-    "viewCodeButton": {
-        "message": "कोड देखें"
-    },
-    "reportIssueButton": {
-        "message": "समस्या की रिपोर्ट करें"
-    },
-    "repoFilterLabel": {
-        "message": "रिपॉजिटरी द्वारा फ़िल्टर करें"
-    },
-    "enableFilteringLabel": {
-        "message": "फ़िल्टरिंग सक्षम करें"
-    },
-    "tokenRequiredWarning": {
-        "message": "रिपॉजिटरी फ़िल्टरिंग के लिए एक GitHub टोकन आवश्यक है। कृपया सेटिंग्स में एक जोड़ें।"
-    },
-    "repoSearchPlaceholder": {
-        "message": "जोड़ने के लिए एक रिपॉजिटरी खोजें..."
-    },
-    "repoPlaceholder": {
-        "message": "कोई रिपॉजिटरी चयनित नहीं (सभी शामिल होंगी)"
-    },
-    "repoCountNone": {
-        "message": "0 रिपॉजिटरी चयनित"
-    },
-    "repoCount": {
-        "message": "$1 रिपॉजिटरी चयनित"
-    },
-    "repoLoading": {
-        "message": "रिपॉजिटरी लोड हो रही हैं..."
-    },
-    "repoLoaded": {
-        "message": "$1 रिपॉजिटरी लोड हो गईं।"
-    },
-    "repoNotFound": {
-        "message": "कोई रिपॉजिटरी नहीं मिली"
-    },
-    "repoRefetching": {
-        "message": "रिपॉजिटरी फिर से लोड हो रही हैं..."
-    },
-    "repoLoadFailed": {
-        "message": "रिपॉजिटरी लोड करने में विफल।"
-    },
-    "repoTokenPrivate": {
-        "message": "टोकन अमान्य है या निजी रिपॉजिटरी के लिए अधिकार नहीं हैं।"
-    },
-    "repoRefetchFailed": {
-        "message": "रिपॉजिटरी फिर से लोड करने में विफल।"
-    },
-    "orgSetMessage": {
-        "message": "संगठन सफलतापूर्वक सेट हो गया।"
-    },
-    "orgClearedMessage": {
-        "message": "संगठन साफ़ हो गया। सभी गतिविधियाँ प्राप्त करने के लिए 'रिपोर्ट बनाएं' पर क्लिक करें।"
-    },
-    "orgNotFoundMessage": {
-        "message": "GitHub पर संगठन नहीं मिला।"
-    },
-    "orgValidationErrorMessage": {
-        "message": "संगठन को मान्य करने में त्रुटि।"
-    },
-    "refreshingButton": {
-        "message": "रीफ्रेश हो रहा है..."
-    },
-    "cacheClearFailed": {
-        "message": "कैश साफ़ करने में विफल।"
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "बनाया जा रहा है..."
-    },
-    "copiedButton": {
-        "message": "कॉपी किया गया!"
-    },
-    "orgChangedMessage": {
-        "message": "संगठन बदल गया है। GitHub गतिविधियाँ प्राप्त करने के लिए 'रिपोर्ट बनाएं' बटन पर क्लिक करें।"
-    },
-    "cacheClearedMessage": {
-        "message": "कैश सफलतापूर्वक साफ़ हो गया। ताज़ा डेटा प्राप्त करने के लिए 'रिपोर्ट बनाएं' पर क्लिक करें।"
-    },
-    "cacheExpiredMessage": {
-        "message": "कैश समाप्त हो गया। नया डेटा प्राप्त करने के लिए \"रिपोर्ट बनाएं\" पर क्लिक करें।",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "कैश साफ़ हो गया!"
-    },
-    "extensionDisabledMessage": {
-        "message": "एक्सटेंशन अक्षम है। स्क्रम रिपोर्ट बनाने के लिए इसे विकल्पों से सक्षम करें।"
-    },
-    "notePoint1": {
-        "message": "पुल रिक्वेस्ट किसी भी योगदानकर्ता की सबसे हालिया समीक्षा गतिविधि के आधार पर प्राप्त की जाती हैं, न कि केवल आपकी अपनी। कृपया साझा करने से पहले उत्पन्न SCRUM रिपोर्ट की समीक्षा करें और उसे समायोजित करें ताकि यह सुनिश्चित हो सके कि यह आपके काम को सटीक रूप से दर्शाती है।"
-    },
-    "noteSeeIssue": {
-        "message": "यह समस्या देखें"
-    },
-    "platformLabel": {
-        "message": "प्लेटफ़ॉर्म"
-    },
-    "usernameLabel": {
-        "message": "आपका उपयोगकर्ता नाम"
-    },
-    "onlyRevPRsLabel": {
-        "message": "रिपोर्ट में केवल समीक्षित PRs शामिल करें"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "यदि चेक किया गया है, तो रिपोर्ट में केवल आपके द्वारा समीक्षित PRs शामिल होंगे।"
-    },
-    "usernameRequiredError": {
-		"message": "रिपोर्ट बनाने के लिए कृपया अपना उपयोगकर्ता नाम दर्ज करें।"
-	},
-	"unknownPlatformError": {
-		"message": "अज्ञात प्लेटफ़ॉर्म चुना गया है।"
-	},
-	"gitlabFetchingError": {
-		"message": "GitLab डेटा प्राप्त करते समय एक त्रुटि हुई।"
-	},
-	"reportGenerationError": {
-		"message": "रिपोर्ट तैयार करते समय एक त्रुटि हुई।"
-	},
-	"githubUserNotFoundError": {
-		"message": "GitHub उपयोगकर्ता \"$1\" नहीं मिला (404)। कृपया उपयोगकर्ता नाम जांचें और पुनः प्रयास करें।"
-	},
-	"githubUserValidationError": {
-		"message": "GitHub उपयोगकर्ता सत्यापित करते समय त्रुटि: $1 $2"
-	},
-	"invalidSearchQueryError": {
-		"message": "अमान्य खोज क्वेरी या दिनांक सीमा। कृपया अपनी दिनांक सीमा का प्रारूप जांचें और पुनः प्रयास करें।"
-	},
-	"githubIssuesFetchError": {
-		"message": "GitHub issues प्राप्त करते समय त्रुटि: $1 $2"
-	},
-	"githubPRReviewFetchError": {
-		"message": "GitHub PR समीक्षा डेटा प्राप्त करते समय त्रुटि: $1 $2"
-	},
-	"githubUserFetchError": {
-		"message": "GitHub उपयोगकर्ता डेटा प्राप्त करते समय त्रुटि: $1 $2"
-	},
-	"invalidTokenError": {
-		"message": "अमान्य या समाप्त हो चुका GitHub टोकन। कृपया Scrum Helper सेटिंग्स में अपना टोकन जांचें और पुनः प्रयास करें।"
-	},
-	"displayModeNotice": {
-		"message": "एक्सटेंशन अगली बार शुरू होने पर $1 मोड में खुलेगा।"
-	},
-	"repoFilteringGithubOnly": {
-		"message": "रिपॉज़िटरी फ़िल्टरिंग केवल GitHub के लिए उपलब्ध है।"
-	},
-	"repoLoadingGithubOnly": {
-		"message": "रिपॉज़िटरी लोडिंग केवल GitHub के लिए उपलब्ध है।"
-	},
-	"repoFetchingGithubOnly": {
-		"message": "रिपॉज़िटरी प्राप्त करना केवल GitHub के लिए उपलब्ध है।"
-	},
-	"loadingReposAutomatically": {
-		"message": "रिपॉज़िटरी स्वचालित रूप से लोड हो रही हैं.."
-	},
-	"gitlabUserFetchError": {
-		"message": "GitLab उपयोगकर्ता प्राप्त करते समय त्रुटि: $1 $2"
-	},
-	"gitlabUserNotFoundError": {
-		"message": "GitLab उपयोगकर्ता '$1' नहीं मिला"
-	},
-	"gitlabMembershipError": {
-		"message": "GitLab सदस्यता प्रोजेक्ट्स प्राप्त करते समय त्रुटि: $1 $2"
-	},
-	"gitlabContributedError": {
-		"message": "GitLab योगदान किए गए प्रोजेक्ट्स प्राप्त करते समय त्रुटि: $1 $2"
-	},
-	"usernameMissingError": {
-		"message": "उपयोगकर्ता नाम आवश्यक है।"
-	},
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "रिपोर्ट तैयार हो रही है..."
-    },
-    "copyingReportNotification": {
-        "message": "रिपोर्ट कॉपी की जा रही है..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "रिपोर्ट ईमेल में डाली जा रही है..."
-    },
-    "insertedInEmailNotification": {
-        "message": "रिपोर्ट ईमेल में डाल दी गई!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "एक चयनित अवधि के लिए अपनी Git गतिविधि को स्वतः प्राप्त करके अपनी विकास प्रगति की रिपोर्ट करें।"
+  },
+  "disableLabel": {
+    "message": "अक्षम करें"
+  },
+  "enableLabel": {
+    "message": "सक्षम करें"
+  },
+  "projectNameLabel": {
+    "message": "ईमेल विषय"
+  },
+  "projectNamePlaceholder": {
+    "message": "अपनी परियोजना का नाम दर्ज करें"
+  },
+  "githubUsernameLabel": {
+    "message": "आपका GitHub उपयोगकर्ता नाम"
+  },
+  "gitlabUsernameLabel": {
+    "message": "आपका GitLab उपयोगकर्ता नाम"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "आपके योगदानों को प्राप्त करने के लिए आवश्यक"
+  },
+  "contributionsLabel": {
+    "message": "इस अवधि के योगदान प्राप्त करें:"
+  },
+  "last1DayLabel": {
+    "message": "पिछला दिन"
+  },
+  "startDateLabel": {
+    "message": "प्रारंभ तिथि:"
+  },
+  "endDateLabel": {
+    "message": "अंतिम तिथि:"
+  },
+  "showOpenClosedLabel": {
+    "message": "खुला/बंद स्थिति दिखाएं"
+  },
+  "blockersLabel": {
+    "message": "आपको प्रगति करने से क्या रोक रहा है?"
+  },
+  "blockersPlaceholder": {
+    "message": "अपना कारण दर्ज करें"
+  },
+  "scrumReportLabel": {
+    "message": "स्क्रम रिपोर्ट"
+  },
+  "generateReportButton": {
+    "message": "जनरेट"
+  },
+  "copyReportButton": {
+    "message": "कॉपी"
+  },
+  "insertInEmailButton": {
+    "message": "ईमेल में डालें"
+  },
+  "insertToEmailFailedError": {
+    "message": "Open an email tab to insert report"
+  },
+  "settingsOrgNameLabel": {
+    "message": "संगठन का नाम"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "संगठन का नाम दर्ज करें"
+  },
+  "setButton": {
+    "message": "सेट करें"
+  },
+  "githubTokenLabel": {
+    "message": "आपका GitHub टोकन"
+  },
+  "githubTokenPlaceholder": {
+    "message": "प्रमाणित अनुरोधों के लिए आवश्यक"
+  },
+  "githubTokenTooltip": {
+    "message": "GitHub टोकन जोड़ने की सिफारिश क्यों की जाती है? Scrum Helper बिना GitHub टोकन के काम करता है, लेकिन बेहतर अनुभव के लिए व्यक्तिगत एक्सेस टोकन जोड़ने की सिफारिश की जाती है।"
+  },
+  "gitlabTokenLabel": {
+    "message": "आपका GitLab टोकन"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "निजी रेपो के लिए आवश्यक"
+  },
+  "gitlabTokenTooltip": {
+    "message": "GitLab टोकन जोड़ने की सिफारिश क्यों की जाती है? Scrum Helper सार्वजनिक परियोजनाओं के लिए बिना GitLab टोकन के काम करता है, लेकिन बेहतर अनुभव के लिए व्यक्तिगत एक्सेस टोकन जोड़ने की सिफारिश की जाती है।"
+  },
+  "showCommitsLabel": {
+    "message": "खुले पीआर/ ड्राफ्ट पीआर पर कमिट दिखाएं"
+  },
+  "showCommitsTooltip": {
+    "message": "गिटहब टोकन आवश्यक है, इसे सेटिंग्स में जोड़ें।"
+  },
+  "onlyIssuesLabel": {
+    "message": "रिपोर्ट में केवल समस्याएं शामिल करें"
+  },
+  "onlyIssuesTooltip": {
+    "message": "यदि चेक किया गया है, तो रिपोर्ट में केवल उपयोगकर्ता द्वारा बनाए गए या सौंपे गए मुद्दे शामिल होंगे।"
+  },
+  "onlyPRsLabel": {
+    "message": "रिपोर्ट में केवल PRs शामिल करें"
+  },
+  "onlyPRsTooltip": {
+    "message": "चेक करने पर रिपोर्ट में केवल उपयोगकर्ता द्वारा बनाई गई PRs शामिल होंगी; समीक्षित PRs बाहर रखी जाएँगी."
+  },
+  "cacheTTLLabel": {
+    "message": "कैश टीटीएल दर्ज करें"
+  },
+  "cacheTTLUnit": {
+    "message": "(मिनटों में)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "कैश TTL मिनटों में लिखें (डिफ़ॉल्ट: 10)"
+  },
+  "refreshDataButton": {
+    "message": "डेटा रीफ्रेश करें (कैश को बायपास करें)"
+  },
+  "refreshDataInfo": {
+    "message": "ताज़ा डेटा तुरंत प्राप्त करने के लिए इस बटन का उपयोग करें।"
+  },
+  "noteTitle": {
+    "message": "ध्यान दें:"
+  },
+  "viewCodeButton": {
+    "message": "कोड देखें"
+  },
+  "reportIssueButton": {
+    "message": "समस्या की रिपोर्ट करें"
+  },
+  "repoFilterLabel": {
+    "message": "रिपॉजिटरी द्वारा फ़िल्टर करें"
+  },
+  "enableFilteringLabel": {
+    "message": "फ़िल्टरिंग सक्षम करें"
+  },
+  "tokenRequiredWarning": {
+    "message": "रिपॉजिटरी फ़िल्टरिंग के लिए एक GitHub टोकन आवश्यक है। कृपया सेटिंग्स में एक जोड़ें।"
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "A GitHub token is required to show commits on open or draft PRs. Please add one in the settings."
+  },
+  "repoSearchPlaceholder": {
+    "message": "जोड़ने के लिए एक रिपॉजिटरी खोजें..."
+  },
+  "repoPlaceholder": {
+    "message": "कोई रिपॉजिटरी चयनित नहीं (सभी शामिल होंगी)"
+  },
+  "repoCountNone": {
+    "message": "0 रिपॉजिटरी चयनित"
+  },
+  "repoCount": {
+    "message": "$1 रिपॉजिटरी चयनित"
+  },
+  "repoLoading": {
+    "message": "रिपॉजिटरी लोड हो रही हैं..."
+  },
+  "repoLoaded": {
+    "message": "$1 रिपॉजिटरी लोड हो गईं।"
+  },
+  "repoNotFound": {
+    "message": "कोई रिपॉजिटरी नहीं मिली"
+  },
+  "repoRefetching": {
+    "message": "रिपॉजिटरी फिर से लोड हो रही हैं..."
+  },
+  "repoLoadFailed": {
+    "message": "रिपॉजिटरी लोड करने में विफल।"
+  },
+  "repoTokenPrivate": {
+    "message": "टोकन अमान्य है या निजी रिपॉजिटरी के लिए अधिकार नहीं हैं।"
+  },
+  "repoRefetchFailed": {
+    "message": "रिपॉजिटरी फिर से लोड करने में विफल।"
+  },
+  "orgSetMessage": {
+    "message": "संगठन सफलतापूर्वक सेट हो गया।"
+  },
+  "orgClearedMessage": {
+    "message": "संगठन साफ़ हो गया। सभी गतिविधियाँ प्राप्त करने के लिए 'रिपोर्ट बनाएं' पर क्लिक करें।"
+  },
+  "orgNotFoundMessage": {
+    "message": "GitHub पर संगठन नहीं मिला।"
+  },
+  "orgValidationErrorMessage": {
+    "message": "संगठन को मान्य करने में त्रुटि।"
+  },
+  "refreshingButton": {
+    "message": "रीफ्रेश हो रहा है..."
+  },
+  "cacheClearFailed": {
+    "message": "कैश साफ़ करने में विफल।"
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "बनाया जा रहा है..."
+  },
+  "copiedButton": {
+    "message": "कॉपी किया गया!"
+  },
+  "orgChangedMessage": {
+    "message": "संगठन बदल गया है। GitHub गतिविधियाँ प्राप्त करने के लिए 'रिपोर्ट बनाएं' बटन पर क्लिक करें।"
+  },
+  "cacheClearedMessage": {
+    "message": "कैश सफलतापूर्वक साफ़ हो गया। ताज़ा डेटा प्राप्त करने के लिए 'रिपोर्ट बनाएं' पर क्लिक करें।"
+  },
+  "cacheExpiredMessage": {
+    "message": "कैश समाप्त हो गया। नया डेटा प्राप्त करने के लिए \"रिपोर्ट बनाएं\" पर क्लिक करें।"
+  },
+  "cacheClearedButton": {
+    "message": "कैश साफ़ हो गया!"
+  },
+  "extensionDisabledMessage": {
+    "message": "एक्सटेंशन अक्षम है। स्क्रम रिपोर्ट बनाने के लिए इसे विकल्पों से सक्षम करें।"
+  },
+  "notePoint1": {
+    "message": "पुल रिक्वेस्ट किसी भी योगदानकर्ता की सबसे हालिया समीक्षा गतिविधि के आधार पर प्राप्त की जाती हैं, न कि केवल आपकी अपनी। कृपया साझा करने से पहले उत्पन्न SCRUM रिपोर्ट की समीक्षा करें और उसे समायोजित करें ताकि यह सुनिश्चित हो सके कि यह आपके काम को सटीक रूप से दर्शाती है।"
+  },
+  "noteSeeIssue": {
+    "message": "यह समस्या देखें"
+  },
+  "platformLabel": {
+    "message": "प्लेटफ़ॉर्म"
+  },
+  "usernameLabel": {
+    "message": "आपका उपयोगकर्ता नाम"
+  },
+  "onlyRevPRsLabel": {
+    "message": "रिपोर्ट में केवल समीक्षित PRs शामिल करें"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "यदि चेक किया गया है, तो रिपोर्ट में केवल आपके द्वारा समीक्षित PRs शामिल होंगे।"
+  },
+  "onlyMergedPRsLabel": {
+    "message": "Include only merged PRs in the report"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "If checked, the report will only include PRs that have been merged. A GitHub token is required."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "A GitHub token is required to filter by merged PRs. Please add one in the settings."
+  },
+  "usernameRequiredError": {
+    "message": "रिपोर्ट बनाने के लिए कृपया अपना उपयोगकर्ता नाम दर्ज करें।"
+  },
+  "unknownPlatformError": {
+    "message": "अज्ञात प्लेटफ़ॉर्म चुना गया है।"
+  },
+  "gitlabFetchingError": {
+    "message": "GitLab डेटा प्राप्त करते समय एक त्रुटि हुई।"
+  },
+  "reportGenerationError": {
+    "message": "रिपोर्ट तैयार करते समय एक त्रुटि हुई।"
+  },
+  "githubUserNotFoundError": {
+    "message": "GitHub उपयोगकर्ता \"$1\" नहीं मिला (404)। कृपया उपयोगकर्ता नाम जांचें और पुनः प्रयास करें।"
+  },
+  "githubUserValidationError": {
+    "message": "GitHub उपयोगकर्ता सत्यापित करते समय त्रुटि: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "अमान्य खोज क्वेरी या दिनांक सीमा। कृपया अपनी दिनांक सीमा का प्रारूप जांचें और पुनः प्रयास करें।"
+  },
+  "githubIssuesFetchError": {
+    "message": "GitHub issues प्राप्त करते समय त्रुटि: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "GitHub PR समीक्षा डेटा प्राप्त करते समय त्रुटि: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "GitHub उपयोगकर्ता डेटा प्राप्त करते समय त्रुटि: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "अमान्य या समाप्त हो चुका GitHub टोकन। कृपया Scrum Helper सेटिंग्स में अपना टोकन जांचें और पुनः प्रयास करें।"
+  },
+  "displayModeNotice": {
+    "message": "एक्सटेंशन अगली बार शुरू होने पर $1 मोड में खुलेगा।"
+  },
+  "repoFilteringGithubOnly": {
+    "message": "रिपॉज़िटरी फ़िल्टरिंग केवल GitHub के लिए उपलब्ध है।"
+  },
+  "repoLoadingGithubOnly": {
+    "message": "रिपॉज़िटरी लोडिंग केवल GitHub के लिए उपलब्ध है।"
+  },
+  "repoFetchingGithubOnly": {
+    "message": "रिपॉज़िटरी प्राप्त करना केवल GitHub के लिए उपलब्ध है।"
+  },
+  "loadingReposAutomatically": {
+    "message": "रिपॉज़िटरी स्वचालित रूप से लोड हो रही हैं.."
+  },
+  "gitlabUserFetchError": {
+    "message": "GitLab उपयोगकर्ता प्राप्त करते समय त्रुटि: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "GitLab उपयोगकर्ता '$1' नहीं मिला"
+  },
+  "gitlabMembershipError": {
+    "message": "GitLab सदस्यता प्रोजेक्ट्स प्राप्त करते समय त्रुटि: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "GitLab योगदान किए गए प्रोजेक्ट्स प्राप्त करते समय त्रुटि: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "उपयोगकर्ता नाम आवश्यक है।"
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "रिपोर्ट तैयार हो रही है..."
+  },
+  "copyingReportNotification": {
+    "message": "रिपोर्ट कॉपी की जा रही है..."
+  },
+  "copiedReportNotification": {
+    "message": "Report copied!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "रिपोर्ट ईमेल में डाली जा रही है..."
+  },
+  "insertedInEmailNotification": {
+    "message": "रिपोर्ट ईमेल में डाल दी गई!"
+  }
 }

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -184,6 +184,7 @@ function allIncluded(outputTarget = 'email') {
 				onlyIssues = items.onlyIssues === true;
 				onlyPRs = items.onlyPRs === true;
 				onlyRevPRs = items.onlyRevPRs === true;
+				onlyMergedPRs = items.onlyMergedPRs === true;
 				console.log('[SCRUM-DEBUG] loaded flags:', { onlyIssues, onlyPRs, onlyRevPRs });
 				// Enforce mutual exclusivity between onlyIssues and onlyPRs to avoid filtering out everything
 				if (onlyIssues && onlyPRs) {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -185,11 +185,15 @@ function allIncluded(outputTarget = 'email') {
 				onlyPRs = items.onlyPRs === true;
 				onlyRevPRs = items.onlyRevPRs === true;
 				onlyMergedPRs = items.onlyMergedPRs === true;
-				console.log('[SCRUM-DEBUG] loaded flags:', { onlyIssues, onlyPRs, onlyRevPRs });
+				if (onlyMergedPRs) {
+					onlyPRs = true;
+				}
+				console.log('[SCRUM-DEBUG] loaded flags:', { onlyIssues, onlyPRs, onlyRevPRs, onlyMergedPRs });
 				// Enforce mutual exclusivity between onlyIssues and onlyPRs to avoid filtering out everything
 				if (onlyIssues && onlyPRs) {
 					console.warn('[SCRUM-HELPER]: Detected both onlyIssues and onlyPRs enabled; normalizing to onlyIssues.');
 					onlyPRs = false;
+					onlyMergedPRs = false;
 				}
 				showCommits = items.showCommits || false;
 				showOpenLabel = items.showOpenLabel !== false; // Default to true if not explicitly set to false

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -185,15 +185,11 @@ function allIncluded(outputTarget = 'email') {
 				onlyPRs = items.onlyPRs === true;
 				onlyRevPRs = items.onlyRevPRs === true;
 				onlyMergedPRs = items.onlyMergedPRs === true;
-				if (onlyMergedPRs) {
-					onlyPRs = true;
-				}
-				console.log('[SCRUM-DEBUG] loaded flags:', { onlyIssues, onlyPRs, onlyRevPRs, onlyMergedPRs });
+				console.log('[SCRUM-DEBUG] loaded flags:', { onlyIssues, onlyPRs, onlyRevPRs });
 				// Enforce mutual exclusivity between onlyIssues and onlyPRs to avoid filtering out everything
 				if (onlyIssues && onlyPRs) {
 					console.warn('[SCRUM-HELPER]: Detected both onlyIssues and onlyPRs enabled; normalizing to onlyIssues.');
 					onlyPRs = false;
-					onlyMergedPRs = false;
 				}
 				showCommits = items.showCommits || false;
 				showOpenLabel = items.showOpenLabel !== false; // Default to true if not explicitly set to false


### PR DESCRIPTION
## Summary
Fixes #606

The `onlyMergedPRs` flag was declared and fetched from storage but never assigned to the local variable in `getChromeData()`. This caused the "Only Merged PRs" checkbox to have zero effect on the generated report -- all PRs always appeared regardless of the checkbox state.

## Root Cause
In src/scripts/scrumHelper.js lines 184-187, three flags are correctly loaded from storage:
onlyIssues  = items.onlyIssues  === true;
onlyPRs     = items.onlyPRs     === true;
onlyRevPRs  = items.onlyRevPRs  === true;

But onlyMergedPRs was missing from this block despite being declared at line 98 and fetched at line 142.

## Fix
Added one missing line in getChromeData():
onlyMergedPRs = items.onlyMergedPRs === true;

## How to Test
1. Load dist/chrome as unpacked extension in Chrome
2. Open extension popup
3. Enable "Only Merged PRs" checkbox
4. Enter any GitHub username and date range
5. Click Generate
6. Verify only merged PRs appear in the report
7. Disable checkbox and verify all PRs appear again

## Type of Change
- [x] Bug fix (non-breaking -- restores intended behavior)

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My change is limited to one line in one file
- [x] npm run build succeeds
- [x] npm run check passes
- [x] Linked to issue #606