### PR TITLE
fix: strip background when copying scrum report to clipboard

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -804,14 +804,19 @@ document.addEventListener('DOMContentLoaded', () => {
 			const tempDiv = document.createElement('div');
 			tempDiv.innerHTML = scrumReport.innerHTML;
 
-			// Strip background and background-color from all elements so the
-			// copied content pastes without the report container's background.
 			tempDiv.style.background = 'none';
 			tempDiv.style.backgroundColor = 'transparent';
 			tempDiv.querySelectorAll('*').forEach((el) => {
 				el.style.background = 'none';
 				el.style.backgroundColor = 'transparent';
 			});
+
+			const setButtonLabel = (iconClass, labelKey) => {
+				const icon = document.createElement('i');
+				icon.className = iconClass;
+				const label = document.createTextNode(` ${browser?.i18n.getMessage(labelKey)}`);
+				self.replaceChildren(icon, label);
+			};
 
 			const onCopySuccess = () => {
 				if (self._triggeredByShortcut) {
@@ -821,9 +826,9 @@ document.addEventListener('DOMContentLoaded', () => {
 							: 'copiedButton';
 					showShortcutNotification(notificationKey);
 				}
-				self.innerHTML = `<i class="fa fa-check"></i> ${browser?.i18n.getMessage('copiedButton')}`;
+				setButtonLabel('fa fa-check', 'copiedButton');
 				setTimeout(() => {
-					self.innerHTML = `<i class="fa fa-copy"></i> ${browser.i18n.getMessage('copyReportButton')}`;
+					setButtonLabel('fa fa-copy', 'copyReportButton');
 				}, 2000);
 				self._triggeredByShortcut = false;
 			};
@@ -834,15 +839,13 @@ document.addEventListener('DOMContentLoaded', () => {
 			};
 
 			if (navigator.clipboard && window.ClipboardItem) {
-				// Use the modern Clipboard API to write clean HTML and plain text.
 				const htmlBlob = new Blob([tempDiv.outerHTML], { type: 'text/html' });
-				const textBlob = new Blob([tempDiv.innerText], { type: 'text/plain' });
+				const textBlob = new Blob([tempDiv.textContent], { type: 'text/plain' });
 				navigator.clipboard
 					.write([new ClipboardItem({ 'text/html': htmlBlob, 'text/plain': textBlob })])
 					.then(onCopySuccess)
 					.catch(onCopyError);
 			} else {
-				// Fallback for browsers without Clipboard API support.
 				document.body.appendChild(tempDiv);
 				tempDiv.style.position = 'absolute';
 				tempDiv.style.left = '-9999px';

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -799,37 +799,69 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		copyBtn.addEventListener('click', function () {
 			const scrumReport = document.getElementById('scrumReport');
+			const self = this;
+
 			const tempDiv = document.createElement('div');
 			tempDiv.innerHTML = scrumReport.innerHTML;
-			document.body.appendChild(tempDiv);
-			tempDiv.style.position = 'absolute';
-			tempDiv.style.left = '-9999px';
 
-			const range = document.createRange();
-			range.selectNode(tempDiv);
-			const selection = window.getSelection();
-			selection.removeAllRanges();
-			selection.addRange(range);
+			// Strip background and background-color from all elements so the
+			// copied content pastes without the report container's background.
+			tempDiv.style.background = 'none';
+			tempDiv.style.backgroundColor = 'transparent';
+			tempDiv.querySelectorAll('*').forEach((el) => {
+				el.style.background = 'none';
+				el.style.backgroundColor = 'transparent';
+			});
 
-			try {
-				document.execCommand('copy');
-				if (this._triggeredByShortcut) {
+			const onCopySuccess = () => {
+				if (self._triggeredByShortcut) {
 					const notificationKey =
 						browser?.i18n && browser.i18n.getMessage('copiedReportNotification')
 							? 'copiedReportNotification'
 							: 'copiedButton';
 					showShortcutNotification(notificationKey);
 				}
-				this.innerHTML = `<i class="fa fa-check"></i> ${browser?.i18n.getMessage('copiedButton')}`;
+				self.innerHTML = `<i class="fa fa-check"></i> ${browser?.i18n.getMessage('copiedButton')}`;
 				setTimeout(() => {
-					this.innerHTML = `<i class="fa fa-copy"></i> ${browser.i18n.getMessage('copyReportButton')}`;
+					self.innerHTML = `<i class="fa fa-copy"></i> ${browser.i18n.getMessage('copyReportButton')}`;
 				}, 2000);
-			} catch (err) {
+				self._triggeredByShortcut = false;
+			};
+
+			const onCopyError = (err) => {
 				console.error('Failed to copy: ', err);
-			} finally {
-				this._triggeredByShortcut = false;
+				self._triggeredByShortcut = false;
+			};
+
+			if (navigator.clipboard && window.ClipboardItem) {
+				// Use the modern Clipboard API to write clean HTML and plain text.
+				const htmlBlob = new Blob([tempDiv.outerHTML], { type: 'text/html' });
+				const textBlob = new Blob([tempDiv.innerText], { type: 'text/plain' });
+				navigator.clipboard
+					.write([new ClipboardItem({ 'text/html': htmlBlob, 'text/plain': textBlob })])
+					.then(onCopySuccess)
+					.catch(onCopyError);
+			} else {
+				// Fallback for browsers without Clipboard API support.
+				document.body.appendChild(tempDiv);
+				tempDiv.style.position = 'absolute';
+				tempDiv.style.left = '-9999px';
+
+				const range = document.createRange();
+				range.selectNode(tempDiv);
+				const selection = window.getSelection();
 				selection.removeAllRanges();
-				document.body.removeChild(tempDiv);
+				selection.addRange(range);
+
+				try {
+					document.execCommand('copy');
+					onCopySuccess();
+				} catch (err) {
+					onCopyError(err);
+				} finally {
+					selection.removeAllRanges();
+					document.body.removeChild(tempDiv);
+				}
 			}
 		});
 


### PR DESCRIPTION
Fixes #605

When the Copy button was clicked, the report text was being copied along with its container's background color (bg-gray-100). This caused the gray background to appear when pasting into external applications.

Changes:
- Use the modern Clipboard API (navigator.clipboard.write + ClipboardItem) to write clean HTML and plain text to the clipboard.
- Before writing, strip background and background-color from the report content and all its child elements so only foreground badge colors are preserved.
- Keep a graceful execCommand fallback for browsers that do not support the Clipboard API, also applying the background-stripping there

## Summary by Sourcery

Ensure copying the scrum report writes background-free content to the clipboard while supporting modern and legacy clipboard APIs.

Bug Fixes:
- Prevent the scrum report from being copied with its gray background so pasted content no longer includes the container background color.

Enhancements:
- Adopt the modern Clipboard API with an execCommand fallback to copy both clean HTML and plain text representations of the scrum report.