### PR TITLE
fix: Issues without activity incorrectly shown as "Updated Issues

### DIFF
--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1804,12 +1804,36 @@ ${blockerText}`;
 					nextWeekArray.push(li2);
 				}
 
-				const today = new Date();
-				today.setHours(0, 0, 0, 0);
-				const itemCreatedDate = new Date(item.created_at);
-				itemCreatedDate.setHours(0, 0, 0, 0);
-				const isCreatedToday = today.getTime() === itemCreatedDate.getTime();
-				const issueActionText = isCreatedToday ? 'Opened Issue' : 'Updated Issue';
+				// Compute date range for filtering (same pattern as PR path above)
+				let issueStartDateFilter;
+				let issueEndDateFilter;
+				if (yesterdayContribution) {
+					const todayDate = new Date();
+					const yesterdayDate = new Date(todayDate.getTime() - 24 * 60 * 60 * 1000);
+					issueStartDateFilter = new Date(yesterdayDate.toISOString().split('T')[0] + 'T00:00:00Z');
+					issueEndDateFilter = new Date(todayDate.toISOString().split('T')[0] + 'T23:59:59Z');
+				} else if (startingDate && endingDate) {
+					issueStartDateFilter = new Date(startingDate + 'T00:00:00Z');
+					issueEndDateFilter = new Date(endingDate + 'T23:59:59Z');
+				} else {
+					const todayDate = new Date();
+					const lastWeek = new Date(todayDate.getFullYear(), todayDate.getMonth(), todayDate.getDate() - 7);
+					issueStartDateFilter = new Date(lastWeek.toISOString().split('T')[0] + 'T00:00:00Z');
+					issueEndDateFilter = new Date(todayDate.toISOString().split('T')[0] + 'T23:59:59Z');
+				}
+
+				const issueCreatedDate = new Date(item.created_at);
+				const issueUpdatedDate = new Date(item.updated_at);
+				const isNewIssue = issueCreatedDate >= issueStartDateFilter && issueCreatedDate <= issueEndDateFilter;
+				const isUpdatedInRange = issueUpdatedDate >= issueStartDateFilter && issueUpdatedDate <= issueEndDateFilter;
+
+				// Skip issues that were neither created nor updated within the selected date range
+				if (!isNewIssue && !isUpdatedInRange) {
+					log(`[ISSUE DEBUG] Skipping Issue #${number} - not created or updated in date range`);
+					continue;
+				}
+
+				const issueActionText = isNewIssue ? 'Opened Issue' : 'Updated Issue';
 				if (item.state === 'open') {
 					li = `<li><i>(${project})</i> - ${issueActionText}(#${number}) - <a href='${html_url}'>${title}</a>${showOpenLabel ? ' ' + issue_opened_button : ''}</li>`;
 				} else if (item.state === 'closed') {


### PR DESCRIPTION
Fixes #598

## Description

The issue path in `writeGithubIssuesPrs()` decides "Opened Issue" vs "Updated Issue" by comparing `created_at` against **today's date** not the selected reporting period. So any issue not created today gets labeled "Updated Issue", even if there was zero activity during the selected timeframe.

## What this PR does

- Computes the selected date range for issues (yesterday mode / custom range / default 7-day), following the same pattern already used for PRs in the same function
- Checks whether each issue was actually **created** or **updated** within that range
- Skips issues that fall outside the range entirely
- Labels correctly: "Opened Issue" if created within the range, "Updated Issue" if only updated


Before:
```js
const isCreatedToday = today.getTime() === itemCreatedDate.getTime();
const issueActionText = isCreatedToday ? 'Opened Issue' : 'Updated Issue';
```

After: date-range-aware filtering + classification is now matching the PR path pattern.
