### PR TITLE
Add Bitbucket support as platform option

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Berichten Sie über Ihren Entwicklungsfortschritt, indem Sie Ihre Git-Aktivität für einen ausgewählten Zeitraum automatisch abrufen"
-    },
-    "disableLabel": {
-        "message": "Deaktivieren"
-    },
-    "enableLabel": {
-        "message": "Aktivieren"
-    },
-    "projectNameLabel": {
-        "message": "Projektname (wird im E-Mail-Betreff verwendet)",
-        "description": "Label für das Betreff-Feld der E-Mail."
-    },
-    "projectNamePlaceholder": {
-        "message": "Geben Sie Ihren Projektnamen ein"
-    },
-    "githubUsernameLabel": {
-        "message": "Ihr GitHub-Benutzername"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Ihr GitLab-Benutzername"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Erforderlich, um Ihre Beiträge abzurufen"
-    },
-    "contributionsLabel": {
-        "message": "Ihre Beiträge abrufen für:"
-    },
-    "last1DayLabel": {
-        "message": "Vorheriger Tag"
-    },
-    "startDateLabel": {
-        "message": "Von:"
-    },
-    "endDateLabel": {
-        "message": "Bis:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Offen/Geschlossen-Status anzeigen"
-    },
-    "blockersLabel": {
-        "message": "Was hindert Sie am Fortschritt?"
-    },
-    "blockersPlaceholder": {
-        "message": "Geben Sie hier den Grund ein"
-    },
-    "scrumReportLabel": {
-        "message": "Scrum-Bericht"
-    },
-    "generateReportButton": {
-        "message": "Erstellen"
-    },
-    "copyReportButton": {
-        "message": "Kopieren"
-    },
-    "insertInEmailButton": {
-        "message": "In E-Mail einfügen"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Name der Organisation"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Namen der Organisation eingeben"
-    },
-    "setButton": {
-        "message": "Festlegen"
-    },
-    "githubTokenLabel": {
-        "message": "Ihr GitHub-Token"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Erforderlich für authentifizierte Anfragen"
-    },
-    "githubTokenTooltip": {
-        "message": "Warum wird empfohlen, ein GitHub-Token hinzuzufügen? Scrum Helper funktioniert ohne ein GitHub-Token, aber das Hinzufügen eines persönlichen Zugriffstokens wird für ein besseres Erlebnis empfohlen."
-    },
-    "gitlabTokenLabel": {
-        "message": "Ihr GitLab-Token"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Erforderlich für private Repos"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Warum wird empfohlen, ein GitLab-Token hinzuzufügen? Scrum Helper funktioniert ohne ein GitLab-Token für öffentliche Projekte, aber das Hinzufügen eines persönlichen Zugriffstokens wird für ein besseres Erlebnis empfohlen."
-    },
-    "showCommitsLabel": {
-        "message": "Commits in offenen PRs/ Entwurfs-PRs anzeigen"
-    },
-    "showCommitsTooltip": {
-        "message": "Github-Token erforderlich, bitte in den Einstellungen hinzufügen."
-    },
-    "onlyIssuesLabel": {
-        "message": "Nur Probleme in den Bericht aufnehmen"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Wenn diese Option aktiviert ist, enthält der Bericht nur Probleme, die vom Benutzer erstellt oder ihm zugewiesen wurden."
-    },
-    "onlyPRsLabel": {
-        "message": "Nur PRs in den Bericht aufnehmen"
-    },
-    "onlyPRsTooltip": {
-        "message": "Wenn diese Option aktiviert ist, enthält der Bericht nur von Ihnen erstellte Pull Requests; überprüfte PRs werden ausgeschlossen."
-    },
-    "cacheTTLLabel": {
-        "message": "Cache-TTL eingeben"
-    },
-    "cacheTTLUnit": {
-        "message": "(in Minuten)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Cache-TTL in Minuten (Standard: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Daten aktualisieren (Cache umgehen)"
-    },
-    "refreshDataInfo": {
-        "message": "Verwenden Sie diese Schaltfläche, um neue Daten sofort abzurufen."
-    },
-    "noteTitle": {
-        "message": "Hinweis:"
-    },
-    "viewCodeButton": {
-        "message": "Code ansehen"
-    },
-    "reportIssueButton": {
-        "message": "Problem melden"
-    },
-    "repoFilterLabel": {
-        "message": "Nach Repositories filtern"
-    },
-    "enableFilteringLabel": {
-        "message": "Filterung aktivieren"
-    },
-    "tokenRequiredWarning": {
-        "message": "Für die Repository-Filterung ist ein GitHub-Token erforderlich. Bitte fügen Sie einen in den Einstellungen hinzu."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Repository zum Hinzufügen suchen..."
-    },
-    "repoPlaceholder": {
-        "message": "Keine Repositories ausgewählt (alle werden einbezogen)"
-    },
-    "repoCountNone": {
-        "message": "0 Repositories ausgewählt"
-    },
-    "repoCount": {
-        "message": "$1 Repositories ausgewählt"
-    },
-    "repoLoading": {
-        "message": "Lade Repositories..."
-    },
-    "repoLoaded": {
-        "message": "$1 Repositories geladen."
-    },
-    "repoNotFound": {
-        "message": "Keine Repositories gefunden"
-    },
-    "repoRefetching": {
-        "message": "Lade Repositories neu..."
-    },
-    "repoLoadFailed": {
-        "message": "Laden der Repositories fehlgeschlagen."
-    },
-    "repoTokenPrivate": {
-        "message": "Token ist ungültig oder hat keine Rechte für private Repos."
-    },
-    "repoRefetchFailed": {
-        "message": "Neuladen der Repositories fehlgeschlagen."
-    },
-    "orgSetMessage": {
-        "message": "Organisation erfolgreich festgelegt."
-    },
-    "orgClearedMessage": {
-        "message": "Organisation gelöscht. Klicken Sie auf 'Bericht erstellen', um alle Aktivitäten abzurufen."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organisation auf GitHub nicht gefunden."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Fehler bei der Validierung der Organisation."
-    },
-    "refreshingButton": {
-        "message": "Wird aktualisiert..."
-    },
-    "cacheClearFailed": {
-        "message": "Cache-Löschung fehlgeschlagen."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Wird generiert..."
-    },
-    "copiedButton": {
-        "message": "Kopiert!"
-    },
-    "orgChangedMessage": {
-        "message": "Organisation geändert. Klicken Sie auf 'Bericht erstellen', um die GitHub-Aktivitäten abzurufen."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache erfolgreich geleert. Klicken Sie auf 'Bericht erstellen', um neue Daten abzurufen."
-    },
-    "cacheExpiredMessage": {
-        "message": "Cache abgelaufen. Klicken Sie auf \"Erstellen\", um neue Daten abzurufen.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Cache geleert!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Erweiterung ist deaktiviert. Aktivieren Sie sie in den Einstellungen, um Scrum-Berichte zu erstellen."
-    },
-    "notePoint1": {
-        "message": "Pull-Requests werden basierend auf der letzten Review-Aktivität eines beliebigen Beitragenden abgerufen, nicht nur Ihrer eigenen. Bitte überprüfen und passen Sie den generierten SCRUM-Bericht an, um sicherzustellen, dass er Ihre Arbeit korrekt widerspiegelt, bevor Sie ihn teilen."
-    },
-    "noteSeeIssue": {
-        "message": "Siehe dieses Issue"
-    },
-    "platformLabel": {
-        "message": "Plattform"
-    },
-    "usernameLabel": {
-        "message": "Ihr Benutzername"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Nur überprüfte PRs in den Bericht aufnehmen"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Wenn diese Option aktiviert ist, enthält der Bericht nur PRs, die von Ihnen überprüft wurden."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-   },
-        "usernameRequiredError": {
-        "message": "Bitte geben Sie Ihren Benutzernamen ein, um einen Bericht zu erstellen."
-    },
-    "unknownPlatformError": {
-        "message": "Unbekannte Plattform ausgewählt."
-    },
-    "gitlabFetchingError": {
-        "message": "Beim Abrufen der GitLab-Daten ist ein Fehler aufgetreten."
-    },
-    "reportGenerationError": {
-        "message": "Beim Erstellen des Berichts ist ein Fehler aufgetreten."
-    },
-    "githubUserNotFoundError": {
-        "message": "GitHub-Benutzer \"$1\" nicht gefunden (404). Bitte überprüfen Sie den Benutzernamen und versuchen Sie es erneut."
-    },
-    "githubUserValidationError": {
-        "message": "Fehler bei der Validierung des GitHub-Benutzers: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Ungültige Suchanfrage oder Datumsbereich. Bitte überprüfen Sie das Format Ihres Datumsbereichs und versuchen Sie es erneut."
-    },
-    "githubIssuesFetchError": {
-        "message": "Fehler beim Abrufen von GitHub-Issues: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Fehler beim Abrufen der GitHub-PR-Review-Daten: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Fehler beim Abrufen der GitHub-Benutzerdaten: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Ungültiges oder abgelaufenes GitHub-Token. Bitte überprüfen Sie Ihr Token in den Scrum Helper-Einstellungen und versuchen Sie es erneut."
-    },
-    "displayModeNotice": {
-        "message": "Die Erweiterung wird beim nächsten Start im $1-Modus geöffnet."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Repository-Filterung ist nur für GitHub verfügbar."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Repository-Laden ist nur für GitHub verfügbar."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Repository-Abruf ist nur für GitHub verfügbar."
-    },
-    "loadingReposAutomatically": {
-        "message": "Lade Repositories automatisch..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Fehler beim Abrufen des GitLab-Benutzers: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "GitLab-Benutzer '$1' nicht gefunden"
-    },
-    "gitlabMembershipError": {
-        "message": "Fehler beim Abrufen der GitLab-Mitgliedschaftsprojekte: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Fehler beim Abrufen der GitLab-Beitragsprojekte: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Benutzername erforderlich."
-    },
-    "generatingReportNotification": {
-        "message": "Bericht wird erstellt..."
-    },
-    "copyingReportNotification": {
-        "message": "Bericht wird kopiert..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Bericht wird in E-Mail eingefügt..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Bericht in E-Mail eingefügt!"
-    }
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "Berichten Sie über Ihren Entwicklungsfortschritt, indem Sie Ihre Git-Aktivität für einen ausgewählten Zeitraum automatisch abrufen"
+	},
+	"disableLabel": {
+		"message": "Deaktivieren"
+	},
+	"enableLabel": {
+		"message": "Aktivieren"
+	},
+	"projectNameLabel": {
+		"message": "Projektname (wird im E-Mail-Betreff verwendet)",
+		"description": "Label für das Betreff-Feld der E-Mail."
+	},
+	"projectNamePlaceholder": {
+		"message": "Geben Sie Ihren Projektnamen ein"
+	},
+	"githubUsernameLabel": {
+		"message": "Ihr GitHub-Benutzername"
+	},
+	"gitlabUsernameLabel": {
+		"message": "Ihr GitLab-Benutzername"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "Erforderlich, um Ihre Beiträge abzurufen"
+	},
+	"contributionsLabel": {
+		"message": "Ihre Beiträge abrufen für:"
+	},
+	"last1DayLabel": {
+		"message": "Vorheriger Tag"
+	},
+	"startDateLabel": {
+		"message": "Von:"
+	},
+	"endDateLabel": {
+		"message": "Bis:"
+	},
+	"showOpenClosedLabel": {
+		"message": "Offen/Geschlossen-Status anzeigen"
+	},
+	"blockersLabel": {
+		"message": "Was hindert Sie am Fortschritt?"
+	},
+	"blockersPlaceholder": {
+		"message": "Geben Sie hier den Grund ein"
+	},
+	"scrumReportLabel": {
+		"message": "Scrum-Bericht"
+	},
+	"generateReportButton": {
+		"message": "Erstellen"
+	},
+	"copyReportButton": {
+		"message": "Kopieren"
+	},
+	"insertInEmailButton": {
+		"message": "In E-Mail einfügen"
+	},
+	"settingsOrgNameLabel": {
+		"message": "Name der Organisation"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "Namen der Organisation eingeben"
+	},
+	"setButton": {
+		"message": "Festlegen"
+	},
+	"githubTokenLabel": {
+		"message": "Ihr GitHub-Token"
+	},
+	"githubTokenPlaceholder": {
+		"message": "Erforderlich für authentifizierte Anfragen"
+	},
+	"githubTokenTooltip": {
+		"message": "Warum wird empfohlen, ein GitHub-Token hinzuzufügen? Scrum Helper funktioniert ohne ein GitHub-Token, aber das Hinzufügen eines persönlichen Zugriffstokens wird für ein besseres Erlebnis empfohlen."
+	},
+	"gitlabTokenLabel": {
+		"message": "Ihr GitLab-Token"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "Erforderlich für private Repos"
+	},
+	"gitlabTokenTooltip": {
+		"message": "Warum wird empfohlen, ein GitLab-Token hinzuzufügen? Scrum Helper funktioniert ohne ein GitLab-Token für öffentliche Projekte, aber das Hinzufügen eines persönlichen Zugriffstokens wird für ein besseres Erlebnis empfohlen."
+	},
+	"showCommitsLabel": {
+		"message": "Commits in offenen PRs/ Entwurfs-PRs anzeigen"
+	},
+	"showCommitsTooltip": {
+		"message": "Github-Token erforderlich, bitte in den Einstellungen hinzufügen."
+	},
+	"onlyIssuesLabel": {
+		"message": "Nur Probleme in den Bericht aufnehmen"
+	},
+	"onlyIssuesTooltip": {
+		"message": "Wenn diese Option aktiviert ist, enthält der Bericht nur Probleme, die vom Benutzer erstellt oder ihm zugewiesen wurden."
+	},
+	"onlyPRsLabel": {
+		"message": "Nur PRs in den Bericht aufnehmen"
+	},
+	"onlyPRsTooltip": {
+		"message": "Wenn diese Option aktiviert ist, enthält der Bericht nur von Ihnen erstellte Pull Requests; überprüfte PRs werden ausgeschlossen."
+	},
+	"cacheTTLLabel": {
+		"message": "Cache-TTL eingeben"
+	},
+	"cacheTTLUnit": {
+		"message": "(in Minuten)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "Cache-TTL in Minuten (Standard: 10)"
+	},
+	"refreshDataButton": {
+		"message": "Daten aktualisieren (Cache umgehen)"
+	},
+	"refreshDataInfo": {
+		"message": "Verwenden Sie diese Schaltfläche, um neue Daten sofort abzurufen."
+	},
+	"noteTitle": {
+		"message": "Hinweis:"
+	},
+	"viewCodeButton": {
+		"message": "Code ansehen"
+	},
+	"reportIssueButton": {
+		"message": "Problem melden"
+	},
+	"repoFilterLabel": {
+		"message": "Nach Repositories filtern"
+	},
+	"enableFilteringLabel": {
+		"message": "Filterung aktivieren"
+	},
+	"tokenRequiredWarning": {
+		"message": "Für die Repository-Filterung ist ein GitHub-Token erforderlich. Bitte fügen Sie einen in den Einstellungen hinzu."
+	},
+	"repoSearchPlaceholder": {
+		"message": "Repository zum Hinzufügen suchen..."
+	},
+	"repoPlaceholder": {
+		"message": "Keine Repositories ausgewählt (alle werden einbezogen)"
+	},
+	"repoCountNone": {
+		"message": "0 Repositories ausgewählt"
+	},
+	"repoCount": {
+		"message": "$1 Repositories ausgewählt"
+	},
+	"repoLoading": {
+		"message": "Lade Repositories..."
+	},
+	"repoLoaded": {
+		"message": "$1 Repositories geladen."
+	},
+	"repoNotFound": {
+		"message": "Keine Repositories gefunden"
+	},
+	"repoRefetching": {
+		"message": "Lade Repositories neu..."
+	},
+	"repoLoadFailed": {
+		"message": "Laden der Repositories fehlgeschlagen."
+	},
+	"repoTokenPrivate": {
+		"message": "Token ist ungültig oder hat keine Rechte für private Repos."
+	},
+	"repoRefetchFailed": {
+		"message": "Neuladen der Repositories fehlgeschlagen."
+	},
+	"orgSetMessage": {
+		"message": "Organisation erfolgreich festgelegt."
+	},
+	"orgClearedMessage": {
+		"message": "Organisation gelöscht. Klicken Sie auf 'Bericht erstellen', um alle Aktivitäten abzurufen."
+	},
+	"orgNotFoundMessage": {
+		"message": "Organisation auf GitHub nicht gefunden."
+	},
+	"orgValidationErrorMessage": {
+		"message": "Fehler bei der Validierung der Organisation."
+	},
+	"refreshingButton": {
+		"message": "Wird aktualisiert..."
+	},
+	"cacheClearFailed": {
+		"message": "Cache-Löschung fehlgeschlagen."
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "Wird generiert..."
+	},
+	"copiedButton": {
+		"message": "Kopiert!"
+	},
+	"orgChangedMessage": {
+		"message": "Organisation geändert. Klicken Sie auf 'Bericht erstellen', um die GitHub-Aktivitäten abzurufen."
+	},
+	"cacheClearedMessage": {
+		"message": "Cache erfolgreich geleert. Klicken Sie auf 'Bericht erstellen', um neue Daten abzurufen."
+	},
+	"cacheExpiredMessage": {
+		"message": "Cache abgelaufen. Klicken Sie auf \"Erstellen\", um neue Daten abzurufen.",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "Cache geleert!"
+	},
+	"extensionDisabledMessage": {
+		"message": "Erweiterung ist deaktiviert. Aktivieren Sie sie in den Einstellungen, um Scrum-Berichte zu erstellen."
+	},
+	"notePoint1": {
+		"message": "Pull-Requests werden basierend auf der letzten Review-Aktivität eines beliebigen Beitragenden abgerufen, nicht nur Ihrer eigenen. Bitte überprüfen und passen Sie den generierten SCRUM-Bericht an, um sicherzustellen, dass er Ihre Arbeit korrekt widerspiegelt, bevor Sie ihn teilen."
+	},
+	"noteSeeIssue": {
+		"message": "Siehe dieses Issue"
+	},
+	"platformLabel": {
+		"message": "Plattform"
+	},
+	"usernameLabel": {
+		"message": "Ihr Benutzername"
+	},
+	"onlyRevPRsLabel": {
+		"message": "Nur überprüfte PRs in den Bericht aufnehmen"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "Wenn diese Option aktiviert ist, enthält der Bericht nur PRs, die von Ihnen überprüft wurden."
+	},
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"usernameRequiredError": {
+		"message": "Bitte geben Sie Ihren Benutzernamen ein, um einen Bericht zu erstellen."
+	},
+	"unknownPlatformError": {
+		"message": "Unbekannte Plattform ausgewählt."
+	},
+	"gitlabFetchingError": {
+		"message": "Beim Abrufen der GitLab-Daten ist ein Fehler aufgetreten."
+	},
+	"reportGenerationError": {
+		"message": "Beim Erstellen des Berichts ist ein Fehler aufgetreten."
+	},
+	"githubUserNotFoundError": {
+		"message": "GitHub-Benutzer \"$1\" nicht gefunden (404). Bitte überprüfen Sie den Benutzernamen und versuchen Sie es erneut."
+	},
+	"githubUserValidationError": {
+		"message": "Fehler bei der Validierung des GitHub-Benutzers: $1 $2"
+	},
+	"invalidSearchQueryError": {
+		"message": "Ungültige Suchanfrage oder Datumsbereich. Bitte überprüfen Sie das Format Ihres Datumsbereichs und versuchen Sie es erneut."
+	},
+	"githubIssuesFetchError": {
+		"message": "Fehler beim Abrufen von GitHub-Issues: $1 $2"
+	},
+	"githubPRReviewFetchError": {
+		"message": "Fehler beim Abrufen der GitHub-PR-Review-Daten: $1 $2"
+	},
+	"githubUserFetchError": {
+		"message": "Fehler beim Abrufen der GitHub-Benutzerdaten: $1 $2"
+	},
+	"invalidTokenError": {
+		"message": "Ungültiges oder abgelaufenes GitHub-Token. Bitte überprüfen Sie Ihr Token in den Scrum Helper-Einstellungen und versuchen Sie es erneut."
+	},
+	"displayModeNotice": {
+		"message": "Die Erweiterung wird beim nächsten Start im $1-Modus geöffnet."
+	},
+	"repoFilteringGithubOnly": {
+		"message": "Repository-Filterung ist nur für GitHub verfügbar."
+	},
+	"repoLoadingGithubOnly": {
+		"message": "Repository-Laden ist nur für GitHub verfügbar."
+	},
+	"repoFetchingGithubOnly": {
+		"message": "Repository-Abruf ist nur für GitHub verfügbar."
+	},
+	"loadingReposAutomatically": {
+		"message": "Lade Repositories automatisch..."
+	},
+	"gitlabUserFetchError": {
+		"message": "Fehler beim Abrufen des GitLab-Benutzers: $1 $2"
+	},
+	"gitlabUserNotFoundError": {
+		"message": "GitLab-Benutzer '$1' nicht gefunden"
+	},
+	"gitlabMembershipError": {
+		"message": "Fehler beim Abrufen der GitLab-Mitgliedschaftsprojekte: $1 $2"
+	},
+	"gitlabContributedError": {
+		"message": "Fehler beim Abrufen der GitLab-Beitragsprojekte: $1 $2"
+	},
+	"usernameMissingError": {
+		"message": "Benutzername erforderlich."
+	},
+	"generatingReportNotification": {
+		"message": "Bericht wird erstellt..."
+	},
+	"copyingReportNotification": {
+		"message": "Bericht wird kopiert..."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "Bericht wird in E-Mail eingefügt..."
+	},
+	"insertedInEmailNotification": {
+		"message": "Bericht in E-Mail eingefügt!"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/el/messages.json
+++ b/src/_locales/el/messages.json
@@ -1,236 +1,260 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Αναφέρετε την πρόοδο της ανάπτυξής σας ανακτώντας αυτόματα τη δραστηριότητα Git για μια επιλεγμένη περίοδο"
-    },
-    "disableLabel": {
-        "message": "Απενεργοποίηση"
-    },
-    "enableLabel": {
-        "message": "Ενεργοποίηση"
-    },
-    "projectNameLabel": {
-        "message": "Όνομα Έργου (χρησιμοποιείται στο θέμα του email)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Εισαγάγετε το όνομα του έργου σας"
-    },
-    "githubUsernameLabel": {
-        "message": "Το όνομα χρήστη σας στο GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Το όνομα χρήστη σας στο GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Απαιτείται για την ανάκτηση των συνεισφορών σας"
-    },
-    "contributionsLabel": {
-        "message": "Ανακτήστε τις συνεισφορές σας μεταξύ:"
-    },
-    "last1DayLabel": {
-        "message": "Προηγούμενη ημέρα"
-    },
-    "startDateLabel": {
-        "message": "Από:"
-    },
-    "endDateLabel": {
-        "message": "Έως:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Εμφάνιση ετικετών PR"
-    },
-    "blockersLabel": {
-        "message": "Τι σας εμποδίζει να προχωρήσετε;"
-    },
-    "blockersPlaceholder": {
-        "message": "Εισαγάγετε τον λόγο σας"
-    },
-    "scrumReportLabel": {
-        "message": "Αναφορά Scrum"
-    },
-    "generateReportButton": {
-        "message": "Δημιουργία"
-    },
-    "copyReportButton": {
-        "message": "Αντιγραφή"
-    },
-    "insertInEmailButton": {
-        "message": "Εισαγωγή σε email"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Όνομα οργανισμού"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Εισαγάγετε το όνομα του οργανισμού"
-    },
-    "setButton": {
-        "message": "Ορισμός"
-    },
-    "githubTokenLabel": {
-        "message": "Το GitHub token σας"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Απαιτείται για την υποβολή αιτημάτων με έλεγχο ταυτότητας"
-    },
-    "githubTokenTooltip": {
-        "message": "Γιατί συνιστάται η προσθήκη GitHub token; Το Scrum Helper λειτουργεί χωρίς GitHub token, αλλά η προσθήκη ενός προσωπικού token πρόσβασης συνιστάται για καλύτερη εμπειρία."
-    },
-    "gitlabTokenLabel": {
-        "message": "Το GitLab token σας"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Απαιτείται για πρόσβαση σε ιδιωτικά έργα"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Γιατί συνιστάται η προσθήκη GitLab token; Το Scrum Helper λειτουργεί χωρίς GitLab token για δημόσια έργα, αλλά η προσθήκη ενός προσωπικού token πρόσβασης συνιστάται για καλύτερη εμπειρία."
-    },
-    "showCommitsLabel": {
-        "message": "Εμφάνιση commits σε ανοιχτά PR / πρόχειρα PR"
-    },
-    "showCommitsTooltip": {
-        "message": "Απαιτείται GitHub token, προσθέστε το στις ρυθμίσεις."
-    },
-    "onlyIssuesLabel": {
-        "message": "Συμπερίληψη μόνο ζητημάτων στην αναφορά"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Εάν επιλεγεί, η αναφορά θα περιλαμβάνει μόνο ζητήματα που δημιουργήθηκαν ή ανατέθηκαν στον χρήστη."
-    },
-    "onlyPRsLabel": {
-        "message": "Συμπερίληψη μόνο PR στην αναφορά"
-    },
-    "onlyPRsTooltip": {
-        "message": "Εάν επιλεγεί, η αναφορά θα περιλαμβάνει μόνο PR που δημιουργήθηκαν από τον χρήστη. Τα αναθεωρημένα PR θα εξαιρεθούν."
-    },
-    "cacheTTLLabel": {
-        "message": "Εισαγάγετε TTL cache"
-    },
-    "cacheTTLUnit": {
-        "message": "(σε λεπτά)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Εισαγάγετε TTL cache σε λεπτά (Προεπιλογή: 10 λεπτά)"
-    },
-    "refreshDataButton": {
-        "message": "Ανανέωση δεδομένων (παράκαμψη cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Χρησιμοποιήστε αυτό το κουμπί για άμεση ανάκτηση νέων δεδομένων."
-    },
-    "noteTitle": {
-        "message": "Σημείωση:"
-    },
-    "viewCodeButton": {
-        "message": "Προβολή κώδικα"
-    },
-    "reportIssueButton": {
-        "message": "Αναφορά προβλήματος"
-    },
-    "repoFilterLabel": {
-        "message": "Φιλτράρισμα κατά αποθετήρια"
-    },
-    "enableFilteringLabel": {
-        "message": "Ενεργοποίηση φιλτραρίσματος"
-    },
-    "tokenRequiredWarning": {
-        "message": "Απαιτείται GitHub token για φιλτράρισμα αποθετηρίων. Παρακαλώ προσθέστε ένα στις ρυθμίσεις."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "Απαιτείται GitHub token για εμφάνιση commits σε ανοιχτά ή πρόχειρα PR. Παρακαλώ προσθέστε ένα στις ρυθμίσεις."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Αναζητήστε ένα αποθετήριο για προσθήκη..."
-    },
-    "repoPlaceholder": {
-        "message": "Δεν επιλέχθηκαν αποθετήρια (θα συμπεριληφθούν όλα)"
-    },
-    "repoCountNone": {
-        "message": "0 αποθετήρια επιλεγμένα"
-    },
-    "repoCount": {
-        "message": "$1 αποθετήρια επιλεγμένα"
-    },
-    "repoLoading": {
-        "message": "Φόρτωση αποθετηρίων..."
-    },
-    "repoLoaded": {
-        "message": "Φορτώθηκαν $1 αποθετήρια."
-    },
-    "repoNotFound": {
-        "message": "Δεν βρέθηκαν αποθετήρια"
-    },
-    "repoRefetching": {
-        "message": "Επαναφόρτωση αποθετηρίων..."
-    },
-    "repoLoadFailed": {
-        "message": "Αποτυχία φόρτωσης αποθετηρίων."
-    },
-    "repoTokenPrivate": {
-        "message": "Το token είναι άκυρο ή δεν έχει δικαιώματα για ιδιωτικά αποθετήρια."
-    },
-    "repoRefetchFailed": {
-        "message": "Αποτυχία επαναφόρτωσης αποθετηρίων."
-    },
-    "orgSetMessage": {
-        "message": "Ο οργανισμός ορίστηκε επιτυχώς."
-    },
-    "orgClearedMessage": {
-        "message": "Ο οργανισμός διαγράφηκε. Κάντε κλικ στο 'Δημιουργία' για ανάκτηση όλων των δραστηριοτήτων."
-    },
-    "orgNotFoundMessage": {
-        "message": "Ο οργανισμός δεν βρέθηκε στο GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Σφάλμα κατά την επαλήθευση του οργανισμού."
-    },
-    "refreshingButton": {
-        "message": "Ανανέωση..."
-    },
-    "cacheClearFailed": {
-        "message": "Αποτυχία εκκαθάρισης cache."
-    },
-    "madeWithLoveBy": {
-        "message": "Φτιαγμένο με ❤️ από"
-    },
-    "generatingButton": {
-        "message": "Δημιουργία..."
-    },
-    "copiedButton": {
-        "message": "Αντιγράφηκε!"
-    },
-    "orgChangedMessage": {
-        "message": "Ο οργανισμός άλλαξε. Κάντε κλικ στο κουμπί 'Δημιουργία' για ανάκτηση δραστηριοτήτων GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Το cache εκκαθαρίστηκε επιτυχώς. Κάντε κλικ στο «Δημιουργία» για ανάκτηση νέων δεδομένων."
-    },
-    "cacheExpiredMessage": {
-        "message": "Το cache έληξε. Κάντε κλικ στο «Δημιουργία» για ανάκτηση νέων δεδομένων."
-    },
-    "cacheClearedButton": {
-        "message": "Το cache εκκαθαρίστηκε!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Η επέκταση είναι απενεργοποιημένη. Ενεργοποιήστε τη από τις επιλογές για δημιουργία αναφορών Scrum."
-    },
-    "notePoint1": {
-        "message": "Τα pull requests ανακτώνται βάσει της πιο πρόσφατης δραστηριότητας αναθεώρησης από οποιονδήποτε συντελεστή, όχι μόνο τη δική σας. Παρακαλώ ελέγξτε και προσαρμόστε την παραγόμενη αναφορά SCRUM για να διασφαλίσετε ότι αντικατοπτρίζει με ακρίβεια την εργασία σας πριν την κοινοποίηση."
-    },
-    "noteSeeIssue": {
-        "message": "Δείτε αυτό το ζήτημα"
-    },
-    "platformLabel": {
-        "message": "Πλατφόρμα"
-    },
-    "usernameLabel": {
-        "message": "Το όνομα χρήστη σας"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Συμπερίληψη μόνο αναθεωρημένων PR στην αναφορά"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Εάν επιλεγεί, η αναφορά θα περιλαμβάνει μόνο PR που έχετε αναθεωρήσει εσείς."
-    }
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "Αναφέρετε την πρόοδο της ανάπτυξής σας ανακτώντας αυτόματα τη δραστηριότητα Git για μια επιλεγμένη περίοδο"
+	},
+	"disableLabel": {
+		"message": "Απενεργοποίηση"
+	},
+	"enableLabel": {
+		"message": "Ενεργοποίηση"
+	},
+	"projectNameLabel": {
+		"message": "Όνομα Έργου (χρησιμοποιείται στο θέμα του email)"
+	},
+	"projectNamePlaceholder": {
+		"message": "Εισαγάγετε το όνομα του έργου σας"
+	},
+	"githubUsernameLabel": {
+		"message": "Το όνομα χρήστη σας στο GitHub"
+	},
+	"gitlabUsernameLabel": {
+		"message": "Το όνομα χρήστη σας στο GitLab"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "Απαιτείται για την ανάκτηση των συνεισφορών σας"
+	},
+	"contributionsLabel": {
+		"message": "Ανακτήστε τις συνεισφορές σας μεταξύ:"
+	},
+	"last1DayLabel": {
+		"message": "Προηγούμενη ημέρα"
+	},
+	"startDateLabel": {
+		"message": "Από:"
+	},
+	"endDateLabel": {
+		"message": "Έως:"
+	},
+	"showOpenClosedLabel": {
+		"message": "Εμφάνιση ετικετών PR"
+	},
+	"blockersLabel": {
+		"message": "Τι σας εμποδίζει να προχωρήσετε;"
+	},
+	"blockersPlaceholder": {
+		"message": "Εισαγάγετε τον λόγο σας"
+	},
+	"scrumReportLabel": {
+		"message": "Αναφορά Scrum"
+	},
+	"generateReportButton": {
+		"message": "Δημιουργία"
+	},
+	"copyReportButton": {
+		"message": "Αντιγραφή"
+	},
+	"insertInEmailButton": {
+		"message": "Εισαγωγή σε email"
+	},
+	"settingsOrgNameLabel": {
+		"message": "Όνομα οργανισμού"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "Εισαγάγετε το όνομα του οργανισμού"
+	},
+	"setButton": {
+		"message": "Ορισμός"
+	},
+	"githubTokenLabel": {
+		"message": "Το GitHub token σας"
+	},
+	"githubTokenPlaceholder": {
+		"message": "Απαιτείται για την υποβολή αιτημάτων με έλεγχο ταυτότητας"
+	},
+	"githubTokenTooltip": {
+		"message": "Γιατί συνιστάται η προσθήκη GitHub token; Το Scrum Helper λειτουργεί χωρίς GitHub token, αλλά η προσθήκη ενός προσωπικού token πρόσβασης συνιστάται για καλύτερη εμπειρία."
+	},
+	"gitlabTokenLabel": {
+		"message": "Το GitLab token σας"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "Απαιτείται για πρόσβαση σε ιδιωτικά έργα"
+	},
+	"gitlabTokenTooltip": {
+		"message": "Γιατί συνιστάται η προσθήκη GitLab token; Το Scrum Helper λειτουργεί χωρίς GitLab token για δημόσια έργα, αλλά η προσθήκη ενός προσωπικού token πρόσβασης συνιστάται για καλύτερη εμπειρία."
+	},
+	"showCommitsLabel": {
+		"message": "Εμφάνιση commits σε ανοιχτά PR / πρόχειρα PR"
+	},
+	"showCommitsTooltip": {
+		"message": "Απαιτείται GitHub token, προσθέστε το στις ρυθμίσεις."
+	},
+	"onlyIssuesLabel": {
+		"message": "Συμπερίληψη μόνο ζητημάτων στην αναφορά"
+	},
+	"onlyIssuesTooltip": {
+		"message": "Εάν επιλεγεί, η αναφορά θα περιλαμβάνει μόνο ζητήματα που δημιουργήθηκαν ή ανατέθηκαν στον χρήστη."
+	},
+	"onlyPRsLabel": {
+		"message": "Συμπερίληψη μόνο PR στην αναφορά"
+	},
+	"onlyPRsTooltip": {
+		"message": "Εάν επιλεγεί, η αναφορά θα περιλαμβάνει μόνο PR που δημιουργήθηκαν από τον χρήστη. Τα αναθεωρημένα PR θα εξαιρεθούν."
+	},
+	"cacheTTLLabel": {
+		"message": "Εισαγάγετε TTL cache"
+	},
+	"cacheTTLUnit": {
+		"message": "(σε λεπτά)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "Εισαγάγετε TTL cache σε λεπτά (Προεπιλογή: 10 λεπτά)"
+	},
+	"refreshDataButton": {
+		"message": "Ανανέωση δεδομένων (παράκαμψη cache)"
+	},
+	"refreshDataInfo": {
+		"message": "Χρησιμοποιήστε αυτό το κουμπί για άμεση ανάκτηση νέων δεδομένων."
+	},
+	"noteTitle": {
+		"message": "Σημείωση:"
+	},
+	"viewCodeButton": {
+		"message": "Προβολή κώδικα"
+	},
+	"reportIssueButton": {
+		"message": "Αναφορά προβλήματος"
+	},
+	"repoFilterLabel": {
+		"message": "Φιλτράρισμα κατά αποθετήρια"
+	},
+	"enableFilteringLabel": {
+		"message": "Ενεργοποίηση φιλτραρίσματος"
+	},
+	"tokenRequiredWarning": {
+		"message": "Απαιτείται GitHub token για φιλτράρισμα αποθετηρίων. Παρακαλώ προσθέστε ένα στις ρυθμίσεις."
+	},
+	"tokenRequiredShowCommitsWarning": {
+		"message": "Απαιτείται GitHub token για εμφάνιση commits σε ανοιχτά ή πρόχειρα PR. Παρακαλώ προσθέστε ένα στις ρυθμίσεις."
+	},
+	"repoSearchPlaceholder": {
+		"message": "Αναζητήστε ένα αποθετήριο για προσθήκη..."
+	},
+	"repoPlaceholder": {
+		"message": "Δεν επιλέχθηκαν αποθετήρια (θα συμπεριληφθούν όλα)"
+	},
+	"repoCountNone": {
+		"message": "0 αποθετήρια επιλεγμένα"
+	},
+	"repoCount": {
+		"message": "$1 αποθετήρια επιλεγμένα"
+	},
+	"repoLoading": {
+		"message": "Φόρτωση αποθετηρίων..."
+	},
+	"repoLoaded": {
+		"message": "Φορτώθηκαν $1 αποθετήρια."
+	},
+	"repoNotFound": {
+		"message": "Δεν βρέθηκαν αποθετήρια"
+	},
+	"repoRefetching": {
+		"message": "Επαναφόρτωση αποθετηρίων..."
+	},
+	"repoLoadFailed": {
+		"message": "Αποτυχία φόρτωσης αποθετηρίων."
+	},
+	"repoTokenPrivate": {
+		"message": "Το token είναι άκυρο ή δεν έχει δικαιώματα για ιδιωτικά αποθετήρια."
+	},
+	"repoRefetchFailed": {
+		"message": "Αποτυχία επαναφόρτωσης αποθετηρίων."
+	},
+	"orgSetMessage": {
+		"message": "Ο οργανισμός ορίστηκε επιτυχώς."
+	},
+	"orgClearedMessage": {
+		"message": "Ο οργανισμός διαγράφηκε. Κάντε κλικ στο 'Δημιουργία' για ανάκτηση όλων των δραστηριοτήτων."
+	},
+	"orgNotFoundMessage": {
+		"message": "Ο οργανισμός δεν βρέθηκε στο GitHub."
+	},
+	"orgValidationErrorMessage": {
+		"message": "Σφάλμα κατά την επαλήθευση του οργανισμού."
+	},
+	"refreshingButton": {
+		"message": "Ανανέωση..."
+	},
+	"cacheClearFailed": {
+		"message": "Αποτυχία εκκαθάρισης cache."
+	},
+	"madeWithLoveBy": {
+		"message": "Φτιαγμένο με ❤️ από"
+	},
+	"generatingButton": {
+		"message": "Δημιουργία..."
+	},
+	"copiedButton": {
+		"message": "Αντιγράφηκε!"
+	},
+	"orgChangedMessage": {
+		"message": "Ο οργανισμός άλλαξε. Κάντε κλικ στο κουμπί 'Δημιουργία' για ανάκτηση δραστηριοτήτων GitHub."
+	},
+	"cacheClearedMessage": {
+		"message": "Το cache εκκαθαρίστηκε επιτυχώς. Κάντε κλικ στο «Δημιουργία» για ανάκτηση νέων δεδομένων."
+	},
+	"cacheExpiredMessage": {
+		"message": "Το cache έληξε. Κάντε κλικ στο «Δημιουργία» για ανάκτηση νέων δεδομένων."
+	},
+	"cacheClearedButton": {
+		"message": "Το cache εκκαθαρίστηκε!"
+	},
+	"extensionDisabledMessage": {
+		"message": "Η επέκταση είναι απενεργοποιημένη. Ενεργοποιήστε τη από τις επιλογές για δημιουργία αναφορών Scrum."
+	},
+	"notePoint1": {
+		"message": "Τα pull requests ανακτώνται βάσει της πιο πρόσφατης δραστηριότητας αναθεώρησης από οποιονδήποτε συντελεστή, όχι μόνο τη δική σας. Παρακαλώ ελέγξτε και προσαρμόστε την παραγόμενη αναφορά SCRUM για να διασφαλίσετε ότι αντικατοπτρίζει με ακρίβεια την εργασία σας πριν την κοινοποίηση."
+	},
+	"noteSeeIssue": {
+		"message": "Δείτε αυτό το ζήτημα"
+	},
+	"platformLabel": {
+		"message": "Πλατφόρμα"
+	},
+	"usernameLabel": {
+		"message": "Το όνομα χρήστη σας"
+	},
+	"onlyRevPRsLabel": {
+		"message": "Συμπερίληψη μόνο αναθεωρημένων PR στην αναφορά"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "Εάν επιλεγεί, η αναφορά θα περιλαμβάνει μόνο PR που έχετε αναθεωρήσει εσείς."
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,440 +1,464 @@
 {
-  "appName": {
-    "message": "Scrum Helper",
-    "description": "The name of the extension."
-  },
-  "appDescription": {
-    "message": "Report your development progress by auto-fetching your Git activity for a selected period",
-    "description": "A brief description of what the extension does."
-  },
-  "disableLabel": {
-    "message": "Disable",
-    "description": "Label for the toggle switch to disable the extension."
-  },
-  "enableLabel": {
-    "message": "Enable",
-    "description": "Label for the toggle switch to enable the extension."
-  },
-  "projectNameLabel": {
-    "message": "Project Name (used in email subject)",
-    "description": "Label for the project name input field."
-  },
-  "projectNamePlaceholder": {
-    "message": "Enter your project name",
-    "description": "Placeholder text for the project name input."
-  },
-  "githubUsernameLabel": {
-    "message": "Your Github Username",
-    "description": "Label for the GitHub username input field."
-  },
-  "gitlabUsernameLabel": {
-    "message": "Your GitLab Username",
-    "description": "Label for the GitLab username input field."
-  },
-  "githubUsernamePlaceholder": {
-    "message": "Required for fetching your contributions",
-    "description": "Placeholder text for the GitHub username input."
-  },
-  "contributionsLabel": {
-    "message": "Fetch your contributions between:",
-    "description": "Label for the date range selection."
-  },
-  "last1DayLabel": {
-    "message": "Previous day",
-    "description": "Radio button option for the last 1 day."
-  },
-  "startDateLabel": {
-    "message": "From:",
-    "description": "Label for the start date picker."
-  },
-  "endDateLabel": {
-    "message": "To:",
-    "description": "Label for the end date picker."
-  },
-  "showOpenClosedLabel": {
-    "message": "Show PRs Labels",
-    "description": "Label for the checkbox to show PR labels."
-  },
-  "blockersLabel": {
-    "message": "What is blocking you from making progress?",
-    "description": "Label for the input field for blockers."
-  },
-  "blockersPlaceholder": {
-    "message": "Enter your reason",
-    "description": "Placeholder text for the blockers input field."
-  },
-  "scrumReportLabel": {
-    "message": "Scrum Report"
-  },
-  "generateReportButton": {
-    "message": "Generate",
-    "description": "Text for the 'Generate' button."
-  },
-  "copyReportButton": {
-    "message": "Copy",
-    "description": "Text for the 'Copy' button."
-  },
-  "insertInEmailButton": {
-    "message": "Insert to Email",
-    "description": "Text for the 'Insert to Email' button."
-  },
-  "insertToEmailFailedError": {
-    "message": "Open an email tab to insert report",
-    "description": "Error message shown when no active email tab can receive insert action."
-  },
-  "settingsOrgNameLabel": {
-    "message": "Organization Name",
-    "description": "Label for the organization name input in settings."
-  },
-  "settingsOrgNamePlaceholder": {
-    "message": "Enter organization name",
-    "description": "Placeholder for the organization name input."
-  },
-  "setButton": {
-    "message": "Set",
-    "description": "Text for the 'Set' button for the organization."
-  },
-  "githubTokenLabel": {
-    "message": "Your Github Token",
-    "description": "Label for the GitHub token input."
-  },
-  "githubTokenPlaceholder": {
-    "message": "Required for making authenticated requests",
-    "description": "Placeholder for the GitHub token input."
-  },
-  "githubTokenTooltip": {
-    "message": "Why is it recommended to add a GitHub token? Scrum Helper works without a GitHub token, but adding a personal access token is recommended for a better experience.",
-    "description": "Tooltip for GitHub token explaining why it's needed."
-  },
-  "gitlabTokenLabel": {
-    "message": "Your GitLab Token",
-    "description": "Label for the GitLab token input."
-  },
-  "gitlabTokenPlaceholder": {
-    "message": "Required for accessing private projects",
-    "description": "Placeholder for the GitLab token input."
-  },
-  "gitlabTokenTooltip": {
-    "message": "Why is it recommended to add a GitLab token? Scrum Helper works without a GitLab token for public projects, but adding a personal access token is recommended for a better experience.",
-    "description": "Tooltip for GitLab token explaining why it's needed."
-  },
-  "showCommitsLabel": {
-    "message": "Show commits on open PRs/ draft PRs",
-    "description": "Label for the checkbox to show commits in open PRs."
-  },
-  "showCommitsTooltip": {
-    "message": "Github Token required, add it in the settings."
-  },
-  "onlyIssuesLabel": {
-    "message": "Include only issues in the report"
-  },
-  "onlyIssuesTooltip": {
-    "message": "If checked, the report will only include issues created or assigned to the user."
-  },
-  "onlyPRsLabel": {
-    "message": "Include only PRs in the report"
-  },
-  "onlyPRsTooltip": {
-    "message": "If checked, the report will only include PRs created by the user. Reviewed PRs will be excluded."
-  },
-  "cacheTTLLabel": {
-    "message": "Enter cache TTL",
-    "description": "Label for the cache time-to-live input."
-  },
-  "cacheTTLUnit": {
-    "message": "(in minutes)",
-    "description": "Unit for the cache TTL."
-  },
-  "cacheTTLPlaceholder": {
-    "message": "Write Cache TTL in minutes (Default 10 minutes)",
-    "description": "Placeholder for the cache TTL input."
-  },
-  "refreshDataButton": {
-    "message": "Refresh Data (bypass cache)",
-    "description": "Text for the button to refresh data, ignoring the cache."
-  },
-  "refreshDataInfo": {
-    "message": "Use this button to fetch fresh data immediately.",
-    "description": "Informational text below the refresh button."
-  },
-  "noteTitle": {
-    "message": "Note:",
-    "description": "Title for the notes section."
-  },
-  "viewCodeButton": {
-    "message": "View Code",
-    "description": "Text for the button to view the source code on GitHub."
-  },
-  "reportIssueButton": {
-    "message": "Report Issue",
-    "description": "Text for the button to report an issue on GitHub."
-  },
-  "repoFilterLabel": {
-    "message": "Filter by repositories",
-    "description": "Label for the repository filter section."
-  },
-  "enableFilteringLabel": {
-    "message": "Enable filtering",
-    "description": "Label for the checkbox to enable repository filtering."
-  },
-  "tokenRequiredWarning": {
-    "message": "A GitHub token is required for repository filtering. Please add one in the settings.",
-    "description": "Warning message shown when repo filtering is enabled without a token."
-  },
-  "tokenRequiredShowCommitsWarning": {
-    "message": "A GitHub token is required to show commits on open or draft PRs. Please add one in the settings.",
-    "description": "Warning message shown when show commits is enabled without a token."
-  },
-  "repoSearchPlaceholder": {
-    "message": "Search for a repository to add...",
-    "description": "Placeholder for the repository search input."
-  },
-  "repoPlaceholder": {
-    "message": "No repositories selected (all will be included)",
-    "description": "Placeholder text when no repositories are selected for filtering."
-  },
-  "repoCountNone": {
-    "message": "0 repositories selected",
-    "description": "Text showing the count of selected repositories when it's zero."
-  },
-  "repoCount": {
-    "message": "$1 repositories selected",
-    "description": "Text showing the count of selected repositories. $1 is a placeholder for the number."
-  },
-  "repoLoading": {
-    "message": "Loading repositories...",
-    "description": "Status message when repositories are being loaded."
-  },
-  "repoLoaded": {
-    "message": "Loaded $1 repositories.",
-    "description": "Status message after repositories have been successfully loaded. $1 is a placeholder for the number."
-  },
-  "repoNotFound": {
-    "message": "No repositories found",
-    "description": "Message shown in the dropdown when a search yields no results."
-  },
-  "repoRefetching": {
-    "message": "Refetching repositories...",
-    "description": "Status message when repositories are being refetched."
-  },
-  "repoLoadFailed": {
-    "message": "Failed to load repositories.",
-    "description": "Error message when repository loading fails."
-  },
-  "repoTokenPrivate": {
-    "message": "Token is invalid or does not have rights for private repos.",
-    "description": "Error message when the token is invalid or lacks permissions."
-  },
-  "repoRefetchFailed": {
-    "message": "Failed to refetch repositories.",
-    "description": "Error message when refetching repositories fails."
-  },
-  "orgSetMessage": {
-    "message": "Organization set successfully.",
-    "description": "Success toast message when an organization is set."
-  },
-  "orgClearedMessage": {
-    "message": "Organization cleared. Click 'Generate' to fetch all activities.",
-    "description": "Message shown when the organization is cleared."
-  },
-  "orgNotFoundMessage": {
-    "message": "Organization not found on GitHub.",
-    "description": "Error toast message when an organization is not found."
-  },
-  "orgValidationErrorMessage": {
-    "message": "Error validating organization.",
-    "description": "Error toast message for general organization validation errors."
-  },
-  "refreshingButton": {
-    "message": "Refreshing...",
-    "description": "Text on the refresh button while it's in a loading state."
-  },
-  "cacheClearFailed": {
-    "message": "Cache clear failed.",
-    "description": "Error message when clearing the cache fails."
-  },
-  "madeWithLoveBy": {
-    "message": "Made with ❤️ by",
-    "description": "Footer credit text."
-  },
-  "generatingButton": {
-    "message": "Generating...",
-    "description": "Text shown on the generate button when the report is being created."
-  },
-  "copiedButton": {
-    "message": "Copied!",
-    "description": "Text shown on the copy button after a successful copy."
-  },
-  "orgChangedMessage": {
-    "message": "Organization changed. Click Generate button to fetch the GitHub activities.",
-    "description": "Message shown in the report area after the organization is changed."
-  },
-  "cacheClearedMessage": {
-    "message": "Cache cleared successfully. Click \"Generate\" to fetch fresh data.",
-    "description": "Message shown in the report area after the cache is cleared."
-  },
-  "cacheExpiredMessage": {
-    "message": "Cache expired. Click \"Generate\" to fetch fresh data.",
-    "description": "Message shown when the cached data has expired and user needs to regenerate."
-  },
-  "cacheClearedButton": {
-    "message": "Cache Cleared!",
-    "description": "Text on the refresh button after the cache is cleared."
-  },
-  "extensionDisabledMessage": {
-    "message": "Extension is disabled. Enable it from the options to generate scrum reports.",
-    "description": "Message shown when the extension is disabled."
-  },
-  "notePoint1": {
-    "message": "Pull requests are fetched based on the most recent review activity by any contributor, not just your own. Please review and adjust the generated SCRUM report to ensure it accurately reflects your work before sharing.",
-    "description": "First point in the notes section."
-  },
-  "noteSeeIssue": {
-    "message": "See this issue",
-    "description": "Link text for the GitHub issue in the notes."
-  },
-  "platformLabel": {
-    "message": "Platform",
-    "description": "Label for the platform selection header."
-  },
-  "usernameLabel": {
-    "message": "Your Username",
-    "description": "Label for the username input header."
-  },
-  "onlyRevPRsLabel": {
-    "message": "Include only reviewed PRs in the report",
-    "description": "Label for the checkbox to include only reviewed PRs."
-  },
-  "onlyRevPRsTooltip": {
-    "message": "If checked, the report will only include PRs reviewed by you.",
-    "description": "Tooltip for the reviewed PRs filter checkbox."
-  },
-  "onlyMergedPRsLabel": {
-    "message": "Include only merged PRs in the report",
-    "description": "Label for the checkbox to include only merged PRs."
-  },
-  "onlyMergedPRsTooltip": {
-    "message": "If checked, the report will only include PRs that have been merged. A GitHub token is required.",
-    "description": "Tooltip for the merged PRs filter checkbox."
-  },
-  "tokenRequiredMergedPRsWarning": {
-    "message": "A GitHub token is required to filter by merged PRs. Please add one in the settings.",
-    "description": "Warning shown when merged PRs filter is enabled without a GitHub token."
-  },
-  "usernameRequiredError": {
-    "message": "Please enter your username to generate a report.",
-    "description": "Error shown when username is missing."
-  },
-  "unknownPlatformError": {
-    "message": "Unknown platform selected.",
-    "description": "Error shown when an unsupported platform is selected."
-  },
-  "gitlabFetchingError": {
-    "message": "An error occurred while fetching GitLab data.",
-    "description": "Error shown when GitLab data fetch fails."
-  },
-  "reportGenerationError": {
-    "message": "An error occurred while generating the report.",
-    "description": "Error when report generation fails."
-  },
-  "githubUserNotFoundError": {
-    "message": "GitHub user \"$1\" not found.",
-    "description": "Error when GitHub user is not found."
-  },
-  "githubUserValidationError": {
-    "message": "Error validating GitHub user: $1 $2",
-    "description": "Error when validating GitHub user fails. $1=status, $2=statusText"
-  },
-  "invalidSearchQueryError": {
-    "message": "Invalid search query or date range. Please verify your date range format and try again.",
-    "description": "Error when the search query or date range is invalid."
-  },
-  "githubIssuesFetchError": {
-    "message": "Error fetching GitHub issues: $1 $2",
-    "description": "Error when fetching GitHub issues fails. $1=status, $2=statusText"
-  },
-  "githubPRReviewFetchError": {
-    "message": "Error fetching GitHub PR review data: $1 $2",
-    "description": "Error when fetching GitHub PR review data fails. $1=status, $2=statusText"
-  },
-  "githubUserFetchError": {
-    "message": "Error fetching GitHub user data: $1 $2",
-    "description": "Error when fetching GitHub user data fails. $1=status, $2=statusText"
-  },
-  "invalidTokenError": {
-    "message": "Invalid or expired GitHub token. Please check your token in the Scrum Helper settings and try again.",
-    "description": "Error for invalid or expired GitHub token."
-  },
-  "displayModeNotice": {
-    "message": "The extension will open in $1 mode on the next launch.",
-    "description": "Notice for display mode change. $1=mode label"
-  },
-  "repoFilteringGithubOnly": {
-    "message": "Repository filtering is only available for GitHub.",
-    "description": "Shown when repo filtering is not available for other platforms."
-  },
-  "repoLoadingGithubOnly": {
-    "message": "Repository loading is only available for GitHub.",
-    "description": "Shown when repo loading is not available for other platforms."
-  },
-  "repoFetchingGithubOnly": {
-    "message": "Repository fetching is only available for GitHub.",
-    "description": "Shown when repo fetching is not available for other platforms."
-  },
-  "loadingReposAutomatically": {
-    "message": "Loading repos automatically...",
-    "description": "Status message when repos are loading."
-  },
-  "gitlabUserFetchError": {
-    "message": "Error fetching GitLab user: $1 $2",
-    "description": "Error when fetching GitLab user fails. $1=status, $2=statusText"
-  },
-  "gitlabUserNotFoundError": {
-    "message": "GitLab user '$1' not found.",
-    "description": "Error when GitLab user is not found. $1=username"
-  },
-  "gitlabMembershipError": {
-    "message": "Error fetching GitLab membership projects: $1 $2",
-    "description": "Error when fetching GitLab membership projects fails. $1=status, $2=statusText"
-  },
-  "gitlabContributedError": {
-    "message": "Error fetching GitLab contributed projects: $1 $2",
-    "description": "Error when fetching GitLab contributed projects fails. $1=status, $2=statusText"
-  },
-  "usernameMissingError": {
-    "message": "Username required.",
-    "description": "Error shown when username is missing."
-   },
-  "generateReportTooltip": {
-    "message": "Ctrl+G",
-    "description": "Tooltip shortcut for the Generate button. Dynamically replaced with Cmd+G on macOS."
-  },
-  "copyReportTooltip": {
-    "message": "Ctrl+Shift+Y",
-    "description": "Tooltip shortcut for the Copy button. Dynamically replaced with Cmd+Shift+Y on macOS."
-  },
-  "generatingReportNotification": {
-    "message": "Generating report...",
-    "description": "Notification shown when report generation is triggered via keyboard shortcut."
-  },
-  "copyingReportNotification": {
-    "message": "Copying report...",
-    "description": "Notification shown when report copy is triggered via keyboard shortcut."
-  },
-  "copiedReportNotification": {
-    "message": "Report copied!",
-    "description": "Notification shown when report is successfully copied via keyboard shortcut."
-  },
-  "insertInEmailTooltip": {
-    "message": "Ctrl+Shift+M",
-    "description": "Tooltip shortcut for the Insert in Email button. Dynamically replaced with Cmd+Shift+M on macOS."
-  },
-  "insertingInEmailNotification": {
-    "message": "Inserting report into email...",
-    "description": "Notification shown when report insertion into email is triggered via keyboard shortcut."
-  },
-  "insertedInEmailNotification": {
-    "message": "Report inserted into email!",
-    "description": "Notification shown when report is successfully inserted into email."
-  }
+	"appName": {
+		"message": "Scrum Helper",
+		"description": "The name of the extension."
+	},
+	"appDescription": {
+		"message": "Report your development progress by auto-fetching your Git activity for a selected period",
+		"description": "A brief description of what the extension does."
+	},
+	"disableLabel": {
+		"message": "Disable",
+		"description": "Label for the toggle switch to disable the extension."
+	},
+	"enableLabel": {
+		"message": "Enable",
+		"description": "Label for the toggle switch to enable the extension."
+	},
+	"projectNameLabel": {
+		"message": "Project Name (used in email subject)",
+		"description": "Label for the project name input field."
+	},
+	"projectNamePlaceholder": {
+		"message": "Enter your project name",
+		"description": "Placeholder text for the project name input."
+	},
+	"githubUsernameLabel": {
+		"message": "Your Github Username",
+		"description": "Label for the GitHub username input field."
+	},
+	"gitlabUsernameLabel": {
+		"message": "Your GitLab Username",
+		"description": "Label for the GitLab username input field."
+	},
+	"githubUsernamePlaceholder": {
+		"message": "Required for fetching your contributions",
+		"description": "Placeholder text for the GitHub username input."
+	},
+	"contributionsLabel": {
+		"message": "Fetch your contributions between:",
+		"description": "Label for the date range selection."
+	},
+	"last1DayLabel": {
+		"message": "Previous day",
+		"description": "Radio button option for the last 1 day."
+	},
+	"startDateLabel": {
+		"message": "From:",
+		"description": "Label for the start date picker."
+	},
+	"endDateLabel": {
+		"message": "To:",
+		"description": "Label for the end date picker."
+	},
+	"showOpenClosedLabel": {
+		"message": "Show PRs Labels",
+		"description": "Label for the checkbox to show PR labels."
+	},
+	"blockersLabel": {
+		"message": "What is blocking you from making progress?",
+		"description": "Label for the input field for blockers."
+	},
+	"blockersPlaceholder": {
+		"message": "Enter your reason",
+		"description": "Placeholder text for the blockers input field."
+	},
+	"scrumReportLabel": {
+		"message": "Scrum Report"
+	},
+	"generateReportButton": {
+		"message": "Generate",
+		"description": "Text for the 'Generate' button."
+	},
+	"copyReportButton": {
+		"message": "Copy",
+		"description": "Text for the 'Copy' button."
+	},
+	"insertInEmailButton": {
+		"message": "Insert to Email",
+		"description": "Text for the 'Insert to Email' button."
+	},
+	"insertToEmailFailedError": {
+		"message": "Open an email tab to insert report",
+		"description": "Error message shown when no active email tab can receive insert action."
+	},
+	"settingsOrgNameLabel": {
+		"message": "Organization Name",
+		"description": "Label for the organization name input in settings."
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "Enter organization name",
+		"description": "Placeholder for the organization name input."
+	},
+	"setButton": {
+		"message": "Set",
+		"description": "Text for the 'Set' button for the organization."
+	},
+	"githubTokenLabel": {
+		"message": "Your Github Token",
+		"description": "Label for the GitHub token input."
+	},
+	"githubTokenPlaceholder": {
+		"message": "Required for making authenticated requests",
+		"description": "Placeholder for the GitHub token input."
+	},
+	"githubTokenTooltip": {
+		"message": "Why is it recommended to add a GitHub token? Scrum Helper works without a GitHub token, but adding a personal access token is recommended for a better experience.",
+		"description": "Tooltip for GitHub token explaining why it's needed."
+	},
+	"gitlabTokenLabel": {
+		"message": "Your GitLab Token",
+		"description": "Label for the GitLab token input."
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "Required for accessing private projects",
+		"description": "Placeholder for the GitLab token input."
+	},
+	"gitlabTokenTooltip": {
+		"message": "Why is it recommended to add a GitLab token? Scrum Helper works without a GitLab token for public projects, but adding a personal access token is recommended for a better experience.",
+		"description": "Tooltip for GitLab token explaining why it's needed."
+	},
+	"showCommitsLabel": {
+		"message": "Show commits on open PRs/ draft PRs",
+		"description": "Label for the checkbox to show commits in open PRs."
+	},
+	"showCommitsTooltip": {
+		"message": "Github Token required, add it in the settings."
+	},
+	"onlyIssuesLabel": {
+		"message": "Include only issues in the report"
+	},
+	"onlyIssuesTooltip": {
+		"message": "If checked, the report will only include issues created or assigned to the user."
+	},
+	"onlyPRsLabel": {
+		"message": "Include only PRs in the report"
+	},
+	"onlyPRsTooltip": {
+		"message": "If checked, the report will only include PRs created by the user. Reviewed PRs will be excluded."
+	},
+	"cacheTTLLabel": {
+		"message": "Enter cache TTL",
+		"description": "Label for the cache time-to-live input."
+	},
+	"cacheTTLUnit": {
+		"message": "(in minutes)",
+		"description": "Unit for the cache TTL."
+	},
+	"cacheTTLPlaceholder": {
+		"message": "Write Cache TTL in minutes (Default 10 minutes)",
+		"description": "Placeholder for the cache TTL input."
+	},
+	"refreshDataButton": {
+		"message": "Refresh Data (bypass cache)",
+		"description": "Text for the button to refresh data, ignoring the cache."
+	},
+	"refreshDataInfo": {
+		"message": "Use this button to fetch fresh data immediately.",
+		"description": "Informational text below the refresh button."
+	},
+	"noteTitle": {
+		"message": "Note:",
+		"description": "Title for the notes section."
+	},
+	"viewCodeButton": {
+		"message": "View Code",
+		"description": "Text for the button to view the source code on GitHub."
+	},
+	"reportIssueButton": {
+		"message": "Report Issue",
+		"description": "Text for the button to report an issue on GitHub."
+	},
+	"repoFilterLabel": {
+		"message": "Filter by repositories",
+		"description": "Label for the repository filter section."
+	},
+	"enableFilteringLabel": {
+		"message": "Enable filtering",
+		"description": "Label for the checkbox to enable repository filtering."
+	},
+	"tokenRequiredWarning": {
+		"message": "A GitHub token is required for repository filtering. Please add one in the settings.",
+		"description": "Warning message shown when repo filtering is enabled without a token."
+	},
+	"tokenRequiredShowCommitsWarning": {
+		"message": "A GitHub token is required to show commits on open or draft PRs. Please add one in the settings.",
+		"description": "Warning message shown when show commits is enabled without a token."
+	},
+	"repoSearchPlaceholder": {
+		"message": "Search for a repository to add...",
+		"description": "Placeholder for the repository search input."
+	},
+	"repoPlaceholder": {
+		"message": "No repositories selected (all will be included)",
+		"description": "Placeholder text when no repositories are selected for filtering."
+	},
+	"repoCountNone": {
+		"message": "0 repositories selected",
+		"description": "Text showing the count of selected repositories when it's zero."
+	},
+	"repoCount": {
+		"message": "$1 repositories selected",
+		"description": "Text showing the count of selected repositories. $1 is a placeholder for the number."
+	},
+	"repoLoading": {
+		"message": "Loading repositories...",
+		"description": "Status message when repositories are being loaded."
+	},
+	"repoLoaded": {
+		"message": "Loaded $1 repositories.",
+		"description": "Status message after repositories have been successfully loaded. $1 is a placeholder for the number."
+	},
+	"repoNotFound": {
+		"message": "No repositories found",
+		"description": "Message shown in the dropdown when a search yields no results."
+	},
+	"repoRefetching": {
+		"message": "Refetching repositories...",
+		"description": "Status message when repositories are being refetched."
+	},
+	"repoLoadFailed": {
+		"message": "Failed to load repositories.",
+		"description": "Error message when repository loading fails."
+	},
+	"repoTokenPrivate": {
+		"message": "Token is invalid or does not have rights for private repos.",
+		"description": "Error message when the token is invalid or lacks permissions."
+	},
+	"repoRefetchFailed": {
+		"message": "Failed to refetch repositories.",
+		"description": "Error message when refetching repositories fails."
+	},
+	"orgSetMessage": {
+		"message": "Organization set successfully.",
+		"description": "Success toast message when an organization is set."
+	},
+	"orgClearedMessage": {
+		"message": "Organization cleared. Click 'Generate' to fetch all activities.",
+		"description": "Message shown when the organization is cleared."
+	},
+	"orgNotFoundMessage": {
+		"message": "Organization not found on GitHub.",
+		"description": "Error toast message when an organization is not found."
+	},
+	"orgValidationErrorMessage": {
+		"message": "Error validating organization.",
+		"description": "Error toast message for general organization validation errors."
+	},
+	"refreshingButton": {
+		"message": "Refreshing...",
+		"description": "Text on the refresh button while it's in a loading state."
+	},
+	"cacheClearFailed": {
+		"message": "Cache clear failed.",
+		"description": "Error message when clearing the cache fails."
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by",
+		"description": "Footer credit text."
+	},
+	"generatingButton": {
+		"message": "Generating...",
+		"description": "Text shown on the generate button when the report is being created."
+	},
+	"copiedButton": {
+		"message": "Copied!",
+		"description": "Text shown on the copy button after a successful copy."
+	},
+	"orgChangedMessage": {
+		"message": "Organization changed. Click Generate button to fetch the GitHub activities.",
+		"description": "Message shown in the report area after the organization is changed."
+	},
+	"cacheClearedMessage": {
+		"message": "Cache cleared successfully. Click \"Generate\" to fetch fresh data.",
+		"description": "Message shown in the report area after the cache is cleared."
+	},
+	"cacheExpiredMessage": {
+		"message": "Cache expired. Click \"Generate\" to fetch fresh data.",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "Cache Cleared!",
+		"description": "Text on the refresh button after the cache is cleared."
+	},
+	"extensionDisabledMessage": {
+		"message": "Extension is disabled. Enable it from the options to generate scrum reports.",
+		"description": "Message shown when the extension is disabled."
+	},
+	"notePoint1": {
+		"message": "Pull requests are fetched based on the most recent review activity by any contributor, not just your own. Please review and adjust the generated SCRUM report to ensure it accurately reflects your work before sharing.",
+		"description": "First point in the notes section."
+	},
+	"noteSeeIssue": {
+		"message": "See this issue",
+		"description": "Link text for the GitHub issue in the notes."
+	},
+	"platformLabel": {
+		"message": "Platform",
+		"description": "Label for the platform selection header."
+	},
+	"usernameLabel": {
+		"message": "Your Username",
+		"description": "Label for the username input header."
+	},
+	"onlyRevPRsLabel": {
+		"message": "Include only reviewed PRs in the report",
+		"description": "Label for the checkbox to include only reviewed PRs."
+	},
+	"onlyRevPRsTooltip": {
+		"message": "If checked, the report will only include PRs reviewed by you.",
+		"description": "Tooltip for the reviewed PRs filter checkbox."
+	},
+	"onlyMergedPRsLabel": {
+		"message": "Include only merged PRs in the report",
+		"description": "Label for the checkbox to include only merged PRs."
+	},
+	"onlyMergedPRsTooltip": {
+		"message": "If checked, the report will only include PRs that have been merged. A GitHub token is required.",
+		"description": "Tooltip for the merged PRs filter checkbox."
+	},
+	"tokenRequiredMergedPRsWarning": {
+		"message": "A GitHub token is required to filter by merged PRs. Please add one in the settings.",
+		"description": "Warning shown when merged PRs filter is enabled without a GitHub token."
+	},
+	"usernameRequiredError": {
+		"message": "Please enter your username to generate a report.",
+		"description": "Error shown when username is missing."
+	},
+	"unknownPlatformError": {
+		"message": "Unknown platform selected.",
+		"description": "Error shown when an unsupported platform is selected."
+	},
+	"gitlabFetchingError": {
+		"message": "An error occurred while fetching GitLab data.",
+		"description": "Error shown when GitLab data fetch fails."
+	},
+	"reportGenerationError": {
+		"message": "An error occurred while generating the report.",
+		"description": "Error when report generation fails."
+	},
+	"githubUserNotFoundError": {
+		"message": "GitHub user \"$1\" not found.",
+		"description": "Error when GitHub user is not found."
+	},
+	"githubUserValidationError": {
+		"message": "Error validating GitHub user: $1 $2",
+		"description": "Error when validating GitHub user fails. $1=status, $2=statusText"
+	},
+	"invalidSearchQueryError": {
+		"message": "Invalid search query or date range. Please verify your date range format and try again.",
+		"description": "Error when the search query or date range is invalid."
+	},
+	"githubIssuesFetchError": {
+		"message": "Error fetching GitHub issues: $1 $2",
+		"description": "Error when fetching GitHub issues fails. $1=status, $2=statusText"
+	},
+	"githubPRReviewFetchError": {
+		"message": "Error fetching GitHub PR review data: $1 $2",
+		"description": "Error when fetching GitHub PR review data fails. $1=status, $2=statusText"
+	},
+	"githubUserFetchError": {
+		"message": "Error fetching GitHub user data: $1 $2",
+		"description": "Error when fetching GitHub user data fails. $1=status, $2=statusText"
+	},
+	"invalidTokenError": {
+		"message": "Invalid or expired GitHub token. Please check your token in the Scrum Helper settings and try again.",
+		"description": "Error for invalid or expired GitHub token."
+	},
+	"displayModeNotice": {
+		"message": "The extension will open in $1 mode on the next launch.",
+		"description": "Notice for display mode change. $1=mode label"
+	},
+	"repoFilteringGithubOnly": {
+		"message": "Repository filtering is only available for GitHub.",
+		"description": "Shown when repo filtering is not available for other platforms."
+	},
+	"repoLoadingGithubOnly": {
+		"message": "Repository loading is only available for GitHub.",
+		"description": "Shown when repo loading is not available for other platforms."
+	},
+	"repoFetchingGithubOnly": {
+		"message": "Repository fetching is only available for GitHub.",
+		"description": "Shown when repo fetching is not available for other platforms."
+	},
+	"loadingReposAutomatically": {
+		"message": "Loading repos automatically...",
+		"description": "Status message when repos are loading."
+	},
+	"gitlabUserFetchError": {
+		"message": "Error fetching GitLab user: $1 $2",
+		"description": "Error when fetching GitLab user fails. $1=status, $2=statusText"
+	},
+	"gitlabUserNotFoundError": {
+		"message": "GitLab user '$1' not found.",
+		"description": "Error when GitLab user is not found. $1=username"
+	},
+	"gitlabMembershipError": {
+		"message": "Error fetching GitLab membership projects: $1 $2",
+		"description": "Error when fetching GitLab membership projects fails. $1=status, $2=statusText"
+	},
+	"gitlabContributedError": {
+		"message": "Error fetching GitLab contributed projects: $1 $2",
+		"description": "Error when fetching GitLab contributed projects fails. $1=status, $2=statusText"
+	},
+	"usernameMissingError": {
+		"message": "Username required.",
+		"description": "Error shown when username is missing."
+	},
+	"generateReportTooltip": {
+		"message": "Ctrl+G",
+		"description": "Tooltip shortcut for the Generate button. Dynamically replaced with Cmd+G on macOS."
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y",
+		"description": "Tooltip shortcut for the Copy button. Dynamically replaced with Cmd+Shift+Y on macOS."
+	},
+	"generatingReportNotification": {
+		"message": "Generating report...",
+		"description": "Notification shown when report generation is triggered via keyboard shortcut."
+	},
+	"copyingReportNotification": {
+		"message": "Copying report...",
+		"description": "Notification shown when report copy is triggered via keyboard shortcut."
+	},
+	"copiedReportNotification": {
+		"message": "Report copied!",
+		"description": "Notification shown when report is successfully copied via keyboard shortcut."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M",
+		"description": "Tooltip shortcut for the Insert in Email button. Dynamically replaced with Cmd+Shift+M on macOS."
+	},
+	"insertingInEmailNotification": {
+		"message": "Inserting report into email...",
+		"description": "Notification shown when report insertion into email is triggered via keyboard shortcut."
+	},
+	"insertedInEmailNotification": {
+		"message": "Report inserted into email!",
+		"description": "Notification shown when report is successfully inserted into email."
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -1,237 +1,237 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Informe sobre su progreso de desarrollo obteniendo automáticamente su actividad de Git para un período seleccionado."
-    },
-    "disableLabel": {
-        "message": "Desactivar"
-    },
-    "enableLabel": {
-        "message": "Activar"
-    },
-    "projectNameLabel": {
-        "message": "Nombre del proyecto (usado en el asunto del correo)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Ingrese el nombre de su proyecto"
-    },
-    "githubUsernameLabel": {
-        "message": "Su nombre de usuario de GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Su nombre de usuario de GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Requerido para obtener sus contribuciones"
-    },
-    "contributionsLabel": {
-        "message": "Obtener sus contribuciones de:"
-    },
-    "last1DayLabel": {
-        "message": "Día anterior"
-    },
-    "startDateLabel": {
-        "message": "Desde:"
-    },
-    "endDateLabel": {
-        "message": "Hasta:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Mostrar estado Abierto/Cerrado"
-    },
-    "blockersLabel": {
-        "message": "¿Qué le impide progresar?"
-    },
-    "blockersPlaceholder": {
-        "message": "Ingrese su motivo"
-    },
-    "scrumReportLabel": {
-        "message": "Informe de Scrum"
-    },
-    "generateReportButton": {
-        "message": "Generar"
-    },
-    "copyReportButton": {
-        "message": "Copiar"
-    },
-    "insertInEmailButton": {
-        "message": "Insertar en correo"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nombre de la organización"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Ingrese el nombre de la organización"
-    },
-    "setButton": {
-        "message": "Establecer"
-    },
-    "githubTokenLabel": {
-        "message": "Su token de GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Requerido para realizar solicitudes autenticadas"
-    },
-    "githubTokenTooltip": {
-        "message": "¿Por qué se recomienda agregar un token de GitHub? Scrum Helper funciona sin un token de GitHub, pero se recomienda agregar un token de acceso personal para una mejor experiencia."
-    },
-    "gitlabTokenLabel": {
-        "message": "Tu token de GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Requerido para repos privados"
-    },
-    "gitlabTokenTooltip": {
-        "message": "¿Por qué se recomienda agregar un token de GitLab? Scrum Helper funciona sin un token de GitLab para proyectos públicos, pero se recomienda agregar un token de acceso personal para una mejor experiencia."
-    },
-    "showCommitsLabel": {
-        "message": "Mostrar commits en PRs abiertos/ borradores de PRs"
-    },
-    "showCommitsTooltip": {
-        "message": "Se requiere un token de GitHub, agréguelo en la configuración."
-    },
-    "onlyIssuesLabel": {
-        "message": "Incluir solo incidencias en el informe"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Si está marcado, el informe solo incluirá las incidencias creadas o asignadas al usuario."
-    },
-    "onlyPRsLabel": {
-        "message": "Incluir solo PRs en el informe"
-    },
-    "onlyPRsTooltip": {
-        "message": "Si está marcado, el informe solo incluirá pull requests creados por el usuario; los pull requests revisados se excluirán."
-    },
-    "cacheTTLLabel": {
-        "message": "Introducir TTL de caché",
-        "description": "Etiqueta para la entrada de tiempo de vida de la caché."
-    },
-    "cacheTTLUnit": {
-        "message": "(en minutos)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Escriba el TTL del caché en minutos (Predeterminado: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Actualizar datos (omitir caché)"
-    },
-    "refreshDataInfo": {
-        "message": "Use este botón para obtener datos nuevos inmediatamente."
-    },
-    "noteTitle": {
-        "message": "Nota:"
-    },
-    "viewCodeButton": {
-        "message": "Ver código"
-    },
-    "reportIssueButton": {
-        "message": "Reportar un problema"
-    },
-    "repoFilterLabel": {
-        "message": "Filtrar por repositorios"
-    },
-    "enableFilteringLabel": {
-        "message": "Activar filtrado"
-    },
-    "tokenRequiredWarning": {
-        "message": "Se requiere un token de GitHub para filtrar repositorios. Por favor, agregue uno en la configuración."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Buscar un repositorio para agregar..."
-    },
-    "repoPlaceholder": {
-        "message": "No hay repositorios seleccionados (se incluirán todos)"
-    },
-    "repoCountNone": {
-        "message": "0 repositorios seleccionados"
-    },
-    "repoCount": {
-        "message": "$1 repositorios seleccionados"
-    },
-    "repoLoading": {
-        "message": "Cargando repositorios..."
-    },
-    "repoLoaded": {
-        "message": "$1 repositorios cargados."
-    },
-    "repoNotFound": {
-        "message": "No se encontraron repositorios"
-    },
-    "repoRefetching": {
-        "message": "Recargando repositorios..."
-    },
-    "repoLoadFailed": {
-        "message": "Error al cargar los repositorios."
-    },
-    "repoTokenPrivate": {
-        "message": "El token no es válido o no tiene derechos para repositorios privados."
-    },
-    "repoRefetchFailed": {
-        "message": "Error al recargar los repositorios."
-    },
-    "orgSetMessage": {
-        "message": "Organización establecida correctamente."
-    },
-    "orgClearedMessage": {
-        "message": "Organización eliminada. Haga clic en 'Generar informe' para obtener todas las actividades."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organización no encontrada en GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Error al validar la organización."
-    },
-    "refreshingButton": {
-        "message": "Actualizando..."
-    },
-    "cacheClearFailed": {
-        "message": "Error al borrar el caché."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Generando..."
-    },
-    "copiedButton": {
-        "message": "¡Copiado!"
-    },
-    "orgChangedMessage": {
-        "message": "Organización cambiada. Haga clic en 'Generar informe' para obtener las actividades de GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Caché borrado con éxito. Haga clic en 'Generar informe' para obtener datos nuevos."
-    },
-    "cacheExpiredMessage": {
-        "message": "La caché ha expirado. Haga clic en \"Generar\" para obtener datos nuevos.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "¡Caché borrado!"
-    },
-    "extensionDisabledMessage": {
-        "message": "La extensión está deshabilitada. Habilítela desde las opciones para generar informes de scrum."
-    },
-    "notePoint1": {
-        "message": "Las solicitudes de extracción se obtienen en función de la actividad de revisión más reciente de cualquier colaborador, no solo la suya. Revise y ajuste el informe SCRUM generado para asegurarse de que refleje con precisión su trabajo antes de compartirlo."
-    },
-    "noteSeeIssue": {
-        "message": "Ver este issue"
-    },
-    "platformLabel": {
-        "message": "Plataforma"
-    },
-    "usernameLabel": {
-        "message": "Su nombre de usuario"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Incluir solo PRs revisados en el informe"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Si está marcado, el informe solo incluirá PRs revisados por usted."
-    },
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "Informe sobre su progreso de desarrollo obteniendo automáticamente su actividad de Git para un período seleccionado."
+	},
+	"disableLabel": {
+		"message": "Desactivar"
+	},
+	"enableLabel": {
+		"message": "Activar"
+	},
+	"projectNameLabel": {
+		"message": "Nombre del proyecto (usado en el asunto del correo)"
+	},
+	"projectNamePlaceholder": {
+		"message": "Ingrese el nombre de su proyecto"
+	},
+	"githubUsernameLabel": {
+		"message": "Su nombre de usuario de GitHub"
+	},
+	"gitlabUsernameLabel": {
+		"message": "Su nombre de usuario de GitLab"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "Requerido para obtener sus contribuciones"
+	},
+	"contributionsLabel": {
+		"message": "Obtener sus contribuciones de:"
+	},
+	"last1DayLabel": {
+		"message": "Día anterior"
+	},
+	"startDateLabel": {
+		"message": "Desde:"
+	},
+	"endDateLabel": {
+		"message": "Hasta:"
+	},
+	"showOpenClosedLabel": {
+		"message": "Mostrar estado Abierto/Cerrado"
+	},
+	"blockersLabel": {
+		"message": "¿Qué le impide progresar?"
+	},
+	"blockersPlaceholder": {
+		"message": "Ingrese su motivo"
+	},
+	"scrumReportLabel": {
+		"message": "Informe de Scrum"
+	},
+	"generateReportButton": {
+		"message": "Generar"
+	},
+	"copyReportButton": {
+		"message": "Copiar"
+	},
+	"insertInEmailButton": {
+		"message": "Insertar en correo"
+	},
+	"settingsOrgNameLabel": {
+		"message": "Nombre de la organización"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "Ingrese el nombre de la organización"
+	},
+	"setButton": {
+		"message": "Establecer"
+	},
+	"githubTokenLabel": {
+		"message": "Su token de GitHub"
+	},
+	"githubTokenPlaceholder": {
+		"message": "Requerido para realizar solicitudes autenticadas"
+	},
+	"githubTokenTooltip": {
+		"message": "¿Por qué se recomienda agregar un token de GitHub? Scrum Helper funciona sin un token de GitHub, pero se recomienda agregar un token de acceso personal para una mejor experiencia."
+	},
+	"gitlabTokenLabel": {
+		"message": "Tu token de GitLab"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "Requerido para repos privados"
+	},
+	"gitlabTokenTooltip": {
+		"message": "¿Por qué se recomienda agregar un token de GitLab? Scrum Helper funciona sin un token de GitLab para proyectos públicos, pero se recomienda agregar un token de acceso personal para una mejor experiencia."
+	},
+	"showCommitsLabel": {
+		"message": "Mostrar commits en PRs abiertos/ borradores de PRs"
+	},
+	"showCommitsTooltip": {
+		"message": "Se requiere un token de GitHub, agréguelo en la configuración."
+	},
+	"onlyIssuesLabel": {
+		"message": "Incluir solo incidencias en el informe"
+	},
+	"onlyIssuesTooltip": {
+		"message": "Si está marcado, el informe solo incluirá las incidencias creadas o asignadas al usuario."
+	},
+	"onlyPRsLabel": {
+		"message": "Incluir solo PRs en el informe"
+	},
+	"onlyPRsTooltip": {
+		"message": "Si está marcado, el informe solo incluirá pull requests creados por el usuario; los pull requests revisados se excluirán."
+	},
+	"cacheTTLLabel": {
+		"message": "Introducir TTL de caché",
+		"description": "Etiqueta para la entrada de tiempo de vida de la caché."
+	},
+	"cacheTTLUnit": {
+		"message": "(en minutos)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "Escriba el TTL del caché en minutos (Predeterminado: 10)"
+	},
+	"refreshDataButton": {
+		"message": "Actualizar datos (omitir caché)"
+	},
+	"refreshDataInfo": {
+		"message": "Use este botón para obtener datos nuevos inmediatamente."
+	},
+	"noteTitle": {
+		"message": "Nota:"
+	},
+	"viewCodeButton": {
+		"message": "Ver código"
+	},
+	"reportIssueButton": {
+		"message": "Reportar un problema"
+	},
+	"repoFilterLabel": {
+		"message": "Filtrar por repositorios"
+	},
+	"enableFilteringLabel": {
+		"message": "Activar filtrado"
+	},
+	"tokenRequiredWarning": {
+		"message": "Se requiere un token de GitHub para filtrar repositorios. Por favor, agregue uno en la configuración."
+	},
+	"repoSearchPlaceholder": {
+		"message": "Buscar un repositorio para agregar..."
+	},
+	"repoPlaceholder": {
+		"message": "No hay repositorios seleccionados (se incluirán todos)"
+	},
+	"repoCountNone": {
+		"message": "0 repositorios seleccionados"
+	},
+	"repoCount": {
+		"message": "$1 repositorios seleccionados"
+	},
+	"repoLoading": {
+		"message": "Cargando repositorios..."
+	},
+	"repoLoaded": {
+		"message": "$1 repositorios cargados."
+	},
+	"repoNotFound": {
+		"message": "No se encontraron repositorios"
+	},
+	"repoRefetching": {
+		"message": "Recargando repositorios..."
+	},
+	"repoLoadFailed": {
+		"message": "Error al cargar los repositorios."
+	},
+	"repoTokenPrivate": {
+		"message": "El token no es válido o no tiene derechos para repositorios privados."
+	},
+	"repoRefetchFailed": {
+		"message": "Error al recargar los repositorios."
+	},
+	"orgSetMessage": {
+		"message": "Organización establecida correctamente."
+	},
+	"orgClearedMessage": {
+		"message": "Organización eliminada. Haga clic en 'Generar informe' para obtener todas las actividades."
+	},
+	"orgNotFoundMessage": {
+		"message": "Organización no encontrada en GitHub."
+	},
+	"orgValidationErrorMessage": {
+		"message": "Error al validar la organización."
+	},
+	"refreshingButton": {
+		"message": "Actualizando..."
+	},
+	"cacheClearFailed": {
+		"message": "Error al borrar el caché."
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "Generando..."
+	},
+	"copiedButton": {
+		"message": "¡Copiado!"
+	},
+	"orgChangedMessage": {
+		"message": "Organización cambiada. Haga clic en 'Generar informe' para obtener las actividades de GitHub."
+	},
+	"cacheClearedMessage": {
+		"message": "Caché borrado con éxito. Haga clic en 'Generar informe' para obtener datos nuevos."
+	},
+	"cacheExpiredMessage": {
+		"message": "La caché ha expirado. Haga clic en \"Generar\" para obtener datos nuevos.",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "¡Caché borrado!"
+	},
+	"extensionDisabledMessage": {
+		"message": "La extensión está deshabilitada. Habilítela desde las opciones para generar informes de scrum."
+	},
+	"notePoint1": {
+		"message": "Las solicitudes de extracción se obtienen en función de la actividad de revisión más reciente de cualquier colaborador, no solo la suya. Revise y ajuste el informe SCRUM generado para asegurarse de que refleje con precisión su trabajo antes de compartirlo."
+	},
+	"noteSeeIssue": {
+		"message": "Ver este issue"
+	},
+	"platformLabel": {
+		"message": "Plataforma"
+	},
+	"usernameLabel": {
+		"message": "Su nombre de usuario"
+	},
+	"onlyRevPRsLabel": {
+		"message": "Incluir solo PRs revisados en el informe"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "Si está marcado, el informe solo incluirá PRs revisados por usted."
+	},
 	"usernameRequiredError": {
 		"message": "Por favor, introduzca su nombre de usuario para generar un informe."
 	},
@@ -295,25 +295,49 @@
 	"usernameMissingError": {
 		"message": "Nombre de usuario requerido."
 	},
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-   },
-    "generatingReportNotification": {
-        "message": "Generando informe..."
-   },
-    "copyingReportNotification": {
-        "message": "Copiando informe..."
-   },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Insertando informe en el correo..."
-    },
-    "insertedInEmailNotification": {
-        "message": "¡Informe insertado en el correo!"
-   }
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"generatingReportNotification": {
+		"message": "Generando informe..."
+	},
+	"copyingReportNotification": {
+		"message": "Copiando informe..."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "Insertando informe en el correo..."
+	},
+	"insertedInEmailNotification": {
+		"message": "¡Informe insertado en el correo!"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -1,238 +1,238 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Rendez compte de votre progression en récupérant automatiquement votre activité Git pour une période sélectionnée."
-    },
-    "disableLabel": {
-        "message": "Désactiver"
-    },
-    "enableLabel": {
-        "message": "Activer"
-    },
-    "projectNameLabel": {
-        "message": "Nom du projet (utilisé dans l'objet de l'e-mail)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Entrez le nom de votre projet"
-    },
-    "githubUsernameLabel": {
-        "message": "Votre nom d'utilisateur GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Votre nom d'utilisateur GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Requis pour récupérer vos contributions"
-    },
-    "contributionsLabel": {
-        "message": "Récupérer vos contributions de :"
-    },
-    "last1DayLabel": {
-        "message": "Jour précédent"
-    },
-    "startDateLabel": {
-        "message": "De :"
-    },
-    "endDateLabel": {
-        "message": "À :"
-    },
-    "showOpenClosedLabel": {
-        "message": "Afficher le statut Ouvert/Fermé"
-    },
-    "blockersLabel": {
-        "message": "Qu'est-ce qui vous empêche de progresser ?"
-    },
-    "blockersPlaceholder": {
-        "message": "Entrez votre raison"
-    },
-    "scrumReportLabel": {
-        "message": "Rapport Scrum"
-    },
-    "generateReportButton": {
-        "message": "Générer"
-    },
-    "copyReportButton": {
-        "message": "Copier"
-    },
-    "insertInEmailButton": {
-        "message": "Insérer dans l’e-mail"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nom de l'organisation"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Entrez le nom de l'organisation"
-    },
-    "setButton": {
-        "message": "Définir"
-    },
-    "githubTokenLabel": {
-        "message": "Votre jeton GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Requis pour les requêtes authentifiées"
-    },
-    "githubTokenTooltip": {
-        "message": "Pourquoi est-il recommandé d'ajouter un jeton GitHub ? Scrum Helper fonctionne sans jeton GitHub, mais l'ajout d'un jeton d'accès personnel est recommandé pour une meilleure expérience."
-    },
-    "gitlabTokenLabel": {
-        "message": "Votre jeton GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Requis pour les dépôts privés"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Pourquoi est-il recommandé d'ajouter un jeton GitLab ? Scrum Helper fonctionne sans jeton GitLab pour les projets publics, mais l'ajout d'un jeton d'accès personnel est recommandé pour une meilleure expérience."
-    },
-    "showCommitsLabel": {
-        "message": "Afficher les commits sur les PRs ouverts/ brouillons de PRs"
-    },
-    "showCommitsTooltip": {
-        "message": "Jeton Github requis, ajoutez-le dans les paramètres."
-    },
-    "onlyIssuesLabel": {
-        "message": "Inclure uniquement les problèmes dans le rapport"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Si cette case est cochée, le rapport n'inclura que les problèmes créés par l'utilisateur ou qui lui sont assignés."
-    },
-    "onlyPRsLabel": {
-        "message": "Inclure uniquement les PRs dans le rapport"
-    },
-    "onlyPRsTooltip": {
-        "message": "Si coché, le rapport n'inclura que les pull requests créées par l'utilisateur ; les pull requests revues seront exclues."
-    },
-    "cacheTTLLabel": {
-        "message": "Entrez le TTL du cache",
-        "description": "Étiquette pour le champ de saisie de la durée de vie du cache."
-    },
-    "cacheTTLUnit": {
-        "message": "(en minutes)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Entrez le TTL du cache en minutes (Défaut : 10)"
-    },
-    "refreshDataButton": {
-        "message": "Actualiser les données (ignorer le cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Utilisez ce bouton pour récupérer des données fraîches immédiatement."
-    },
-    "noteTitle": {
-        "message": "Note :"
-    },
-    "viewCodeButton": {
-        "message": "Voir le code"
-    },
-    "reportIssueButton": {
-        "message": "Signaler un problème"
-    },
-    "repoFilterLabel": {
-        "message": "Filtrer par dépôts"
-    },
-    "enableFilteringLabel": {
-        "message": "Activer le filtrage"
-    },
-    "tokenRequiredWarning": {
-        "message": "Un jeton GitHub est requis pour filtrer les dépôts. Veuillez en ajouter un dans les paramètres."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Rechercher un dépôt à ajouter..."
-    },
-    "repoPlaceholder": {
-        "message": "Aucun dépôt sélectionné (tous seront inclus)"
-    },
-    "repoCountNone": {
-        "message": "0 dépôts sélectionnés"
-    },
-    "repoCount": {
-        "message": "$1 dépôts sélectionnés"
-    },
-    "repoLoading": {
-        "message": "Chargement des dépôts..."
-    },
-    "repoLoaded": {
-        "message": "$1 dépôts chargés."
-    },
-    "repoNotFound": {
-        "message": "Aucun dépôt trouvé"
-    },
-    "repoRefetching": {
-        "message": "Rechargement des dépôts..."
-    },
-    "repoLoadFailed": {
-        "message": "Échec du chargement des dépôts."
-    },
-    "repoTokenPrivate": {
-        "message": "Le jeton est invalide ou n'a pas les droits pour les dépôts privés."
-    },
-    "repoRefetchFailed": {
-        "message": "Échec du rechargement des dépôts."
-    },
-    "orgSetMessage": {
-        "message": "Organisation définie avec succès."
-    },
-    "orgClearedMessage": {
-        "message": "Organisation effacée. Cliquez sur 'Générer le rapport' pour récupérer toutes les activités."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organisation non trouvée sur GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Erreur lors de la validation de l'organisation."
-    },
-    "refreshingButton": {
-        "message": "Actualisation..."
-    },
-    "cacheClearFailed": {
-        "message": "Échec de la suppression du cache."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Génération..."
-    },
-    "copiedButton": {
-        "message": "Copié !"
-    },
-    "orgChangedMessage": {
-        "message": "Organisation modifiée. Cliquez sur 'Générer le rapport' pour récupérer les activités GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache vidé avec succès. Cliquez sur 'Générer le rapport' pour récupérer des données fraîches."
-    },
-    "cacheExpiredMessage": {
-        "message": "Le cache a expiré. Cliquez sur \"Générer\" pour récupérer des données fraîches.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Cache vidé !"
-    },
-    "extensionDisabledMessage": {
-        "message": "L'extension est désactivée. Activez-la depuis les paramètres pour générer des rapports Scrum."
-    },
-    "notePoint1": {
-        "message": "Les pull requests sont récupérées en fonction de l'activité de revue la plus récente de n'importe quel contributeur, pas seulement la vôtre. Veuillez examiner et ajuster le rapport SCRUM généré pour vous assurer qu'il reflète fidèlement votre travail avant de le partager."
-    },
-    "noteSeeIssue": {
-        "message": "Voir ce ticket"
-    },
-    "platformLabel": {
-        "message": "Plateforme"
-    },
-    "usernameLabel": {
-        "message": "Votre nom d'utilisateur"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Inclure uniquement les PRs revues dans le rapport"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Si coché, le rapport n'inclura que les PRs que vous avez revues."
-    },
-    	"usernameRequiredError": {
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "Rendez compte de votre progression en récupérant automatiquement votre activité Git pour une période sélectionnée."
+	},
+	"disableLabel": {
+		"message": "Désactiver"
+	},
+	"enableLabel": {
+		"message": "Activer"
+	},
+	"projectNameLabel": {
+		"message": "Nom du projet (utilisé dans l'objet de l'e-mail)"
+	},
+	"projectNamePlaceholder": {
+		"message": "Entrez le nom de votre projet"
+	},
+	"githubUsernameLabel": {
+		"message": "Votre nom d'utilisateur GitHub"
+	},
+	"gitlabUsernameLabel": {
+		"message": "Votre nom d'utilisateur GitLab"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "Requis pour récupérer vos contributions"
+	},
+	"contributionsLabel": {
+		"message": "Récupérer vos contributions de :"
+	},
+	"last1DayLabel": {
+		"message": "Jour précédent"
+	},
+	"startDateLabel": {
+		"message": "De :"
+	},
+	"endDateLabel": {
+		"message": "À :"
+	},
+	"showOpenClosedLabel": {
+		"message": "Afficher le statut Ouvert/Fermé"
+	},
+	"blockersLabel": {
+		"message": "Qu'est-ce qui vous empêche de progresser ?"
+	},
+	"blockersPlaceholder": {
+		"message": "Entrez votre raison"
+	},
+	"scrumReportLabel": {
+		"message": "Rapport Scrum"
+	},
+	"generateReportButton": {
+		"message": "Générer"
+	},
+	"copyReportButton": {
+		"message": "Copier"
+	},
+	"insertInEmailButton": {
+		"message": "Insérer dans l’e-mail"
+	},
+	"settingsOrgNameLabel": {
+		"message": "Nom de l'organisation"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "Entrez le nom de l'organisation"
+	},
+	"setButton": {
+		"message": "Définir"
+	},
+	"githubTokenLabel": {
+		"message": "Votre jeton GitHub"
+	},
+	"githubTokenPlaceholder": {
+		"message": "Requis pour les requêtes authentifiées"
+	},
+	"githubTokenTooltip": {
+		"message": "Pourquoi est-il recommandé d'ajouter un jeton GitHub ? Scrum Helper fonctionne sans jeton GitHub, mais l'ajout d'un jeton d'accès personnel est recommandé pour une meilleure expérience."
+	},
+	"gitlabTokenLabel": {
+		"message": "Votre jeton GitLab"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "Requis pour les dépôts privés"
+	},
+	"gitlabTokenTooltip": {
+		"message": "Pourquoi est-il recommandé d'ajouter un jeton GitLab ? Scrum Helper fonctionne sans jeton GitLab pour les projets publics, mais l'ajout d'un jeton d'accès personnel est recommandé pour une meilleure expérience."
+	},
+	"showCommitsLabel": {
+		"message": "Afficher les commits sur les PRs ouverts/ brouillons de PRs"
+	},
+	"showCommitsTooltip": {
+		"message": "Jeton Github requis, ajoutez-le dans les paramètres."
+	},
+	"onlyIssuesLabel": {
+		"message": "Inclure uniquement les problèmes dans le rapport"
+	},
+	"onlyIssuesTooltip": {
+		"message": "Si cette case est cochée, le rapport n'inclura que les problèmes créés par l'utilisateur ou qui lui sont assignés."
+	},
+	"onlyPRsLabel": {
+		"message": "Inclure uniquement les PRs dans le rapport"
+	},
+	"onlyPRsTooltip": {
+		"message": "Si coché, le rapport n'inclura que les pull requests créées par l'utilisateur ; les pull requests revues seront exclues."
+	},
+	"cacheTTLLabel": {
+		"message": "Entrez le TTL du cache",
+		"description": "Étiquette pour le champ de saisie de la durée de vie du cache."
+	},
+	"cacheTTLUnit": {
+		"message": "(en minutes)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "Entrez le TTL du cache en minutes (Défaut : 10)"
+	},
+	"refreshDataButton": {
+		"message": "Actualiser les données (ignorer le cache)"
+	},
+	"refreshDataInfo": {
+		"message": "Utilisez ce bouton pour récupérer des données fraîches immédiatement."
+	},
+	"noteTitle": {
+		"message": "Note :"
+	},
+	"viewCodeButton": {
+		"message": "Voir le code"
+	},
+	"reportIssueButton": {
+		"message": "Signaler un problème"
+	},
+	"repoFilterLabel": {
+		"message": "Filtrer par dépôts"
+	},
+	"enableFilteringLabel": {
+		"message": "Activer le filtrage"
+	},
+	"tokenRequiredWarning": {
+		"message": "Un jeton GitHub est requis pour filtrer les dépôts. Veuillez en ajouter un dans les paramètres."
+	},
+	"repoSearchPlaceholder": {
+		"message": "Rechercher un dépôt à ajouter..."
+	},
+	"repoPlaceholder": {
+		"message": "Aucun dépôt sélectionné (tous seront inclus)"
+	},
+	"repoCountNone": {
+		"message": "0 dépôts sélectionnés"
+	},
+	"repoCount": {
+		"message": "$1 dépôts sélectionnés"
+	},
+	"repoLoading": {
+		"message": "Chargement des dépôts..."
+	},
+	"repoLoaded": {
+		"message": "$1 dépôts chargés."
+	},
+	"repoNotFound": {
+		"message": "Aucun dépôt trouvé"
+	},
+	"repoRefetching": {
+		"message": "Rechargement des dépôts..."
+	},
+	"repoLoadFailed": {
+		"message": "Échec du chargement des dépôts."
+	},
+	"repoTokenPrivate": {
+		"message": "Le jeton est invalide ou n'a pas les droits pour les dépôts privés."
+	},
+	"repoRefetchFailed": {
+		"message": "Échec du rechargement des dépôts."
+	},
+	"orgSetMessage": {
+		"message": "Organisation définie avec succès."
+	},
+	"orgClearedMessage": {
+		"message": "Organisation effacée. Cliquez sur 'Générer le rapport' pour récupérer toutes les activités."
+	},
+	"orgNotFoundMessage": {
+		"message": "Organisation non trouvée sur GitHub."
+	},
+	"orgValidationErrorMessage": {
+		"message": "Erreur lors de la validation de l'organisation."
+	},
+	"refreshingButton": {
+		"message": "Actualisation..."
+	},
+	"cacheClearFailed": {
+		"message": "Échec de la suppression du cache."
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "Génération..."
+	},
+	"copiedButton": {
+		"message": "Copié !"
+	},
+	"orgChangedMessage": {
+		"message": "Organisation modifiée. Cliquez sur 'Générer le rapport' pour récupérer les activités GitHub."
+	},
+	"cacheClearedMessage": {
+		"message": "Cache vidé avec succès. Cliquez sur 'Générer le rapport' pour récupérer des données fraîches."
+	},
+	"cacheExpiredMessage": {
+		"message": "Le cache a expiré. Cliquez sur \"Générer\" pour récupérer des données fraîches.",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "Cache vidé !"
+	},
+	"extensionDisabledMessage": {
+		"message": "L'extension est désactivée. Activez-la depuis les paramètres pour générer des rapports Scrum."
+	},
+	"notePoint1": {
+		"message": "Les pull requests sont récupérées en fonction de l'activité de revue la plus récente de n'importe quel contributeur, pas seulement la vôtre. Veuillez examiner et ajuster le rapport SCRUM généré pour vous assurer qu'il reflète fidèlement votre travail avant de le partager."
+	},
+	"noteSeeIssue": {
+		"message": "Voir ce ticket"
+	},
+	"platformLabel": {
+		"message": "Plateforme"
+	},
+	"usernameLabel": {
+		"message": "Votre nom d'utilisateur"
+	},
+	"onlyRevPRsLabel": {
+		"message": "Inclure uniquement les PRs revues dans le rapport"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "Si coché, le rapport n'inclura que les PRs que vous avez revues."
+	},
+	"usernameRequiredError": {
 		"message": "Veuillez saisir votre nom d'utilisateur pour générer un rapport."
 	},
 	"unknownPlatformError": {
@@ -295,25 +295,49 @@
 	"usernameMissingError": {
 		"message": "Nom d'utilisateur requis."
 	},
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Génération du rapport..."
-    },
-    "copyingReportNotification": {
-        "message": "Copie du rapport..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Insertion du rapport dans l'e-mail..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Rapport inséré dans l'e-mail !"
-   }
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"generatingReportNotification": {
+		"message": "Génération du rapport..."
+	},
+	"copyingReportNotification": {
+		"message": "Copie du rapport..."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "Insertion du rapport dans l'e-mail..."
+	},
+	"insertedInEmailNotification": {
+		"message": "Rapport inséré dans l'e-mail !"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -1,238 +1,238 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "דווח על התקדמות הפיתוח שלך על ידי שליפה אוטומטית של פעילות ה-Git שלך לתקופה נבחרת."
-    },
-    "disableLabel": {
-        "message": "השבת"
-    },
-    "enableLabel": {
-        "message": "הפעל"
-    },
-    "projectNameLabel": {
-        "message": "שם פרויקט (משמש בנושא האימייל)"
-    },
-    "projectNamePlaceholder": {
-        "message": "הזן את שם הפרויקט שלך"
-    },
-    "githubUsernameLabel": {
-        "message": "שם המשתמש שלך ב-GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "שם המשתמש שלך ב-GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "נדרש כדי להביא את התרומות שלך"
-    },
-    "contributionsLabel": {
-        "message": "הבא את התרומות שלך עבור:"
-    },
-    "last1DayLabel": {
-        "message": "היום הקודם"
-    },
-    "startDateLabel": {
-        "message": "מ:"
-    },
-    "endDateLabel": {
-        "message": "עד:"
-    },
-    "showOpenClosedLabel": {
-        "message": "הצג סטטוס פתוח/סגור"
-    },
-    "blockersLabel": {
-        "message": "מה מונע ממך להתקדם?"
-    },
-    "blockersPlaceholder": {
-        "message": "הזן את הסיבה שלך"
-    },
-    "scrumReportLabel": {
-        "message": "דוח סקראם"
-    },
-    "generateReportButton": {
-        "message": "צור דוח"
-    },
-    "copyReportButton": {
-        "message": "העתק דוח"
-    },
-    "insertInEmailButton": {
-        "message": "הוסף לאימייל",
-        "description": "Text for the 'Insert to Email' button."
-    },
-    "settingsOrgNameLabel": {
-        "message": "שם הארגון"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "הזן את שם הארגון"
-    },
-    "setButton": {
-        "message": "הגדר"
-    },
-    "githubTokenLabel": {
-        "message": "אסימון ה-GitHub שלך"
-    },
-    "githubTokenPlaceholder": {
-        "message": "נדרש לבקשות מאומתות"
-    },
-    "githubTokenTooltip": {
-        "message": "למה מומלץ להוסיף אסימון GitHub? Scrum Helper עובד ללא אסימון GitHub, אך הוספת אסימון גישה אישי מומלצת לחוויה טובה יותר."
-    },
-    "gitlabTokenLabel": {
-        "message": "אסימון ה-GitLab שלך"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "נדרש למאגרים פרטיים"
-    },
-    "gitlabTokenTooltip": {
-        "message": "למה מומלץ להוסיף אסימון GitLab? Scrum Helper עובד ללא אסימון GitLab לפרויקטים ציבוריים, אך הוספת אסימון גישה אישי מומלצת לחוויה טובה יותר."
-    },
-    "showCommitsLabel": {
-        "message": "הצג קומיטים ב-PR פתוחים/טיוטות PR"
-    },
-    "showCommitsTooltip": {
-        "message": "נדרש אסימון GitHub, הוסף אותו בהגדרות."
-    },
-    "onlyIssuesLabel": {
-        "message": "הכלל רק בעיות בדוח"
-    },
-    "onlyIssuesTooltip": {
-        "message": "אם מסומן, הדוח יכיל רק בעיות שנוצרו או הוקצו למשתמש."
-    },
-    "onlyPRsLabel": {
-        "message": "הכלל רק PR בדוח"
-    },
-    "onlyPRsTooltip": {
-        "message": "אם מסומן, הדוח יכיל רק pull requests שנוצרו על ידי המשתמש; PR שנסקרו יוחרגו."
-    },
-    "cacheTTLLabel": {
-        "message": "הזן TTL למטמון"
-    },
-    "cacheTTLUnit": {
-        "message": "(בדקות)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "כתוב את ה-TTL של המטמון בדקות (ברירת מחדל: 10)"
-    },
-    "refreshDataButton": {
-        "message": "רענן נתונים (עקוף מטמון)"
-    },
-    "refreshDataInfo": {
-        "message": "השתמש בכפתור זה כדי להביא נתונים טריים באופן מיידי."
-    },
-    "noteTitle": {
-        "message": "הערה:"
-    },
-    "viewCodeButton": {
-        "message": "הצג קוד"
-    },
-    "reportIssueButton": {
-        "message": "דווח על בעיה"
-    },
-    "repoFilterLabel": {
-        "message": "סנן לפי מאגרים"
-    },
-    "enableFilteringLabel": {
-        "message": "הפעל סינון"
-    },
-    "tokenRequiredWarning": {
-        "message": "נדרש אסימון GitHub לסינון מאגרים. אנא הוסף אחד בהגדרות."
-    },
-    "repoSearchPlaceholder": {
-        "message": "חפש מאגר להוספה..."
-    },
-    "repoPlaceholder": {
-        "message": "לא נבחרו מאגרים (כולם ייכללו)"
-    },
-    "repoCountNone": {
-        "message": "נבחרו 0 מאגרים"
-    },
-    "repoCount": {
-        "message": "נבחרו $1 מאגרים"
-    },
-    "repoLoading": {
-        "message": "טוען מאגרים..."
-    },
-    "repoLoaded": {
-        "message": "נטענו $1 מאגרים."
-    },
-    "repoNotFound": {
-        "message": "לא נמצאו מאגרים"
-    },
-    "repoRefetching": {
-        "message": "מביא מחדש מאגרים..."
-    },
-    "repoLoadFailed": {
-        "message": "נכשל בטעינת מאגרים."
-    },
-    "repoTokenPrivate": {
-        "message": "האסימון אינו חוקי או שאין לו הרשאות למאגרים פרטיים."
-    },
-    "repoRefetchFailed": {
-        "message": "נכשל בהבאה מחדש של מאגרים."
-    },
-    "orgSetMessage": {
-        "message": "הארגון הוגדר בהצלחה."
-    },
-    "orgClearedMessage": {
-        "message": "הארגון נוקה. לחץ על 'צור דוח' כדי להביא את כל הפעילויות."
-    },
-    "orgNotFoundMessage": {
-        "message": "הארגון לא נמצא ב-GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "שגיאה באימות הארגון."
-    },
-    "refreshingButton": {
-        "message": "מרענן..."
-    },
-    "cacheClearFailed": {
-        "message": "ניקוי המטמון נכשל."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "יוצר..."
-    },
-    "copiedButton": {
-        "message": "הועתק!"
-    },
-    "orgChangedMessage": {
-        "message": "הארגון השתנה. לחץ על 'צור דוח' כדי להביא פעילויות GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "המטמון נוקה בהצלחה. לחץ על 'צור דוח' כדי להביא נתונים טריים."
-    },
-    "cacheExpiredMessage": {
-        "message": "המטמון פג תוקף. לחץ על \"צור\" כדי להביא נתונים חדשים.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "המטמון נוקה!"
-    },
-    "extensionDisabledMessage": {
-        "message": "ההרחבה מושבתת. הפעל אותה מההגדרות כדי ליצור דוחות סקראם."
-    },
-    "notePoint1": {
-        "message": "בקשות משיכה (Pull requests) מאוחזרות על סמך פעילות הסקירה האחרונה של כל תורם, לא רק שלך. אנא בדוק והתאם את דוח ה-SCRUM שנוצר כדי לוודא שהוא משקף במדויק את עבודתך לפני השיתוף."
-    },
-    "noteSeeIssue": {
-        "message": "ראה בעיה זו"
-    },
-    "platformLabel": {
-        "message": "פלטפורמה"
-    },
-    "usernameLabel": {
-        "message": "שם המשתמש שלך"
-    },
-    "onlyRevPRsLabel": {
-        "message": "כלול בדוח רק PR שנבדקו על ידך"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "אם מסומן, הדוח יכלול רק PR שנבדקו על ידך."
-    },
-    "usernameRequiredError": {
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "דווח על התקדמות הפיתוח שלך על ידי שליפה אוטומטית של פעילות ה-Git שלך לתקופה נבחרת."
+	},
+	"disableLabel": {
+		"message": "השבת"
+	},
+	"enableLabel": {
+		"message": "הפעל"
+	},
+	"projectNameLabel": {
+		"message": "שם פרויקט (משמש בנושא האימייל)"
+	},
+	"projectNamePlaceholder": {
+		"message": "הזן את שם הפרויקט שלך"
+	},
+	"githubUsernameLabel": {
+		"message": "שם המשתמש שלך ב-GitHub"
+	},
+	"gitlabUsernameLabel": {
+		"message": "שם המשתמש שלך ב-GitLab"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "נדרש כדי להביא את התרומות שלך"
+	},
+	"contributionsLabel": {
+		"message": "הבא את התרומות שלך עבור:"
+	},
+	"last1DayLabel": {
+		"message": "היום הקודם"
+	},
+	"startDateLabel": {
+		"message": "מ:"
+	},
+	"endDateLabel": {
+		"message": "עד:"
+	},
+	"showOpenClosedLabel": {
+		"message": "הצג סטטוס פתוח/סגור"
+	},
+	"blockersLabel": {
+		"message": "מה מונע ממך להתקדם?"
+	},
+	"blockersPlaceholder": {
+		"message": "הזן את הסיבה שלך"
+	},
+	"scrumReportLabel": {
+		"message": "דוח סקראם"
+	},
+	"generateReportButton": {
+		"message": "צור דוח"
+	},
+	"copyReportButton": {
+		"message": "העתק דוח"
+	},
+	"insertInEmailButton": {
+		"message": "הוסף לאימייל",
+		"description": "Text for the 'Insert to Email' button."
+	},
+	"settingsOrgNameLabel": {
+		"message": "שם הארגון"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "הזן את שם הארגון"
+	},
+	"setButton": {
+		"message": "הגדר"
+	},
+	"githubTokenLabel": {
+		"message": "אסימון ה-GitHub שלך"
+	},
+	"githubTokenPlaceholder": {
+		"message": "נדרש לבקשות מאומתות"
+	},
+	"githubTokenTooltip": {
+		"message": "למה מומלץ להוסיף אסימון GitHub? Scrum Helper עובד ללא אסימון GitHub, אך הוספת אסימון גישה אישי מומלצת לחוויה טובה יותר."
+	},
+	"gitlabTokenLabel": {
+		"message": "אסימון ה-GitLab שלך"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "נדרש למאגרים פרטיים"
+	},
+	"gitlabTokenTooltip": {
+		"message": "למה מומלץ להוסיף אסימון GitLab? Scrum Helper עובד ללא אסימון GitLab לפרויקטים ציבוריים, אך הוספת אסימון גישה אישי מומלצת לחוויה טובה יותר."
+	},
+	"showCommitsLabel": {
+		"message": "הצג קומיטים ב-PR פתוחים/טיוטות PR"
+	},
+	"showCommitsTooltip": {
+		"message": "נדרש אסימון GitHub, הוסף אותו בהגדרות."
+	},
+	"onlyIssuesLabel": {
+		"message": "הכלל רק בעיות בדוח"
+	},
+	"onlyIssuesTooltip": {
+		"message": "אם מסומן, הדוח יכיל רק בעיות שנוצרו או הוקצו למשתמש."
+	},
+	"onlyPRsLabel": {
+		"message": "הכלל רק PR בדוח"
+	},
+	"onlyPRsTooltip": {
+		"message": "אם מסומן, הדוח יכיל רק pull requests שנוצרו על ידי המשתמש; PR שנסקרו יוחרגו."
+	},
+	"cacheTTLLabel": {
+		"message": "הזן TTL למטמון"
+	},
+	"cacheTTLUnit": {
+		"message": "(בדקות)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "כתוב את ה-TTL של המטמון בדקות (ברירת מחדל: 10)"
+	},
+	"refreshDataButton": {
+		"message": "רענן נתונים (עקוף מטמון)"
+	},
+	"refreshDataInfo": {
+		"message": "השתמש בכפתור זה כדי להביא נתונים טריים באופן מיידי."
+	},
+	"noteTitle": {
+		"message": "הערה:"
+	},
+	"viewCodeButton": {
+		"message": "הצג קוד"
+	},
+	"reportIssueButton": {
+		"message": "דווח על בעיה"
+	},
+	"repoFilterLabel": {
+		"message": "סנן לפי מאגרים"
+	},
+	"enableFilteringLabel": {
+		"message": "הפעל סינון"
+	},
+	"tokenRequiredWarning": {
+		"message": "נדרש אסימון GitHub לסינון מאגרים. אנא הוסף אחד בהגדרות."
+	},
+	"repoSearchPlaceholder": {
+		"message": "חפש מאגר להוספה..."
+	},
+	"repoPlaceholder": {
+		"message": "לא נבחרו מאגרים (כולם ייכללו)"
+	},
+	"repoCountNone": {
+		"message": "נבחרו 0 מאגרים"
+	},
+	"repoCount": {
+		"message": "נבחרו $1 מאגרים"
+	},
+	"repoLoading": {
+		"message": "טוען מאגרים..."
+	},
+	"repoLoaded": {
+		"message": "נטענו $1 מאגרים."
+	},
+	"repoNotFound": {
+		"message": "לא נמצאו מאגרים"
+	},
+	"repoRefetching": {
+		"message": "מביא מחדש מאגרים..."
+	},
+	"repoLoadFailed": {
+		"message": "נכשל בטעינת מאגרים."
+	},
+	"repoTokenPrivate": {
+		"message": "האסימון אינו חוקי או שאין לו הרשאות למאגרים פרטיים."
+	},
+	"repoRefetchFailed": {
+		"message": "נכשל בהבאה מחדש של מאגרים."
+	},
+	"orgSetMessage": {
+		"message": "הארגון הוגדר בהצלחה."
+	},
+	"orgClearedMessage": {
+		"message": "הארגון נוקה. לחץ על 'צור דוח' כדי להביא את כל הפעילויות."
+	},
+	"orgNotFoundMessage": {
+		"message": "הארגון לא נמצא ב-GitHub."
+	},
+	"orgValidationErrorMessage": {
+		"message": "שגיאה באימות הארגון."
+	},
+	"refreshingButton": {
+		"message": "מרענן..."
+	},
+	"cacheClearFailed": {
+		"message": "ניקוי המטמון נכשל."
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "יוצר..."
+	},
+	"copiedButton": {
+		"message": "הועתק!"
+	},
+	"orgChangedMessage": {
+		"message": "הארגון השתנה. לחץ על 'צור דוח' כדי להביא פעילויות GitHub."
+	},
+	"cacheClearedMessage": {
+		"message": "המטמון נוקה בהצלחה. לחץ על 'צור דוח' כדי להביא נתונים טריים."
+	},
+	"cacheExpiredMessage": {
+		"message": "המטמון פג תוקף. לחץ על \"צור\" כדי להביא נתונים חדשים.",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "המטמון נוקה!"
+	},
+	"extensionDisabledMessage": {
+		"message": "ההרחבה מושבתת. הפעל אותה מההגדרות כדי ליצור דוחות סקראם."
+	},
+	"notePoint1": {
+		"message": "בקשות משיכה (Pull requests) מאוחזרות על סמך פעילות הסקירה האחרונה של כל תורם, לא רק שלך. אנא בדוק והתאם את דוח ה-SCRUM שנוצר כדי לוודא שהוא משקף במדויק את עבודתך לפני השיתוף."
+	},
+	"noteSeeIssue": {
+		"message": "ראה בעיה זו"
+	},
+	"platformLabel": {
+		"message": "פלטפורמה"
+	},
+	"usernameLabel": {
+		"message": "שם המשתמש שלך"
+	},
+	"onlyRevPRsLabel": {
+		"message": "כלול בדוח רק PR שנבדקו על ידך"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "אם מסומן, הדוח יכלול רק PR שנבדקו על ידך."
+	},
+	"usernameRequiredError": {
 		"message": "אנא הזן את שם המשתמש שלך כדי ליצור דוח."
 	},
 	"unknownPlatformError": {
@@ -291,29 +291,53 @@
 	},
 	"gitlabContributedError": {
 		"message": "שגיאה באחזור פרויקטים שאליהם המשתמש תרם ב-GitLab: $1 $2"
-    },
-    "usernameMissingError": {
+	},
+	"usernameMissingError": {
 		"message": "שם משתמש נדרש."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "מייצר דוח..."
-    },
-    "copyingReportNotification": {
-        "message": "מעתיק דוח..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "מוסיף דוח לאימייל..."
-    },
-    "insertedInEmailNotification": {
-        "message": "הדוח הוכנס לאימייל!"
-    }
+	},
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"generatingReportNotification": {
+		"message": "מייצר דוח..."
+	},
+	"copyingReportNotification": {
+		"message": "מעתיק דוח..."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "מוסיף דוח לאימייל..."
+	},
+	"insertedInEmailNotification": {
+		"message": "הדוח הוכנס לאימייל!"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -1,238 +1,238 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "एक चयनित अवधि के लिए अपनी Git गतिविधि को स्वतः प्राप्त करके अपनी विकास प्रगति की रिपोर्ट करें।"
-    },
-    "disableLabel": {
-        "message": "अक्षम करें"
-    },
-    "enableLabel": {
-        "message": "सक्षम करें"
-    },
-    "projectNameLabel": {
-        "message": "ईमेल विषय"
-    },
-    "projectNamePlaceholder": {
-        "message": "अपनी परियोजना का नाम दर्ज करें"
-    },
-    "githubUsernameLabel": {
-        "message": "आपका GitHub उपयोगकर्ता नाम"
-    },
-    "gitlabUsernameLabel": {
-        "message": "आपका GitLab उपयोगकर्ता नाम"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "आपके योगदानों को प्राप्त करने के लिए आवश्यक"
-    },
-    "contributionsLabel": {
-        "message": "इस अवधि के योगदान प्राप्त करें:"
-    },
-    "last1DayLabel": {
-        "message": "पिछला दिन"
-    },
-    "startDateLabel": {
-        "message": "प्रारंभ तिथि:"
-    },
-    "endDateLabel": {
-        "message": "अंतिम तिथि:"
-    },
-    "showOpenClosedLabel": {
-        "message": "खुला/बंद स्थिति दिखाएं"
-    },
-    "blockersLabel": {
-        "message": "आपको प्रगति करने से क्या रोक रहा है?"
-    },
-    "blockersPlaceholder": {
-        "message": "अपना कारण दर्ज करें"
-    },
-    "scrumReportLabel": {
-        "message": "स्क्रम रिपोर्ट"
-    },
-    "generateReportButton": {
-        "message": "जनरेट"
-    },
-    "copyReportButton": {
-        "message": "कॉपी"
-    },
-    "insertInEmailButton": {
-        "message": "ईमेल में डालें"
-    },
-    "settingsOrgNameLabel": {
-        "message": "संगठन का नाम"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "संगठन का नाम दर्ज करें"
-    },
-    "setButton": {
-        "message": "सेट करें"
-    },
-    "githubTokenLabel": {
-        "message": "आपका GitHub टोकन"
-    },
-    "githubTokenPlaceholder": {
-        "message": "प्रमाणित अनुरोधों के लिए आवश्यक"
-    },
-    "githubTokenTooltip": {
-        "message": "GitHub टोकन जोड़ने की सिफारिश क्यों की जाती है? Scrum Helper बिना GitHub टोकन के काम करता है, लेकिन बेहतर अनुभव के लिए व्यक्तिगत एक्सेस टोकन जोड़ने की सिफारिश की जाती है।"
-    },
-    "gitlabTokenLabel": {
-        "message": "आपका GitLab टोकन"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "निजी रेपो के लिए आवश्यक"
-    },
-    "gitlabTokenTooltip": {
-        "message": "GitLab टोकन जोड़ने की सिफारिश क्यों की जाती है? Scrum Helper सार्वजनिक परियोजनाओं के लिए बिना GitLab टोकन के काम करता है, लेकिन बेहतर अनुभव के लिए व्यक्तिगत एक्सेस टोकन जोड़ने की सिफारिश की जाती है।"
-    },
-    "showCommitsLabel": {
-        "message": "खुले पीआर/ ड्राफ्ट पीआर पर कमिट दिखाएं"
-    },
-    "showCommitsTooltip": {
-        "message": "गिटहब टोकन आवश्यक है, इसे सेटिंग्स में जोड़ें।"
-    },
-    "onlyIssuesLabel": {
-        "message": "रिपोर्ट में केवल समस्याएं शामिल करें"
-    },
-    "onlyIssuesTooltip": {
-        "message": "यदि चेक किया गया है, तो रिपोर्ट में केवल उपयोगकर्ता द्वारा बनाए गए या सौंपे गए मुद्दे शामिल होंगे।"
-    },
-    "onlyPRsLabel": {
-        "message": "रिपोर्ट में केवल PRs शामिल करें"
-    },
-    "onlyPRsTooltip": {
-        "message": "चेक करने पर रिपोर्ट में केवल उपयोगकर्ता द्वारा बनाई गई PRs शामिल होंगी; समीक्षित PRs बाहर रखी जाएँगी."
-    },
-    "cacheTTLLabel": {
-        "message": "कैश टीटीएल दर्ज करें",
-        "description": "कैश टाइम-टू-लाइव इनपुट के लिए लेबल।"
-    },
-    "cacheTTLUnit": {
-        "message": "(मिनटों में)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "कैश TTL मिनटों में लिखें (डिफ़ॉल्ट: 10)"
-    },
-    "refreshDataButton": {
-        "message": "डेटा रीफ्रेश करें (कैश को बायपास करें)"
-    },
-    "refreshDataInfo": {
-        "message": "ताज़ा डेटा तुरंत प्राप्त करने के लिए इस बटन का उपयोग करें।"
-    },
-    "noteTitle": {
-        "message": "ध्यान दें:"
-    },
-    "viewCodeButton": {
-        "message": "कोड देखें"
-    },
-    "reportIssueButton": {
-        "message": "समस्या की रिपोर्ट करें"
-    },
-    "repoFilterLabel": {
-        "message": "रिपॉजिटरी द्वारा फ़िल्टर करें"
-    },
-    "enableFilteringLabel": {
-        "message": "फ़िल्टरिंग सक्षम करें"
-    },
-    "tokenRequiredWarning": {
-        "message": "रिपॉजिटरी फ़िल्टरिंग के लिए एक GitHub टोकन आवश्यक है। कृपया सेटिंग्स में एक जोड़ें।"
-    },
-    "repoSearchPlaceholder": {
-        "message": "जोड़ने के लिए एक रिपॉजिटरी खोजें..."
-    },
-    "repoPlaceholder": {
-        "message": "कोई रिपॉजिटरी चयनित नहीं (सभी शामिल होंगी)"
-    },
-    "repoCountNone": {
-        "message": "0 रिपॉजिटरी चयनित"
-    },
-    "repoCount": {
-        "message": "$1 रिपॉजिटरी चयनित"
-    },
-    "repoLoading": {
-        "message": "रिपॉजिटरी लोड हो रही हैं..."
-    },
-    "repoLoaded": {
-        "message": "$1 रिपॉजिटरी लोड हो गईं।"
-    },
-    "repoNotFound": {
-        "message": "कोई रिपॉजिटरी नहीं मिली"
-    },
-    "repoRefetching": {
-        "message": "रिपॉजिटरी फिर से लोड हो रही हैं..."
-    },
-    "repoLoadFailed": {
-        "message": "रिपॉजिटरी लोड करने में विफल।"
-    },
-    "repoTokenPrivate": {
-        "message": "टोकन अमान्य है या निजी रिपॉजिटरी के लिए अधिकार नहीं हैं।"
-    },
-    "repoRefetchFailed": {
-        "message": "रिपॉजिटरी फिर से लोड करने में विफल।"
-    },
-    "orgSetMessage": {
-        "message": "संगठन सफलतापूर्वक सेट हो गया।"
-    },
-    "orgClearedMessage": {
-        "message": "संगठन साफ़ हो गया। सभी गतिविधियाँ प्राप्त करने के लिए 'रिपोर्ट बनाएं' पर क्लिक करें।"
-    },
-    "orgNotFoundMessage": {
-        "message": "GitHub पर संगठन नहीं मिला।"
-    },
-    "orgValidationErrorMessage": {
-        "message": "संगठन को मान्य करने में त्रुटि।"
-    },
-    "refreshingButton": {
-        "message": "रीफ्रेश हो रहा है..."
-    },
-    "cacheClearFailed": {
-        "message": "कैश साफ़ करने में विफल।"
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "बनाया जा रहा है..."
-    },
-    "copiedButton": {
-        "message": "कॉपी किया गया!"
-    },
-    "orgChangedMessage": {
-        "message": "संगठन बदल गया है। GitHub गतिविधियाँ प्राप्त करने के लिए 'रिपोर्ट बनाएं' बटन पर क्लिक करें।"
-    },
-    "cacheClearedMessage": {
-        "message": "कैश सफलतापूर्वक साफ़ हो गया। ताज़ा डेटा प्राप्त करने के लिए 'रिपोर्ट बनाएं' पर क्लिक करें।"
-    },
-    "cacheExpiredMessage": {
-        "message": "कैश समाप्त हो गया। नया डेटा प्राप्त करने के लिए \"रिपोर्ट बनाएं\" पर क्लिक करें।",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "कैश साफ़ हो गया!"
-    },
-    "extensionDisabledMessage": {
-        "message": "एक्सटेंशन अक्षम है। स्क्रम रिपोर्ट बनाने के लिए इसे विकल्पों से सक्षम करें।"
-    },
-    "notePoint1": {
-        "message": "पुल रिक्वेस्ट किसी भी योगदानकर्ता की सबसे हालिया समीक्षा गतिविधि के आधार पर प्राप्त की जाती हैं, न कि केवल आपकी अपनी। कृपया साझा करने से पहले उत्पन्न SCRUM रिपोर्ट की समीक्षा करें और उसे समायोजित करें ताकि यह सुनिश्चित हो सके कि यह आपके काम को सटीक रूप से दर्शाती है।"
-    },
-    "noteSeeIssue": {
-        "message": "यह समस्या देखें"
-    },
-    "platformLabel": {
-        "message": "प्लेटफ़ॉर्म"
-    },
-    "usernameLabel": {
-        "message": "आपका उपयोगकर्ता नाम"
-    },
-    "onlyRevPRsLabel": {
-        "message": "रिपोर्ट में केवल समीक्षित PRs शामिल करें"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "यदि चेक किया गया है, तो रिपोर्ट में केवल आपके द्वारा समीक्षित PRs शामिल होंगे।"
-    },
-    "usernameRequiredError": {
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "एक चयनित अवधि के लिए अपनी Git गतिविधि को स्वतः प्राप्त करके अपनी विकास प्रगति की रिपोर्ट करें।"
+	},
+	"disableLabel": {
+		"message": "अक्षम करें"
+	},
+	"enableLabel": {
+		"message": "सक्षम करें"
+	},
+	"projectNameLabel": {
+		"message": "ईमेल विषय"
+	},
+	"projectNamePlaceholder": {
+		"message": "अपनी परियोजना का नाम दर्ज करें"
+	},
+	"githubUsernameLabel": {
+		"message": "आपका GitHub उपयोगकर्ता नाम"
+	},
+	"gitlabUsernameLabel": {
+		"message": "आपका GitLab उपयोगकर्ता नाम"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "आपके योगदानों को प्राप्त करने के लिए आवश्यक"
+	},
+	"contributionsLabel": {
+		"message": "इस अवधि के योगदान प्राप्त करें:"
+	},
+	"last1DayLabel": {
+		"message": "पिछला दिन"
+	},
+	"startDateLabel": {
+		"message": "प्रारंभ तिथि:"
+	},
+	"endDateLabel": {
+		"message": "अंतिम तिथि:"
+	},
+	"showOpenClosedLabel": {
+		"message": "खुला/बंद स्थिति दिखाएं"
+	},
+	"blockersLabel": {
+		"message": "आपको प्रगति करने से क्या रोक रहा है?"
+	},
+	"blockersPlaceholder": {
+		"message": "अपना कारण दर्ज करें"
+	},
+	"scrumReportLabel": {
+		"message": "स्क्रम रिपोर्ट"
+	},
+	"generateReportButton": {
+		"message": "जनरेट"
+	},
+	"copyReportButton": {
+		"message": "कॉपी"
+	},
+	"insertInEmailButton": {
+		"message": "ईमेल में डालें"
+	},
+	"settingsOrgNameLabel": {
+		"message": "संगठन का नाम"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "संगठन का नाम दर्ज करें"
+	},
+	"setButton": {
+		"message": "सेट करें"
+	},
+	"githubTokenLabel": {
+		"message": "आपका GitHub टोकन"
+	},
+	"githubTokenPlaceholder": {
+		"message": "प्रमाणित अनुरोधों के लिए आवश्यक"
+	},
+	"githubTokenTooltip": {
+		"message": "GitHub टोकन जोड़ने की सिफारिश क्यों की जाती है? Scrum Helper बिना GitHub टोकन के काम करता है, लेकिन बेहतर अनुभव के लिए व्यक्तिगत एक्सेस टोकन जोड़ने की सिफारिश की जाती है।"
+	},
+	"gitlabTokenLabel": {
+		"message": "आपका GitLab टोकन"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "निजी रेपो के लिए आवश्यक"
+	},
+	"gitlabTokenTooltip": {
+		"message": "GitLab टोकन जोड़ने की सिफारिश क्यों की जाती है? Scrum Helper सार्वजनिक परियोजनाओं के लिए बिना GitLab टोकन के काम करता है, लेकिन बेहतर अनुभव के लिए व्यक्तिगत एक्सेस टोकन जोड़ने की सिफारिश की जाती है।"
+	},
+	"showCommitsLabel": {
+		"message": "खुले पीआर/ ड्राफ्ट पीआर पर कमिट दिखाएं"
+	},
+	"showCommitsTooltip": {
+		"message": "गिटहब टोकन आवश्यक है, इसे सेटिंग्स में जोड़ें।"
+	},
+	"onlyIssuesLabel": {
+		"message": "रिपोर्ट में केवल समस्याएं शामिल करें"
+	},
+	"onlyIssuesTooltip": {
+		"message": "यदि चेक किया गया है, तो रिपोर्ट में केवल उपयोगकर्ता द्वारा बनाए गए या सौंपे गए मुद्दे शामिल होंगे।"
+	},
+	"onlyPRsLabel": {
+		"message": "रिपोर्ट में केवल PRs शामिल करें"
+	},
+	"onlyPRsTooltip": {
+		"message": "चेक करने पर रिपोर्ट में केवल उपयोगकर्ता द्वारा बनाई गई PRs शामिल होंगी; समीक्षित PRs बाहर रखी जाएँगी."
+	},
+	"cacheTTLLabel": {
+		"message": "कैश टीटीएल दर्ज करें",
+		"description": "कैश टाइम-टू-लाइव इनपुट के लिए लेबल।"
+	},
+	"cacheTTLUnit": {
+		"message": "(मिनटों में)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "कैश TTL मिनटों में लिखें (डिफ़ॉल्ट: 10)"
+	},
+	"refreshDataButton": {
+		"message": "डेटा रीफ्रेश करें (कैश को बायपास करें)"
+	},
+	"refreshDataInfo": {
+		"message": "ताज़ा डेटा तुरंत प्राप्त करने के लिए इस बटन का उपयोग करें।"
+	},
+	"noteTitle": {
+		"message": "ध्यान दें:"
+	},
+	"viewCodeButton": {
+		"message": "कोड देखें"
+	},
+	"reportIssueButton": {
+		"message": "समस्या की रिपोर्ट करें"
+	},
+	"repoFilterLabel": {
+		"message": "रिपॉजिटरी द्वारा फ़िल्टर करें"
+	},
+	"enableFilteringLabel": {
+		"message": "फ़िल्टरिंग सक्षम करें"
+	},
+	"tokenRequiredWarning": {
+		"message": "रिपॉजिटरी फ़िल्टरिंग के लिए एक GitHub टोकन आवश्यक है। कृपया सेटिंग्स में एक जोड़ें।"
+	},
+	"repoSearchPlaceholder": {
+		"message": "जोड़ने के लिए एक रिपॉजिटरी खोजें..."
+	},
+	"repoPlaceholder": {
+		"message": "कोई रिपॉजिटरी चयनित नहीं (सभी शामिल होंगी)"
+	},
+	"repoCountNone": {
+		"message": "0 रिपॉजिटरी चयनित"
+	},
+	"repoCount": {
+		"message": "$1 रिपॉजिटरी चयनित"
+	},
+	"repoLoading": {
+		"message": "रिपॉजिटरी लोड हो रही हैं..."
+	},
+	"repoLoaded": {
+		"message": "$1 रिपॉजिटरी लोड हो गईं।"
+	},
+	"repoNotFound": {
+		"message": "कोई रिपॉजिटरी नहीं मिली"
+	},
+	"repoRefetching": {
+		"message": "रिपॉजिटरी फिर से लोड हो रही हैं..."
+	},
+	"repoLoadFailed": {
+		"message": "रिपॉजिटरी लोड करने में विफल।"
+	},
+	"repoTokenPrivate": {
+		"message": "टोकन अमान्य है या निजी रिपॉजिटरी के लिए अधिकार नहीं हैं।"
+	},
+	"repoRefetchFailed": {
+		"message": "रिपॉजिटरी फिर से लोड करने में विफल।"
+	},
+	"orgSetMessage": {
+		"message": "संगठन सफलतापूर्वक सेट हो गया।"
+	},
+	"orgClearedMessage": {
+		"message": "संगठन साफ़ हो गया। सभी गतिविधियाँ प्राप्त करने के लिए 'रिपोर्ट बनाएं' पर क्लिक करें।"
+	},
+	"orgNotFoundMessage": {
+		"message": "GitHub पर संगठन नहीं मिला।"
+	},
+	"orgValidationErrorMessage": {
+		"message": "संगठन को मान्य करने में त्रुटि।"
+	},
+	"refreshingButton": {
+		"message": "रीफ्रेश हो रहा है..."
+	},
+	"cacheClearFailed": {
+		"message": "कैश साफ़ करने में विफल।"
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "बनाया जा रहा है..."
+	},
+	"copiedButton": {
+		"message": "कॉपी किया गया!"
+	},
+	"orgChangedMessage": {
+		"message": "संगठन बदल गया है। GitHub गतिविधियाँ प्राप्त करने के लिए 'रिपोर्ट बनाएं' बटन पर क्लिक करें।"
+	},
+	"cacheClearedMessage": {
+		"message": "कैश सफलतापूर्वक साफ़ हो गया। ताज़ा डेटा प्राप्त करने के लिए 'रिपोर्ट बनाएं' पर क्लिक करें।"
+	},
+	"cacheExpiredMessage": {
+		"message": "कैश समाप्त हो गया। नया डेटा प्राप्त करने के लिए \"रिपोर्ट बनाएं\" पर क्लिक करें।",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "कैश साफ़ हो गया!"
+	},
+	"extensionDisabledMessage": {
+		"message": "एक्सटेंशन अक्षम है। स्क्रम रिपोर्ट बनाने के लिए इसे विकल्पों से सक्षम करें।"
+	},
+	"notePoint1": {
+		"message": "पुल रिक्वेस्ट किसी भी योगदानकर्ता की सबसे हालिया समीक्षा गतिविधि के आधार पर प्राप्त की जाती हैं, न कि केवल आपकी अपनी। कृपया साझा करने से पहले उत्पन्न SCRUM रिपोर्ट की समीक्षा करें और उसे समायोजित करें ताकि यह सुनिश्चित हो सके कि यह आपके काम को सटीक रूप से दर्शाती है।"
+	},
+	"noteSeeIssue": {
+		"message": "यह समस्या देखें"
+	},
+	"platformLabel": {
+		"message": "प्लेटफ़ॉर्म"
+	},
+	"usernameLabel": {
+		"message": "आपका उपयोगकर्ता नाम"
+	},
+	"onlyRevPRsLabel": {
+		"message": "रिपोर्ट में केवल समीक्षित PRs शामिल करें"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "यदि चेक किया गया है, तो रिपोर्ट में केवल आपके द्वारा समीक्षित PRs शामिल होंगे।"
+	},
+	"usernameRequiredError": {
 		"message": "रिपोर्ट बनाने के लिए कृपया अपना उपयोगकर्ता नाम दर्ज करें।"
 	},
 	"unknownPlatformError": {
@@ -295,25 +295,49 @@
 	"usernameMissingError": {
 		"message": "उपयोगकर्ता नाम आवश्यक है।"
 	},
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "रिपोर्ट तैयार हो रही है..."
-    },
-    "copyingReportNotification": {
-        "message": "रिपोर्ट कॉपी की जा रही है..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "रिपोर्ट ईमेल में डाली जा रही है..."
-    },
-    "insertedInEmailNotification": {
-        "message": "रिपोर्ट ईमेल में डाल दी गई!"
-    }
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"generatingReportNotification": {
+		"message": "रिपोर्ट तैयार हो रही है..."
+	},
+	"copyingReportNotification": {
+		"message": "रिपोर्ट कॉपी की जा रही है..."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "रिपोर्ट ईमेल में डाली जा रही है..."
+	},
+	"insertedInEmailNotification": {
+		"message": "रिपोर्ट ईमेल में डाल दी गई!"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -1,238 +1,238 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Laporkan kemajuan pengembangan Anda dengan mengambil aktivitas Git Anda secara otomatis untuk periode yang dipilih."
-    },
-    "disableLabel": {
-        "message": "Nonaktifkan"
-    },
-    "enableLabel": {
-        "message": "Aktifkan"
-    },
-    "projectNameLabel": {
-        "message": "Nama Proyek (digunakan di subjek email)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Masukkan nama proyek Anda"
-    },
-    "githubUsernameLabel": {
-        "message": "Nama Pengguna GitHub Anda"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Nama Pengguna GitLab Anda"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Diperlukan untuk mengambil kontribusi Anda"
-    },
-    "contributionsLabel": {
-        "message": "Ambil kontribusi Anda untuk:"
-    },
-    "last1DayLabel": {
-        "message": "Hari sebelumnya"
-    },
-    "startDateLabel": {
-        "message": "Dari:"
-    },
-    "endDateLabel": {
-        "message": "Hingga:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Tampilkan status Buka/Tutup"
-    },
-    "blockersLabel": {
-        "message": "Apa yang menghalangi kemajuan Anda?"
-    },
-    "blockersPlaceholder": {
-        "message": "Masukkan alasan Anda"
-    },
-    "scrumReportLabel": {
-        "message": "Laporan Scrum"
-    },
-    "generateReportButton": {
-        "message": "Buat"
-    },
-    "copyReportButton": {
-        "message": "Salin"
-    },
-    "insertInEmailButton": {
-        "message": "Sisipkan ke Email"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nama Organisasi"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Masukkan nama organisasi"
-    },
-    "setButton": {
-        "message": "Atur"
-    },
-    "githubTokenLabel": {
-        "message": "Token GitHub Anda"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Diperlukan untuk permintaan terotentikasi"
-    },
-    "githubTokenTooltip": {
-        "message": "Mengapa disarankan untuk menambahkan token GitHub? Scrum Helper berfungsi tanpa token GitHub, tetapi menambahkan token akses pribadi disarankan untuk pengalaman yang lebih baik."
-    },
-    "gitlabTokenLabel": {
-        "message": "Token GitLab Anda"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Diperlukan untuk repo pribadi"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Mengapa disarankan untuk menambahkan token GitLab? Scrum Helper berfungsi tanpa token GitLab untuk proyek publik, tetapi menambahkan token akses pribadi disarankan untuk pengalaman yang lebih baik."
-    },
-    "showCommitsLabel": {
-        "message": "Tampilkan commit pada PR terbuka/ draf PR"
-    },
-    "showCommitsTooltip": {
-        "message": "Token Github diperlukan, tambahkan di pengaturan."
-    },
-    "onlyIssuesLabel": {
-        "message": "Hanya sertakan masalah dalam laporan"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Jika dicentang, laporan hanya akan menyertakan masalah yang dibuat atau ditugaskan kepada pengguna."
-    },
-    "onlyPRsLabel": {
-        "message": "Hanya sertakan PR dalam laporan"
-    },
-    "onlyPRsTooltip": {
-        "message": "Jika dicentang, laporan hanya akan menyertakan PR yang dibuat oleh pengguna; PR yang telah ditinjau akan dikecualikan."
-    },
-    "cacheTTLLabel": {
-        "message": "Masukkan TTL cache",
-        "description": "Label untuk masukan time-to-live cache."
-    },
-    "cacheTTLUnit": {
-        "message": "(dalam menit)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Tulis TTL Cache dalam menit (Default: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Segarkan Data (abaikan cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Gunakan tombol ini untuk mengambil data baru segera."
-    },
-    "noteTitle": {
-        "message": "Catatan:"
-    },
-    "viewCodeButton": {
-        "message": "Lihat Kode"
-    },
-    "reportIssueButton": {
-        "message": "Laporkan Masalah"
-    },
-    "repoFilterLabel": {
-        "message": "Filter berdasarkan repositori"
-    },
-    "enableFilteringLabel": {
-        "message": "Aktifkan pemfilteran"
-    },
-    "tokenRequiredWarning": {
-        "message": "Token GitHub diperlukan untuk pemfilteran repositori. Harap tambahkan di pengaturan."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Cari repositori untuk ditambahkan..."
-    },
-    "repoPlaceholder": {
-        "message": "Tidak ada repositori yang dipilih (semua akan disertakan)"
-    },
-    "repoCountNone": {
-        "message": "0 repositori dipilih"
-    },
-    "repoCount": {
-        "message": "$1 repositori dipilih"
-    },
-    "repoLoading": {
-        "message": "Memuat repositori..."
-    },
-    "repoLoaded": {
-        "message": "$1 repositori dimuat."
-    },
-    "repoNotFound": {
-        "message": "Tidak ada repositori ditemukan"
-    },
-    "repoRefetching": {
-        "message": "Memuat ulang repositori..."
-    },
-    "repoLoadFailed": {
-        "message": "Gagal memuat repositori."
-    },
-    "repoTokenPrivate": {
-        "message": "Token tidak valid atau tidak memiliki hak untuk repo pribadi."
-    },
-    "repoRefetchFailed": {
-        "message": "Gagal memuat ulang repositori."
-    },
-    "orgSetMessage": {
-        "message": "Organisasi berhasil diatur."
-    },
-    "orgClearedMessage": {
-        "message": "Organisasi dihapus. Klik 'Buat Laporan' untuk mengambil semua aktivitas."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organisasi tidak ditemukan di GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Gagal memvalidasi organisasi."
-    },
-    "refreshingButton": {
-        "message": "Menyegarkan..."
-    },
-    "cacheClearFailed": {
-        "message": "Gagal membersihkan cache."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Membuat..."
-    },
-    "copiedButton": {
-        "message": "Tersalin!"
-    },
-    "orgChangedMessage": {
-        "message": "Organisasi diubah. Klik tombol 'Buat Laporan' untuk mengambil aktivitas GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache berhasil dihapus. Klik 'Buat Laporan' untuk mengambil data baru."
-    },
-    "cacheExpiredMessage": {
-        "message": "Cache telah kedaluwarsa. Klik \"Buat\" untuk mengambil data baru.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Cache Dihapus!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Ekstensi dinonaktifkan. Aktifkan dari opsi untuk membuat laporan scrum."
-    },
-    "notePoint1": {
-        "message": "Pull request diambil berdasarkan aktivitas review terbaru oleh kontributor mana pun, bukan hanya milik Anda. Harap tinjau dan sesuaikan laporan SCRUM yang dihasilkan untuk memastikan laporan tersebut secara akurat mencerminkan pekerjaan Anda sebelum dibagikan."
-    },
-    "noteSeeIssue": {
-        "message": "Lihat masalah ini"
-    },
-    "platformLabel": {
-        "message": "Platform"
-    },
-    "usernameLabel": {
-        "message": "Nama pengguna Anda"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Hanya sertakan PR yang ditinjau dalam laporan"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Jika dicentang, laporan hanya akan menyertakan PR yang ditinjau oleh Anda."
-    },
-    	"usernameRequiredError": {
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "Laporkan kemajuan pengembangan Anda dengan mengambil aktivitas Git Anda secara otomatis untuk periode yang dipilih."
+	},
+	"disableLabel": {
+		"message": "Nonaktifkan"
+	},
+	"enableLabel": {
+		"message": "Aktifkan"
+	},
+	"projectNameLabel": {
+		"message": "Nama Proyek (digunakan di subjek email)"
+	},
+	"projectNamePlaceholder": {
+		"message": "Masukkan nama proyek Anda"
+	},
+	"githubUsernameLabel": {
+		"message": "Nama Pengguna GitHub Anda"
+	},
+	"gitlabUsernameLabel": {
+		"message": "Nama Pengguna GitLab Anda"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "Diperlukan untuk mengambil kontribusi Anda"
+	},
+	"contributionsLabel": {
+		"message": "Ambil kontribusi Anda untuk:"
+	},
+	"last1DayLabel": {
+		"message": "Hari sebelumnya"
+	},
+	"startDateLabel": {
+		"message": "Dari:"
+	},
+	"endDateLabel": {
+		"message": "Hingga:"
+	},
+	"showOpenClosedLabel": {
+		"message": "Tampilkan status Buka/Tutup"
+	},
+	"blockersLabel": {
+		"message": "Apa yang menghalangi kemajuan Anda?"
+	},
+	"blockersPlaceholder": {
+		"message": "Masukkan alasan Anda"
+	},
+	"scrumReportLabel": {
+		"message": "Laporan Scrum"
+	},
+	"generateReportButton": {
+		"message": "Buat"
+	},
+	"copyReportButton": {
+		"message": "Salin"
+	},
+	"insertInEmailButton": {
+		"message": "Sisipkan ke Email"
+	},
+	"settingsOrgNameLabel": {
+		"message": "Nama Organisasi"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "Masukkan nama organisasi"
+	},
+	"setButton": {
+		"message": "Atur"
+	},
+	"githubTokenLabel": {
+		"message": "Token GitHub Anda"
+	},
+	"githubTokenPlaceholder": {
+		"message": "Diperlukan untuk permintaan terotentikasi"
+	},
+	"githubTokenTooltip": {
+		"message": "Mengapa disarankan untuk menambahkan token GitHub? Scrum Helper berfungsi tanpa token GitHub, tetapi menambahkan token akses pribadi disarankan untuk pengalaman yang lebih baik."
+	},
+	"gitlabTokenLabel": {
+		"message": "Token GitLab Anda"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "Diperlukan untuk repo pribadi"
+	},
+	"gitlabTokenTooltip": {
+		"message": "Mengapa disarankan untuk menambahkan token GitLab? Scrum Helper berfungsi tanpa token GitLab untuk proyek publik, tetapi menambahkan token akses pribadi disarankan untuk pengalaman yang lebih baik."
+	},
+	"showCommitsLabel": {
+		"message": "Tampilkan commit pada PR terbuka/ draf PR"
+	},
+	"showCommitsTooltip": {
+		"message": "Token Github diperlukan, tambahkan di pengaturan."
+	},
+	"onlyIssuesLabel": {
+		"message": "Hanya sertakan masalah dalam laporan"
+	},
+	"onlyIssuesTooltip": {
+		"message": "Jika dicentang, laporan hanya akan menyertakan masalah yang dibuat atau ditugaskan kepada pengguna."
+	},
+	"onlyPRsLabel": {
+		"message": "Hanya sertakan PR dalam laporan"
+	},
+	"onlyPRsTooltip": {
+		"message": "Jika dicentang, laporan hanya akan menyertakan PR yang dibuat oleh pengguna; PR yang telah ditinjau akan dikecualikan."
+	},
+	"cacheTTLLabel": {
+		"message": "Masukkan TTL cache",
+		"description": "Label untuk masukan time-to-live cache."
+	},
+	"cacheTTLUnit": {
+		"message": "(dalam menit)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "Tulis TTL Cache dalam menit (Default: 10)"
+	},
+	"refreshDataButton": {
+		"message": "Segarkan Data (abaikan cache)"
+	},
+	"refreshDataInfo": {
+		"message": "Gunakan tombol ini untuk mengambil data baru segera."
+	},
+	"noteTitle": {
+		"message": "Catatan:"
+	},
+	"viewCodeButton": {
+		"message": "Lihat Kode"
+	},
+	"reportIssueButton": {
+		"message": "Laporkan Masalah"
+	},
+	"repoFilterLabel": {
+		"message": "Filter berdasarkan repositori"
+	},
+	"enableFilteringLabel": {
+		"message": "Aktifkan pemfilteran"
+	},
+	"tokenRequiredWarning": {
+		"message": "Token GitHub diperlukan untuk pemfilteran repositori. Harap tambahkan di pengaturan."
+	},
+	"repoSearchPlaceholder": {
+		"message": "Cari repositori untuk ditambahkan..."
+	},
+	"repoPlaceholder": {
+		"message": "Tidak ada repositori yang dipilih (semua akan disertakan)"
+	},
+	"repoCountNone": {
+		"message": "0 repositori dipilih"
+	},
+	"repoCount": {
+		"message": "$1 repositori dipilih"
+	},
+	"repoLoading": {
+		"message": "Memuat repositori..."
+	},
+	"repoLoaded": {
+		"message": "$1 repositori dimuat."
+	},
+	"repoNotFound": {
+		"message": "Tidak ada repositori ditemukan"
+	},
+	"repoRefetching": {
+		"message": "Memuat ulang repositori..."
+	},
+	"repoLoadFailed": {
+		"message": "Gagal memuat repositori."
+	},
+	"repoTokenPrivate": {
+		"message": "Token tidak valid atau tidak memiliki hak untuk repo pribadi."
+	},
+	"repoRefetchFailed": {
+		"message": "Gagal memuat ulang repositori."
+	},
+	"orgSetMessage": {
+		"message": "Organisasi berhasil diatur."
+	},
+	"orgClearedMessage": {
+		"message": "Organisasi dihapus. Klik 'Buat Laporan' untuk mengambil semua aktivitas."
+	},
+	"orgNotFoundMessage": {
+		"message": "Organisasi tidak ditemukan di GitHub."
+	},
+	"orgValidationErrorMessage": {
+		"message": "Gagal memvalidasi organisasi."
+	},
+	"refreshingButton": {
+		"message": "Menyegarkan..."
+	},
+	"cacheClearFailed": {
+		"message": "Gagal membersihkan cache."
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "Membuat..."
+	},
+	"copiedButton": {
+		"message": "Tersalin!"
+	},
+	"orgChangedMessage": {
+		"message": "Organisasi diubah. Klik tombol 'Buat Laporan' untuk mengambil aktivitas GitHub."
+	},
+	"cacheClearedMessage": {
+		"message": "Cache berhasil dihapus. Klik 'Buat Laporan' untuk mengambil data baru."
+	},
+	"cacheExpiredMessage": {
+		"message": "Cache telah kedaluwarsa. Klik \"Buat\" untuk mengambil data baru.",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "Cache Dihapus!"
+	},
+	"extensionDisabledMessage": {
+		"message": "Ekstensi dinonaktifkan. Aktifkan dari opsi untuk membuat laporan scrum."
+	},
+	"notePoint1": {
+		"message": "Pull request diambil berdasarkan aktivitas review terbaru oleh kontributor mana pun, bukan hanya milik Anda. Harap tinjau dan sesuaikan laporan SCRUM yang dihasilkan untuk memastikan laporan tersebut secara akurat mencerminkan pekerjaan Anda sebelum dibagikan."
+	},
+	"noteSeeIssue": {
+		"message": "Lihat masalah ini"
+	},
+	"platformLabel": {
+		"message": "Platform"
+	},
+	"usernameLabel": {
+		"message": "Nama pengguna Anda"
+	},
+	"onlyRevPRsLabel": {
+		"message": "Hanya sertakan PR yang ditinjau dalam laporan"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "Jika dicentang, laporan hanya akan menyertakan PR yang ditinjau oleh Anda."
+	},
+	"usernameRequiredError": {
 		"message": "Silakan masukkan nama pengguna Anda untuk membuat laporan."
 	},
 	"unknownPlatformError": {
@@ -295,25 +295,49 @@
 	"usernameMissingError": {
 		"message": "Nama pengguna diperlukan."
 	},
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Membuat laporan..."
-    },
-    "copyingReportNotification": {
-        "message": "Menyalin laporan..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Menyisipkan laporan ke email..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Laporan disisipkan ke email!"
-    }
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"generatingReportNotification": {
+		"message": "Membuat laporan..."
+	},
+	"copyingReportNotification": {
+		"message": "Menyalin laporan..."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "Menyisipkan laporan ke email..."
+	},
+	"insertedInEmailNotification": {
+		"message": "Laporan disisipkan ke email!"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -1,238 +1,238 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Segnala i tuoi progressi di sviluppo recuperando automaticamente la tua attività Git per un periodo selezionato."
-    },
-    "disableLabel": {
-        "message": "Disabilita"
-    },
-    "enableLabel": {
-        "message": "Abilita"
-    },
-    "projectNameLabel": {
-        "message": "Nome del progetto (usato nell'oggetto dell'email)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Inserisci il nome del tuo progetto"
-    },
-    "githubUsernameLabel": {
-        "message": "Il tuo nome utente GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Il tuo nome utente GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Richiesto per recuperare i tuoi contributi"
-    },
-    "contributionsLabel": {
-        "message": "Recupera i tuoi contributi per:"
-    },
-    "last1DayLabel": {
-        "message": "Giorno precedente"
-    },
-    "startDateLabel": {
-        "message": "Da:"
-    },
-    "endDateLabel": {
-        "message": "A:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Mostra stato Aperto/Chiuso"
-    },
-    "blockersLabel": {
-        "message": "Cosa ti impedisce di progredire?"
-    },
-    "blockersPlaceholder": {
-        "message": "Inserisci il motivo"
-    },
-    "scrumReportLabel": {
-        "message": "Rapporto Scrum"
-    },
-    "generateReportButton": {
-        "message": "Genera Rapporto"
-    },
-    "copyReportButton": {
-        "message": "Copia Rapporto"
-    },
-    "insertInEmailButton": {
-        "message": "Inserisci nell'email",
-        "description": "Text for the 'Insert to Email' button."
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nome dell'organizzazione"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Inserisci il nome dell'organizzazione"
-    },
-    "setButton": {
-        "message": "Imposta"
-    },
-    "githubTokenLabel": {
-        "message": "Il tuo token GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Richiesto per richieste autenticate"
-    },
-    "githubTokenTooltip": {
-        "message": "Perché è consigliato aggiungere un token GitHub? Scrum Helper funziona senza un token GitHub, ma aggiungere un token di accesso personale è consigliato per un'esperienza migliore."
-    },
-    "gitlabTokenLabel": {
-        "message": "Il tuo token GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Richiesto per repo privati"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Perché è consigliato aggiungere un token GitLab? Scrum Helper funziona senza un token GitLab per progetti pubblici, ma aggiungere un token di accesso personale è consigliato per un'esperienza migliore."
-    },
-    "showCommitsLabel": {
-        "message": "Mostra commit su PR aperti/ bozze di PR"
-    },
-    "showCommitsTooltip": {
-        "message": "Token GitHub richiesto, aggiungilo nelle impostazioni."
-    },
-    "onlyIssuesLabel": {
-        "message": "Includi solo i problemi nel report"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Se selezionato, il report includerà solo i problemi creati o assegnati all'utente."
-    },
-    "onlyPRsLabel": {
-        "message": "Includi solo le PR nel report"
-    },
-    "onlyPRsTooltip": {
-        "message": "Se selezionato, il report includerà solo le pull request create dall'utente; le PR revisionate saranno escluse."
-    },
-    "cacheTTLLabel": {
-        "message": "Inserisci TTL della cache"
-    },
-    "cacheTTLUnit": {
-        "message": "(in minuti)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Scrivi il TTL della cache in minuti (Predefinito: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Aggiorna dati (ignora cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Usa questo pulsante per recuperare immediatamente dati aggiornati."
-    },
-    "noteTitle": {
-        "message": "Nota:"
-    },
-    "viewCodeButton": {
-        "message": "Visualizza Codice"
-    },
-    "reportIssueButton": {
-        "message": "Segnala un problema"
-    },
-    "repoFilterLabel": {
-        "message": "Filtra per repository"
-    },
-    "enableFilteringLabel": {
-        "message": "Abilita filtro"
-    },
-    "tokenRequiredWarning": {
-        "message": "È richiesto un token GitHub per filtrare i repository. Aggiungine uno nelle impostazioni."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Cerca un repository da aggiungere..."
-    },
-    "repoPlaceholder": {
-        "message": "Nessun repository selezionato (tutti saranno inclusi)"
-    },
-    "repoCountNone": {
-        "message": "0 repository selezionati"
-    },
-    "repoCount": {
-        "message": "$1 repository selezionati"
-    },
-    "repoLoading": {
-        "message": "Caricamento repository..."
-    },
-    "repoLoaded": {
-        "message": "Caricati $1 repository."
-    },
-    "repoNotFound": {
-        "message": "Nessun repository trovato"
-    },
-    "repoRefetching": {
-        "message": "Recupero repository in corso..."
-    },
-    "repoLoadFailed": {
-        "message": "Caricamento repository fallito."
-    },
-    "repoTokenPrivate": {
-        "message": "Il token non è valido o non ha i permessi per i repository privati."
-    },
-    "repoRefetchFailed": {
-        "message": "Recupero repository fallito."
-    },
-    "orgSetMessage": {
-        "message": "Organizzazione impostata con successo."
-    },
-    "orgClearedMessage": {
-        "message": "Organizzazione rimossa. Clicca 'Genera Rapporto' per recuperare tutte le attività."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organizzazione non trovata su GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Errore durante la convalida dell'organizzazione."
-    },
-    "refreshingButton": {
-        "message": "Aggiornamento..."
-    },
-    "cacheClearFailed": {
-        "message": "Pulizia della cache fallita."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Generazione in corso..."
-    },
-    "copiedButton": {
-        "message": "Copiato!"
-    },
-    "orgChangedMessage": {
-        "message": "Organizzazione modificata. Clicca 'Genera Rapporto' per recuperare le attività di GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache svuotata con successo. Clicca 'Genera Rapporto' per recuperare dati aggiornati."
-    },
-    "cacheExpiredMessage": {
-        "message": "Cache scaduta. Clicca \"Genera\" per recuperare dati aggiornati.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Cache Svuotata!"
-    },
-    "extensionDisabledMessage": {
-        "message": "L'estensione è disabilitata. Abilitala dalle impostazioni per generare rapporti scrum."
-    },
-    "notePoint1": {
-        "message": "Le pull request vengono recuperate in base all'attività di revisione più recente di qualsiasi contributore, non solo la tua. Si prega di rivedere e modificare il rapporto SCRUM generato per assicurarsi che rifletta accuratamente il proprio lavoro prima di condividerlo."
-    },
-    "noteSeeIssue": {
-        "message": "Vedi questo problema"
-    },
-    "platformLabel": {
-        "message": "Piattaforma"
-    },
-    "usernameLabel": {
-        "message": "Il tuo nome utente"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Includi solo le PR revisionate nel report"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Se selezionato, il report includerà solo le PR revisionate da te."
-    },
-    	"usernameRequiredError": {
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "Segnala i tuoi progressi di sviluppo recuperando automaticamente la tua attività Git per un periodo selezionato."
+	},
+	"disableLabel": {
+		"message": "Disabilita"
+	},
+	"enableLabel": {
+		"message": "Abilita"
+	},
+	"projectNameLabel": {
+		"message": "Nome del progetto (usato nell'oggetto dell'email)"
+	},
+	"projectNamePlaceholder": {
+		"message": "Inserisci il nome del tuo progetto"
+	},
+	"githubUsernameLabel": {
+		"message": "Il tuo nome utente GitHub"
+	},
+	"gitlabUsernameLabel": {
+		"message": "Il tuo nome utente GitLab"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "Richiesto per recuperare i tuoi contributi"
+	},
+	"contributionsLabel": {
+		"message": "Recupera i tuoi contributi per:"
+	},
+	"last1DayLabel": {
+		"message": "Giorno precedente"
+	},
+	"startDateLabel": {
+		"message": "Da:"
+	},
+	"endDateLabel": {
+		"message": "A:"
+	},
+	"showOpenClosedLabel": {
+		"message": "Mostra stato Aperto/Chiuso"
+	},
+	"blockersLabel": {
+		"message": "Cosa ti impedisce di progredire?"
+	},
+	"blockersPlaceholder": {
+		"message": "Inserisci il motivo"
+	},
+	"scrumReportLabel": {
+		"message": "Rapporto Scrum"
+	},
+	"generateReportButton": {
+		"message": "Genera Rapporto"
+	},
+	"copyReportButton": {
+		"message": "Copia Rapporto"
+	},
+	"insertInEmailButton": {
+		"message": "Inserisci nell'email",
+		"description": "Text for the 'Insert to Email' button."
+	},
+	"settingsOrgNameLabel": {
+		"message": "Nome dell'organizzazione"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "Inserisci il nome dell'organizzazione"
+	},
+	"setButton": {
+		"message": "Imposta"
+	},
+	"githubTokenLabel": {
+		"message": "Il tuo token GitHub"
+	},
+	"githubTokenPlaceholder": {
+		"message": "Richiesto per richieste autenticate"
+	},
+	"githubTokenTooltip": {
+		"message": "Perché è consigliato aggiungere un token GitHub? Scrum Helper funziona senza un token GitHub, ma aggiungere un token di accesso personale è consigliato per un'esperienza migliore."
+	},
+	"gitlabTokenLabel": {
+		"message": "Il tuo token GitLab"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "Richiesto per repo privati"
+	},
+	"gitlabTokenTooltip": {
+		"message": "Perché è consigliato aggiungere un token GitLab? Scrum Helper funziona senza un token GitLab per progetti pubblici, ma aggiungere un token di accesso personale è consigliato per un'esperienza migliore."
+	},
+	"showCommitsLabel": {
+		"message": "Mostra commit su PR aperti/ bozze di PR"
+	},
+	"showCommitsTooltip": {
+		"message": "Token GitHub richiesto, aggiungilo nelle impostazioni."
+	},
+	"onlyIssuesLabel": {
+		"message": "Includi solo i problemi nel report"
+	},
+	"onlyIssuesTooltip": {
+		"message": "Se selezionato, il report includerà solo i problemi creati o assegnati all'utente."
+	},
+	"onlyPRsLabel": {
+		"message": "Includi solo le PR nel report"
+	},
+	"onlyPRsTooltip": {
+		"message": "Se selezionato, il report includerà solo le pull request create dall'utente; le PR revisionate saranno escluse."
+	},
+	"cacheTTLLabel": {
+		"message": "Inserisci TTL della cache"
+	},
+	"cacheTTLUnit": {
+		"message": "(in minuti)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "Scrivi il TTL della cache in minuti (Predefinito: 10)"
+	},
+	"refreshDataButton": {
+		"message": "Aggiorna dati (ignora cache)"
+	},
+	"refreshDataInfo": {
+		"message": "Usa questo pulsante per recuperare immediatamente dati aggiornati."
+	},
+	"noteTitle": {
+		"message": "Nota:"
+	},
+	"viewCodeButton": {
+		"message": "Visualizza Codice"
+	},
+	"reportIssueButton": {
+		"message": "Segnala un problema"
+	},
+	"repoFilterLabel": {
+		"message": "Filtra per repository"
+	},
+	"enableFilteringLabel": {
+		"message": "Abilita filtro"
+	},
+	"tokenRequiredWarning": {
+		"message": "È richiesto un token GitHub per filtrare i repository. Aggiungine uno nelle impostazioni."
+	},
+	"repoSearchPlaceholder": {
+		"message": "Cerca un repository da aggiungere..."
+	},
+	"repoPlaceholder": {
+		"message": "Nessun repository selezionato (tutti saranno inclusi)"
+	},
+	"repoCountNone": {
+		"message": "0 repository selezionati"
+	},
+	"repoCount": {
+		"message": "$1 repository selezionati"
+	},
+	"repoLoading": {
+		"message": "Caricamento repository..."
+	},
+	"repoLoaded": {
+		"message": "Caricati $1 repository."
+	},
+	"repoNotFound": {
+		"message": "Nessun repository trovato"
+	},
+	"repoRefetching": {
+		"message": "Recupero repository in corso..."
+	},
+	"repoLoadFailed": {
+		"message": "Caricamento repository fallito."
+	},
+	"repoTokenPrivate": {
+		"message": "Il token non è valido o non ha i permessi per i repository privati."
+	},
+	"repoRefetchFailed": {
+		"message": "Recupero repository fallito."
+	},
+	"orgSetMessage": {
+		"message": "Organizzazione impostata con successo."
+	},
+	"orgClearedMessage": {
+		"message": "Organizzazione rimossa. Clicca 'Genera Rapporto' per recuperare tutte le attività."
+	},
+	"orgNotFoundMessage": {
+		"message": "Organizzazione non trovata su GitHub."
+	},
+	"orgValidationErrorMessage": {
+		"message": "Errore durante la convalida dell'organizzazione."
+	},
+	"refreshingButton": {
+		"message": "Aggiornamento..."
+	},
+	"cacheClearFailed": {
+		"message": "Pulizia della cache fallita."
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "Generazione in corso..."
+	},
+	"copiedButton": {
+		"message": "Copiato!"
+	},
+	"orgChangedMessage": {
+		"message": "Organizzazione modificata. Clicca 'Genera Rapporto' per recuperare le attività di GitHub."
+	},
+	"cacheClearedMessage": {
+		"message": "Cache svuotata con successo. Clicca 'Genera Rapporto' per recuperare dati aggiornati."
+	},
+	"cacheExpiredMessage": {
+		"message": "Cache scaduta. Clicca \"Genera\" per recuperare dati aggiornati.",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "Cache Svuotata!"
+	},
+	"extensionDisabledMessage": {
+		"message": "L'estensione è disabilitata. Abilitala dalle impostazioni per generare rapporti scrum."
+	},
+	"notePoint1": {
+		"message": "Le pull request vengono recuperate in base all'attività di revisione più recente di qualsiasi contributore, non solo la tua. Si prega di rivedere e modificare il rapporto SCRUM generato per assicurarsi che rifletta accuratamente il proprio lavoro prima di condividerlo."
+	},
+	"noteSeeIssue": {
+		"message": "Vedi questo problema"
+	},
+	"platformLabel": {
+		"message": "Piattaforma"
+	},
+	"usernameLabel": {
+		"message": "Il tuo nome utente"
+	},
+	"onlyRevPRsLabel": {
+		"message": "Includi solo le PR revisionate nel report"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "Se selezionato, il report includerà solo le PR revisionate da te."
+	},
+	"usernameRequiredError": {
 		"message": "Inserisci il tuo nome utente per generare un report."
 	},
 	"unknownPlatformError": {
@@ -295,25 +295,49 @@
 	"usernameMissingError": {
 		"message": "Nome utente richiesto."
 	},
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Generazione del report..."
-    },
-    "copyingReportNotification": {
-        "message": "Copia del report..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Inserimento del report nell'email..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Report inserito nell'email!"
-    }
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"generatingReportNotification": {
+		"message": "Generazione del report..."
+	},
+	"copyingReportNotification": {
+		"message": "Copia del report..."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "Inserimento del report nell'email..."
+	},
+	"insertedInEmailNotification": {
+		"message": "Report inserito nell'email!"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -1,239 +1,239 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "選択した期間のGitアクティビティを自動的に取得して、開発の進捗を報告します。"
-    },
-    "disableLabel": {
-        "message": "無効にする"
-    },
-    "enableLabel": {
-        "message": "有効にする"
-    },
-    "projectNameLabel": {
-        "message": "プロジェクト名（メールの件名に使用）"
-    },
-    "projectNamePlaceholder": {
-        "message": "メール件名"
-    },
-    "githubUsernameLabel": {
-        "message": "GitHubユーザー名"
-    },
-    "gitlabUsernameLabel": {
-        "message": "GitLabユーザー名"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "コントリビューションの取得に必要です"
-    },
-    "contributionsLabel": {
-        "message": "取得するコントリビューションの期間："
-    },
-    "last1DayLabel": {
-        "message": "前日"
-    },
-    "startDateLabel": {
-        "message": "開始:"
-    },
-    "endDateLabel": {
-        "message": "終了:"
-    },
-    "showOpenClosedLabel": {
-        "message": "オープン/クローズ状態を表示"
-    },
-    "blockersLabel": {
-        "message": "進捗の妨げになっているものは何ですか？"
-    },
-    "blockersPlaceholder": {
-        "message": "理由を入力してください"
-    },
-    "scrumReportLabel": {
-        "message": "スクラムレポート"
-    },
-    "generateReportButton": {
-        "message": "レポートを生成"
-    },
-    "copyReportButton": {
-        "message": "レポートをコピー"
-    },
-    "insertInEmailButton": {
-        "message": "メールに挿入",
-        "description": "Text for the 'Insert to Email' button."
-    },
-    "settingsOrgNameLabel": {
-        "message": "組織名"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "組織名を入力してください"
-    },
-    "setButton": {
-        "message": "設定"
-    },
-    "githubTokenLabel": {
-        "message": "GitHubトークン"
-    },
-    "githubTokenPlaceholder": {
-        "message": "認証済みリクエストに必要です"
-    },
-    "githubTokenTooltip": {
-        "message": "GitHubトークンを追加することをお勧めするのはなぜですか？Scrum HelperはGitHubトークンなしで機能しますが、より良いエクスペリエンスのためにパーソナルアクセストークンを追加することをお勧めします。"
-    },
-    "gitlabTokenLabel": {
-        "message": "GitLabトークン"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "プライベートプロジェクトへのアクセスに必要です"
-    },
-    "gitlabTokenTooltip": {
-        "message": "GitLabトークンを追加することをお勧めするのはなぜですか？Scrum HelperはパブリックプロジェクトのGitLabトークンなしで機能しますが、より良いエクスペリエンスのためにパーソナルアクセストークンを追加することをお勧めします。"
-    },
-    "showCommitsLabel": {
-        "message": "オープンなPR/ドラフトPRのコミットを表示"
-    },
-    "showCommitsTooltip": {
-        "message": "GitHubトークンが必要です。設定で追加してください。"
-    },
-    "onlyIssuesLabel": {
-        "message": "レポートに課題のみを含める"
-    },
-    "onlyIssuesTooltip": {
-        "message": "チェックした場合、レポートにはユーザーが作成または割り当てられた課題のみが含まれます。"
-    },
-    "onlyPRsLabel": {
-        "message": "レポートにPRのみを含める"
-    },
-    "onlyPRsTooltip": {
-        "message": "チェックすると、レポートにはユーザーが作成したPRのみが含まれ、レビュー済みのPRは除外されます。"
-    },
-    "cacheTTLLabel": {
-        "message": "キャッシュTTLを入力",
-        "description": "キャッシュの有効期間入力のラベル。"
-    },
-    "cacheTTLUnit": {
-        "message": "（分）"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "キャッシュTTLを分単位で入力 (デフォルト: 10)"
-    },
-    "refreshDataButton": {
-        "message": "データを更新 (キャッシュを無視)"
-    },
-    "refreshDataInfo": {
-        "message": "このボタンで最新のデータをすぐに取得します。"
-    },
-    "noteTitle": {
-        "message": "注："
-    },
-    "viewCodeButton": {
-        "message": "コードを見る"
-    },
-    "reportIssueButton": {
-        "message": "問題を報告"
-    },
-    "repoFilterLabel": {
-        "message": "リポジトリでフィルタリング"
-    },
-    "enableFilteringLabel": {
-        "message": "フィルタリングを有効にする"
-    },
-    "tokenRequiredWarning": {
-        "message": "リポジトリのフィルタリングにはGitHubトークンが必要です。設定で追加してください。"
-    },
-    "repoSearchPlaceholder": {
-        "message": "追加するリポジトリを検索..."
-    },
-    "repoPlaceholder": {
-        "message": "リポジトリが選択されていません（すべて含まれます）"
-    },
-    "repoCountNone": {
-        "message": "0件のリポジトリが選択されています"
-    },
-    "repoCount": {
-        "message": "$1件のリポジトリが選択されています"
-    },
-    "repoLoading": {
-        "message": "リポジトリを読み込み中..."
-    },
-    "repoLoaded": {
-        "message": "$1件のリポジトリを読み込みました。"
-    },
-    "repoNotFound": {
-        "message": "リポジトリが見つかりません"
-    },
-    "repoRefetching": {
-        "message": "リポジトリを再読み込み中..."
-    },
-    "repoLoadFailed": {
-        "message": "リポジトリの読み込みに失敗しました。"
-    },
-    "repoTokenPrivate": {
-        "message": "トークンが無効か、プライベートリポジトリへの権限がありません。"
-    },
-    "repoRefetchFailed": {
-        "message": "リポジトリの再読み込みに失敗しました。"
-    },
-    "orgSetMessage": {
-        "message": "組織が正常に設定されました。"
-    },
-    "orgClearedMessage": {
-        "message": "組織がクリアされました。「レポートを生成」をクリックしてすべてのアクティビティを取得してください。"
-    },
-    "orgNotFoundMessage": {
-        "message": "GitHubで組織が見つかりません。"
-    },
-    "orgValidationErrorMessage": {
-        "message": "組織の検証中にエラーが発生しました。"
-    },
-    "refreshingButton": {
-        "message": "更新中..."
-    },
-    "cacheClearFailed": {
-        "message": "キャッシュのクリアに失敗しました。"
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "生成中..."
-    },
-    "copiedButton": {
-        "message": "コピーしました！"
-    },
-    "orgChangedMessage": {
-        "message": "組織が変更されました。「レポートを生成」ボタンをクリックしてGitHubアクティビティを取得してください。"
-    },
-    "cacheClearedMessage": {
-        "message": "キャッシュが正常にクリアされました。「レポートを生成」をクリックして新しいデータを取得してください。"
-    },
-    "cacheExpiredMessage": {
-        "message": "キャッシュの有効期限が切れました。「生成」をクリックして最新のデータを取得してください。",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "キャッシュクリア！"
-    },
-    "extensionDisabledMessage": {
-        "message": "拡張機能が無効です。スクラムレポートを生成するには、オプションから有効にしてください。"
-    },
-    "notePoint1": {
-        "message": "プルリクエストは、自分だけでなく、任意のコントリビューターによる最新のレビューアクティビティに基づいて取得されます。共有する前に、生成されたSCRUMレポートを確認および調整して、作業が正確に反映されていることを確認してください。"
-    },
-    "noteSeeIssue": {
-        "message": "このIssueを参照"
-    },
-    "platformLabel": {
-        "message": "プラットフォーム"
-    },
-    "usernameLabel": {
-        "message": "あなたのユーザー名"
-    },
-    "onlyRevPRsLabel": {
-        "message": "レポートにレビュー済みのPRのみを含める"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "チェックした場合、レポートにはあなたがレビューしたPRのみが含まれます。"
-    },
-    "usernameRequiredError": {
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "選択した期間のGitアクティビティを自動的に取得して、開発の進捗を報告します。"
+	},
+	"disableLabel": {
+		"message": "無効にする"
+	},
+	"enableLabel": {
+		"message": "有効にする"
+	},
+	"projectNameLabel": {
+		"message": "プロジェクト名（メールの件名に使用）"
+	},
+	"projectNamePlaceholder": {
+		"message": "メール件名"
+	},
+	"githubUsernameLabel": {
+		"message": "GitHubユーザー名"
+	},
+	"gitlabUsernameLabel": {
+		"message": "GitLabユーザー名"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "コントリビューションの取得に必要です"
+	},
+	"contributionsLabel": {
+		"message": "取得するコントリビューションの期間："
+	},
+	"last1DayLabel": {
+		"message": "前日"
+	},
+	"startDateLabel": {
+		"message": "開始:"
+	},
+	"endDateLabel": {
+		"message": "終了:"
+	},
+	"showOpenClosedLabel": {
+		"message": "オープン/クローズ状態を表示"
+	},
+	"blockersLabel": {
+		"message": "進捗の妨げになっているものは何ですか？"
+	},
+	"blockersPlaceholder": {
+		"message": "理由を入力してください"
+	},
+	"scrumReportLabel": {
+		"message": "スクラムレポート"
+	},
+	"generateReportButton": {
+		"message": "レポートを生成"
+	},
+	"copyReportButton": {
+		"message": "レポートをコピー"
+	},
+	"insertInEmailButton": {
+		"message": "メールに挿入",
+		"description": "Text for the 'Insert to Email' button."
+	},
+	"settingsOrgNameLabel": {
+		"message": "組織名"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "組織名を入力してください"
+	},
+	"setButton": {
+		"message": "設定"
+	},
+	"githubTokenLabel": {
+		"message": "GitHubトークン"
+	},
+	"githubTokenPlaceholder": {
+		"message": "認証済みリクエストに必要です"
+	},
+	"githubTokenTooltip": {
+		"message": "GitHubトークンを追加することをお勧めするのはなぜですか？Scrum HelperはGitHubトークンなしで機能しますが、より良いエクスペリエンスのためにパーソナルアクセストークンを追加することをお勧めします。"
+	},
+	"gitlabTokenLabel": {
+		"message": "GitLabトークン"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "プライベートプロジェクトへのアクセスに必要です"
+	},
+	"gitlabTokenTooltip": {
+		"message": "GitLabトークンを追加することをお勧めするのはなぜですか？Scrum HelperはパブリックプロジェクトのGitLabトークンなしで機能しますが、より良いエクスペリエンスのためにパーソナルアクセストークンを追加することをお勧めします。"
+	},
+	"showCommitsLabel": {
+		"message": "オープンなPR/ドラフトPRのコミットを表示"
+	},
+	"showCommitsTooltip": {
+		"message": "GitHubトークンが必要です。設定で追加してください。"
+	},
+	"onlyIssuesLabel": {
+		"message": "レポートに課題のみを含める"
+	},
+	"onlyIssuesTooltip": {
+		"message": "チェックした場合、レポートにはユーザーが作成または割り当てられた課題のみが含まれます。"
+	},
+	"onlyPRsLabel": {
+		"message": "レポートにPRのみを含める"
+	},
+	"onlyPRsTooltip": {
+		"message": "チェックすると、レポートにはユーザーが作成したPRのみが含まれ、レビュー済みのPRは除外されます。"
+	},
+	"cacheTTLLabel": {
+		"message": "キャッシュTTLを入力",
+		"description": "キャッシュの有効期間入力のラベル。"
+	},
+	"cacheTTLUnit": {
+		"message": "（分）"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "キャッシュTTLを分単位で入力 (デフォルト: 10)"
+	},
+	"refreshDataButton": {
+		"message": "データを更新 (キャッシュを無視)"
+	},
+	"refreshDataInfo": {
+		"message": "このボタンで最新のデータをすぐに取得します。"
+	},
+	"noteTitle": {
+		"message": "注："
+	},
+	"viewCodeButton": {
+		"message": "コードを見る"
+	},
+	"reportIssueButton": {
+		"message": "問題を報告"
+	},
+	"repoFilterLabel": {
+		"message": "リポジトリでフィルタリング"
+	},
+	"enableFilteringLabel": {
+		"message": "フィルタリングを有効にする"
+	},
+	"tokenRequiredWarning": {
+		"message": "リポジトリのフィルタリングにはGitHubトークンが必要です。設定で追加してください。"
+	},
+	"repoSearchPlaceholder": {
+		"message": "追加するリポジトリを検索..."
+	},
+	"repoPlaceholder": {
+		"message": "リポジトリが選択されていません（すべて含まれます）"
+	},
+	"repoCountNone": {
+		"message": "0件のリポジトリが選択されています"
+	},
+	"repoCount": {
+		"message": "$1件のリポジトリが選択されています"
+	},
+	"repoLoading": {
+		"message": "リポジトリを読み込み中..."
+	},
+	"repoLoaded": {
+		"message": "$1件のリポジトリを読み込みました。"
+	},
+	"repoNotFound": {
+		"message": "リポジトリが見つかりません"
+	},
+	"repoRefetching": {
+		"message": "リポジトリを再読み込み中..."
+	},
+	"repoLoadFailed": {
+		"message": "リポジトリの読み込みに失敗しました。"
+	},
+	"repoTokenPrivate": {
+		"message": "トークンが無効か、プライベートリポジトリへの権限がありません。"
+	},
+	"repoRefetchFailed": {
+		"message": "リポジトリの再読み込みに失敗しました。"
+	},
+	"orgSetMessage": {
+		"message": "組織が正常に設定されました。"
+	},
+	"orgClearedMessage": {
+		"message": "組織がクリアされました。「レポートを生成」をクリックしてすべてのアクティビティを取得してください。"
+	},
+	"orgNotFoundMessage": {
+		"message": "GitHubで組織が見つかりません。"
+	},
+	"orgValidationErrorMessage": {
+		"message": "組織の検証中にエラーが発生しました。"
+	},
+	"refreshingButton": {
+		"message": "更新中..."
+	},
+	"cacheClearFailed": {
+		"message": "キャッシュのクリアに失敗しました。"
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "生成中..."
+	},
+	"copiedButton": {
+		"message": "コピーしました！"
+	},
+	"orgChangedMessage": {
+		"message": "組織が変更されました。「レポートを生成」ボタンをクリックしてGitHubアクティビティを取得してください。"
+	},
+	"cacheClearedMessage": {
+		"message": "キャッシュが正常にクリアされました。「レポートを生成」をクリックして新しいデータを取得してください。"
+	},
+	"cacheExpiredMessage": {
+		"message": "キャッシュの有効期限が切れました。「生成」をクリックして最新のデータを取得してください。",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "キャッシュクリア！"
+	},
+	"extensionDisabledMessage": {
+		"message": "拡張機能が無効です。スクラムレポートを生成するには、オプションから有効にしてください。"
+	},
+	"notePoint1": {
+		"message": "プルリクエストは、自分だけでなく、任意のコントリビューターによる最新のレビューアクティビティに基づいて取得されます。共有する前に、生成されたSCRUMレポートを確認および調整して、作業が正確に反映されていることを確認してください。"
+	},
+	"noteSeeIssue": {
+		"message": "このIssueを参照"
+	},
+	"platformLabel": {
+		"message": "プラットフォーム"
+	},
+	"usernameLabel": {
+		"message": "あなたのユーザー名"
+	},
+	"onlyRevPRsLabel": {
+		"message": "レポートにレビュー済みのPRのみを含める"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "チェックした場合、レポートにはあなたがレビューしたPRのみが含まれます。"
+	},
+	"usernameRequiredError": {
 		"message": "レポートを生成するには、ユーザー名を入力してください。"
 	},
 	"unknownPlatformError": {
@@ -296,25 +296,49 @@
 	"usernameMissingError": {
 		"message": "ユーザー名が必要です。"
 	},
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "レポートを生成中..."
-    },
-    "copyingReportNotification": {
-        "message": "レポートをコピー中..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "レポートをメールに挿入中..."
-    },
-    "insertedInEmailNotification": {
-        "message": "レポートをメールに挿入しました！"
-    }
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"generatingReportNotification": {
+		"message": "レポートを生成中..."
+	},
+	"copyingReportNotification": {
+		"message": "レポートをコピー中..."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "レポートをメールに挿入中..."
+	},
+	"insertedInEmailNotification": {
+		"message": "レポートをメールに挿入しました！"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/ml/messages.json
+++ b/src/_locales/ml/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "തിരഞ്ഞെടുത്ത കാലയളവിലെ നിങ്ങളുടെ Git പ്രവർത്തനങ്ങൾ സ്വയമേവ ശേഖരിച്ചു നിങ്ങളുടെ വികസന പുരോഗതി റിപ്പോർട്ട് ചെയ്യുക"
-    },
-    "disableLabel": {
-        "message": "അപ്രാപ്തമാക്കുക"
-    },
-    "enableLabel": {
-        "message": "സജീവമാക്കുക"
-    },
-    "projectNameLabel": {
-        "message": "പ്രോജക്ട് പേര് (ഇമെയിൽ വിഷയം ആയി ഉപയോഗിക്കും)"
-    },
-    "projectNamePlaceholder": {
-        "message": "നിങ്ങളുടെ പ്രോജക്ട് പേര് നൽകുക"
-    },
-    "githubUsernameLabel": {
-        "message": "നിങ്ങളുടെ GitHub ഉപയോക്തൃനാമം"
-    },
-    "gitlabUsernameLabel": {
-        "message": "നിങ്ങളുടെ GitLab ഉപയോക്തൃനാമം"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "നിങ്ങളുടെ സംഭാവനകൾ ശേഖരിക്കാൻ ആവശ്യമാണ്"
-    },
-    "contributionsLabel": {
-        "message": "ഈ സമയപരിധിക്കുള്ളിൽ നിങ്ങളുടെ സംഭാവനകൾ ശേഖരിക്കുക:"
-    },
-    "last1DayLabel": {
-        "message": "മുൻ ദിവസം"
-    },
-    "startDateLabel": {
-        "message": "മുതൽ:"
-    },
-    "endDateLabel": {
-        "message": "വരെ:"
-    },
-    "showOpenClosedLabel": {
-        "message": "PR ലേബലുകൾ കാണിക്കുക"
-    },
-    "blockersLabel": {
-        "message": "നിങ്ങളുടെ പുരോഗതിയെ തടയുന്നത് എന്താണ്?"
-    },
-    "blockersPlaceholder": {
-        "message": "നിങ്ങളുടെ കാരണം നൽകുക"
-    },
-    "scrumReportLabel": {
-        "message": "സ്ക്രം റിപ്പോർട്ട്"
-    },
-    "generateReportButton": {
-        "message": "റിപ്പോർട്ട് സൃഷ്ടിക്കുക"
-    },
-    "copyReportButton": {
-        "message": "റിപ്പോർട്ട് പകർത്തുക"
-    },
-    "insertInEmailButton": {
-        "message": "ഇമെയിലിൽ ചേർക്കുക",
-        "description": "Text for the 'Insert to Email' button."
-    },
-    "settingsOrgNameLabel": {
-        "message": "സ്ഥാപനത്തിന്റെ പേര്"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "സ്ഥാപനത്തിന്റെ പേര് നൽകുക"
-    },
-    "setButton": {
-        "message": "സെറ്റ് ചെയ്യുക"
-    },
-    "githubTokenLabel": {
-        "message": "നിങ്ങളുടെ GitHub ടോക്കൺ"
-    },
-    "githubTokenPlaceholder": {
-        "message": "ഓതന്റിക്കേറ്റഡ് അഭ്യർത്ഥനകൾക്കായി ആവശ്യമാണ്"
-    },
-    "githubTokenTooltip": {
-        "message": "GitHub ടോക്കൻ ചേർക്കാൻ എന്ത് ശുപാർശ ചെയ്യുന്നത്? സ്ക്രം ഹെൽപർ GitHub ടോക്കൻ ഇല്ലാതെ പ്രവർത്തിക്കുന്നു, എന്നാൽ നല്ലതായ അനുഭവത്തിന് പ്രത്യക്ഷ ആക്സസ് ടോക്കൻ ചേർക്കാൻ ശുപാർശ ചെയ്യുന്നു."
-    },
-    "gitlabTokenLabel": {
-        "message": "നിങ്ങളുടെ GitLab ടോക്കൺ"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "സ്വകാര്യ പ്രോജക്ടുകൾ ആക്സസ് ചെയ്യാൻ ആവശ്യമാണ്"
-    },
-    "gitlabTokenTooltip": {
-        "message": "GitLab ടോക്കൻ ചേർക്കാൻ എന്ത് ശുപാർശ ചെയ്യുന്നത്? സ്ക്രം ഹെൽപർ പബ്ലിക് പ്രോജക്ടുകൾക്കായി GitLab ടോക്കൻ ഇല്ലാതെ പ്രവർത്തിക്കുന്നു, എന്നാൽ നല്ലതായ അനുഭവത്തിന് പ്രത്യക്ഷ ആക്സസ് ടോക്കൻ ചേർക്കാൻ ശുപാർശ ചെയ്യുന്നു."
-    },
-    "showCommitsLabel": {
-        "message": "ഓപ്പൺ / ഡ്രാഫ്റ്റ് PRകളിലെ കമ്മിറ്റുകൾ കാണിക്കുക"
-    },
-    "showCommitsTooltip": {
-        "message": "GitHub ടോക്കൺ ആവശ്യമാണ്, ദയവായി സെറ്റിംഗ്സിൽ ചേർക്കുക."
-    },
-    "onlyIssuesLabel": {
-        "message": "റിപ്പോർട്ടിൽ ഇഷ്യൂകൾ മാത്രം ഉൾപ്പെടുത്തുക"
-    },
-    "onlyIssuesTooltip": {
-        "message": "തിരഞ്ഞെടുത്താൽ, ഉപയോക്താവ് സൃഷ്ടിച്ചതോ ഏൽപ്പിച്ചതോ ആയ ഇഷ്യൂകൾ മാത്രം റിപ്പോർട്ടിൽ ഉൾപ്പെടും."
-    },
-    "onlyPRsLabel": {
-        "message": "റിപ്പോർട്ടിൽ PRകൾ മാത്രം ഉൾപ്പെടുത്തുക"
-    },
-    "onlyPRsTooltip": {
-        "message": "തിരഞ്ഞെടുത്താൽ, നിങ്ങൾ സൃഷ്ടിച്ച PRകൾ മാത്രം റിപ്പോർട്ടിൽ ഉൾപ്പെടും. റിവ്യൂ ചെയ്ത PRകൾ ഒഴിവാക്കപ്പെടും."
-    },
-    "cacheTTLLabel": {
-        "message": "കാഷ് TTL നൽകുക"
-    },
-    "cacheTTLUnit": {
-        "message": "(മിനിറ്റുകളിൽ)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "കാഷ് TTL മിനിറ്റുകളിൽ നൽകുക (ഡിഫോൾട്ട് 10 മിനിറ്റ്)"
-    },
-    "refreshDataButton": {
-        "message": "ഡാറ്റ പുതുക്കുക (കാഷ് ഒഴിവാക്കി)"
-    },
-    "refreshDataInfo": {
-        "message": "പുതിയ ഡാറ്റ ഉടൻ ശേഖരിക്കാൻ ഈ ബട്ടൺ ഉപയോഗിക്കുക."
-    },
-    "noteTitle": {
-        "message": "കുറിപ്പ്:"
-    },
-    "viewCodeButton": {
-        "message": "കോഡ് കാണുക"
-    },
-    "reportIssueButton": {
-        "message": "പ്രശ്നം റിപ്പോർട്ട് ചെയ്യുക"
-    },
-    "repoFilterLabel": {
-        "message": "റിപ്പോസിറ്ററികളിലൂടെ ഫിൽറ്റർ ചെയ്യുക"
-    },
-    "enableFilteringLabel": {
-        "message": "ഫിൽറ്ററിംഗ് സജീവമാക്കുക"
-    },
-    "tokenRequiredWarning": {
-        "message": "റിപ്പോസിറ്ററി ഫിൽറ്ററിംഗിന് GitHub ടോക്കൺ ആവശ്യമാണ്. ദയവായി സെറ്റിംഗ്സിൽ ചേർക്കുക."
-    },
-    "repoSearchPlaceholder": {
-        "message": "ചേർക്കാനുള്ള റിപ്പോസിറ്ററി തിരയുക..."
-    },
-    "repoPlaceholder": {
-        "message": "റിപ്പോസിറ്ററികളൊന്നും തിരഞ്ഞെടുത്തിട്ടില്ല (എല്ലാം ഉൾപ്പെടും)"
-    },
-    "repoCountNone": {
-        "message": "0 റിപ്പോസിറ്ററികൾ തിരഞ്ഞെടുത്തു"
-    },
-    "repoCount": {
-        "message": "$1 റിപ്പോസിറ്ററികൾ തിരഞ്ഞെടുത്തു"
-    },
-    "repoLoading": {
-        "message": "റിപ്പോസിറ്ററികൾ ലോഡ് ചെയ്യുന്നു..."
-    },
-    "repoLoaded": {
-        "message": "$1 റിപ്പോസിറ്ററികൾ ലോഡ് ചെയ്തു."
-    },
-    "repoNotFound": {
-        "message": "റിപ്പോസിറ്ററികൾ കണ്ടെത്തിയില്ല"
-    },
-    "repoRefetching": {
-        "message": "റിപ്പോസിറ്ററികൾ വീണ്ടും ശേഖരിക്കുന്നു..."
-    },
-    "repoLoadFailed": {
-        "message": "റിപ്പോസിറ്ററികൾ ലോഡ് ചെയ്യാൻ പരാജയപ്പെട്ടു."
-    },
-    "repoTokenPrivate": {
-        "message": "ടോക്കൺ അസാധുവാണ് അല്ലെങ്കിൽ സ്വകാര്യ റിപ്പോസിറ്ററികൾക്ക് അനുമതിയില്ല."
-    },
-    "repoRefetchFailed": {
-        "message": "റിപ്പോസിറ്ററികൾ വീണ്ടും ശേഖരിക്കാൻ പരാജയപ്പെട്ടു."
-    },
-    "orgSetMessage": {
-        "message": "സ്ഥാപനം വിജയകരമായി സെറ്റ് ചെയ്തു."
-    },
-    "orgClearedMessage": {
-        "message": "സ്ഥാപനം നീക്കം ചെയ്തു. എല്ലാ പ്രവർത്തനങ്ങളും ശേഖരിക്കാൻ 'റിപ്പോർട്ട് സൃഷ്ടിക്കുക' ക്ലിക്ക് ചെയ്യുക."
-    },
-    "orgNotFoundMessage": {
-        "message": "GitHub-ൽ സ്ഥാപനം കണ്ടെത്തിയില്ല."
-    },
-    "orgValidationErrorMessage": {
-        "message": "സ്ഥാപനം സ്ഥിരീകരിക്കുന്നതിൽ പിശക്."
-    },
-    "refreshingButton": {
-        "message": "പുതുക്കുന്നു..."
-    },
-    "cacheClearFailed": {
-        "message": "കാഷ് ക്ലിയർ ചെയ്യൽ പരാജയപ്പെട്ടു."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "സൃഷ്ടിക്കുന്നു..."
-    },
-    "copiedButton": {
-        "message": "പകർത്തി!"
-    },
-    "orgChangedMessage": {
-        "message": "സംഘടന മാറി. GitHub പ്രവർത്തനങ്ങൾ ശേഖരിക്കാൻ റിപ്പോർട്ട് സൃഷ്ടിക്കുക ബട്ടൺ ക്ലിക്ക് ചെയ്യുക."
-    },
-    "cacheClearedMessage": {
-        "message": "കാഷ് വിജയകരമായി ക്ലിയർ ചെയ്തു. പുതിയ ഡാറ്റയ്ക്കായി \"റിപ്പോർട്ട് സൃഷ്ടിക്കുക\" ക്ലിക്ക് ചെയ്യുക."
-    },
-    "cacheExpiredMessage": {
-        "message": "കാഷ് കാലഹരണപ്പെട്ടു. പുതിയ ഡാറ്റ ലഭിക്കാൻ \"റിപ്പോർട്ട് സൃഷ്ടിക്കുക\" ക്ലിക്ക് ചെയ്യുക.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "കാഷ് ക്ലിയർ ചെയ്തു!"
-    },
-    "extensionDisabledMessage": {
-        "message": "എക്സ്റ്റെൻഷൻ അപ്രാപ്തമാണ്. സ്ക്രം റിപ്പോർട്ടുകൾ സൃഷ്ടിക്കാൻ ഓപ്ഷനുകളിൽ നിന്ന് സജീവമാക്കുക."
-    },
-    "notePoint1": {
-        "message": "Pull request-കൾ നിങ്ങൾ മാത്രമല്ല, മറ്റ് സംഭാവനകർത്താക്കളുടെ ഏറ്റവും പുതിയ റിവ്യൂ പ്രവർത്തനത്തെ അടിസ്ഥാനമാക്കിയാണ് ശേഖരിക്കുന്നത്. പങ്കിടുന്നതിന് മുമ്പ് സൃഷ്ടിച്ച SCRUM റിപ്പോർട്ട് നിങ്ങളുടെ പ്രവർത്തനം ശരിയായി പ്രതിഫലിപ്പിക്കുന്നുവെന്ന് ഉറപ്പാക്കാൻ പരിശോധിച്ച് തിരുത്തുക."
-    },
-    "noteSeeIssue": {
-        "message": "ഈ ഇഷ്യൂ കാണുക"
-    },
-    "platformLabel": {
-        "message": "പ്ലാറ്റ്ഫോം"
-    },
-    "usernameLabel": {
-        "message": "നിങ്ങളുടെ ഉപയോക്തൃനാമം"
-    },
-    "onlyRevPRsLabel": {
-        "message": "റിപ്പോർട്ടിൽ റിവ്യൂ ചെയ്ത PRകൾ മാത്രം ഉൾപ്പെടുത്തുക"
-    },
-    "onlyRevPRsTooltip": {
-      "message": "തിരഞ്ഞെടുത്താൽ, നിങ്ങൾ റിവ്യൂ ചെയ്ത PRകൾ മാത്രം റിപ്പോർട്ടിൽ ഉൾപ്പെടും."
-    },
-    "usernameRequiredError": {
-      "message": "റിപ്പോർട്ട് സൃഷ്ടിക്കാൻ നിങ്ങളുടെ ഉപയോക്തൃനാമം നൽകുക."
-    },
-    "unknownPlatformError": {
-      "message": "അജ്ഞാതമായ പ്ലാറ്റ്ഫോം തിരഞ്ഞെടുത്തു."
-    },
-    "gitlabFetchingError": {
-      "message": "GitLab ഡാറ്റ ശേഖരിക്കുന്നതിൽ പിശകുണ്ടായി."
-    },
-    "reportGenerationError": {
-      "message": "റിപ്പോർട്ട് സൃഷ്ടിക്കുന്നതിൽ പിശകുണ്ടായി."
-    },
-    "githubUserNotFoundError": {
-      "message": "GitHub ഉപയോക്താവ് \"$1\" കണ്ടെത്തിയില്ല (404). ഉപയോക്തൃനാമം പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
-    },
-    "githubUserValidationError": {
-      "message": "GitHub ഉപയോക്താവ് സ്ഥിരീകരിക്കുന്നതിൽ പിശക്: $1 $2"
-    },
-    "invalidSearchQueryError": {
-      "message": "അസാധുവായ തിരയൽ ക്വറി അല്ലെങ്കിൽ തീയതി പരിധി. നിങ്ങളുടെ തീയതി പരിധി ഫോർമാറ്റ് പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
-    },
-    "githubIssuesFetchError": {
-      "message": "GitHub ഇഷ്യൂകൾ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-      "message": "GitHub PR റിവ്യൂ ഡാറ്റ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
-    },
-    "githubUserFetchError": {
-      "message": "GitHub ഉപയോക്തൃ ഡാറ്റ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
-    },
-    "invalidTokenError": {
-      "message": "അസാധുവായ അല്ലെങ്കിൽ കാലഹരണപ്പെട്ട GitHub ടോക്കൺ. Scrum Helper സെറ്റിംഗ്സിൽ നിങ്ങളുടെ ടോക്കൺ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
-    },
-    "displayModeNotice": {
-      "message": "അടുത്ത സമാരംഭത്തിൽ എക്സ്റ്റെൻഷൻ $1 മോഡിൽ തുറക്കും."
-    },
-    "repoFilteringGithubOnly": {
-      "message": "റിപ്പോസിറ്ററി ഫിൽറ്ററിംഗ് GitHub-ന് മാത്രമേ ലഭ്യമാകൂ."
-    },
-    "repoLoadingGithubOnly": {
-      "message": "റിപ്പോസിറ്ററി ലോഡിംഗ് GitHub-ന് മാത്രമേ ലഭ്യമാകൂ."
-    },
-    "repoFetchingGithubOnly": {
-      "message": "റിപ്പോസിറ്ററി ശേഖരണം GitHub-ന് മാത്രമേ ലഭ്യമാകൂ."
-    },
-    "loadingReposAutomatically": {
-      "message": "റിപ്പോസിറ്ററികൾ സ്വയമേവ ലോഡ് ചെയ്യുന്നു..."
-    },
-    "gitlabUserFetchError": {
-      "message": "GitLab ഉപയോക്താവിനെ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-      "message": "GitLab ഉപയോക്താവ് '$1' കണ്ടെത്തിയില്ല"
-    },
-    "gitlabMembershipError": {
-      "message": "GitLab അംഗത്വ പ്രോജക്ടുകൾ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
-    },
-    "gitlabContributedError": {
-      "message": "GitLab സംഭാവന പ്രോജക്ടുകൾ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
-    },
-    "usernameMissingError": {
-      "message": "ഉപയോക്തൃനാമം ആവശ്യമാണ്."
- },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "റിപ്പോർട്ട് തയ്യാറാക്കുന്നു..."
-    },
-    "copyingReportNotification": {
-        "message": "റിപ്പോർട്ട് പകർത്തുന്നു..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "റിപ്പോർട്ട് ഇമെയിലിൽ ചേർക്കുന്നു..."
-    },
-    "insertedInEmailNotification": {
-        "message": "റിപ്പോർട്ട് ഇമെയിലിൽ ചേർത്തു!"
-    }
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "തിരഞ്ഞെടുത്ത കാലയളവിലെ നിങ്ങളുടെ Git പ്രവർത്തനങ്ങൾ സ്വയമേവ ശേഖരിച്ചു നിങ്ങളുടെ വികസന പുരോഗതി റിപ്പോർട്ട് ചെയ്യുക"
+	},
+	"disableLabel": {
+		"message": "അപ്രാപ്തമാക്കുക"
+	},
+	"enableLabel": {
+		"message": "സജീവമാക്കുക"
+	},
+	"projectNameLabel": {
+		"message": "പ്രോജക്ട് പേര് (ഇമെയിൽ വിഷയം ആയി ഉപയോഗിക്കും)"
+	},
+	"projectNamePlaceholder": {
+		"message": "നിങ്ങളുടെ പ്രോജക്ട് പേര് നൽകുക"
+	},
+	"githubUsernameLabel": {
+		"message": "നിങ്ങളുടെ GitHub ഉപയോക്തൃനാമം"
+	},
+	"gitlabUsernameLabel": {
+		"message": "നിങ്ങളുടെ GitLab ഉപയോക്തൃനാമം"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "നിങ്ങളുടെ സംഭാവനകൾ ശേഖരിക്കാൻ ആവശ്യമാണ്"
+	},
+	"contributionsLabel": {
+		"message": "ഈ സമയപരിധിക്കുള്ളിൽ നിങ്ങളുടെ സംഭാവനകൾ ശേഖരിക്കുക:"
+	},
+	"last1DayLabel": {
+		"message": "മുൻ ദിവസം"
+	},
+	"startDateLabel": {
+		"message": "മുതൽ:"
+	},
+	"endDateLabel": {
+		"message": "വരെ:"
+	},
+	"showOpenClosedLabel": {
+		"message": "PR ലേബലുകൾ കാണിക്കുക"
+	},
+	"blockersLabel": {
+		"message": "നിങ്ങളുടെ പുരോഗതിയെ തടയുന്നത് എന്താണ്?"
+	},
+	"blockersPlaceholder": {
+		"message": "നിങ്ങളുടെ കാരണം നൽകുക"
+	},
+	"scrumReportLabel": {
+		"message": "സ്ക്രം റിപ്പോർട്ട്"
+	},
+	"generateReportButton": {
+		"message": "റിപ്പോർട്ട് സൃഷ്ടിക്കുക"
+	},
+	"copyReportButton": {
+		"message": "റിപ്പോർട്ട് പകർത്തുക"
+	},
+	"insertInEmailButton": {
+		"message": "ഇമെയിലിൽ ചേർക്കുക",
+		"description": "Text for the 'Insert to Email' button."
+	},
+	"settingsOrgNameLabel": {
+		"message": "സ്ഥാപനത്തിന്റെ പേര്"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "സ്ഥാപനത്തിന്റെ പേര് നൽകുക"
+	},
+	"setButton": {
+		"message": "സെറ്റ് ചെയ്യുക"
+	},
+	"githubTokenLabel": {
+		"message": "നിങ്ങളുടെ GitHub ടോക്കൺ"
+	},
+	"githubTokenPlaceholder": {
+		"message": "ഓതന്റിക്കേറ്റഡ് അഭ്യർത്ഥനകൾക്കായി ആവശ്യമാണ്"
+	},
+	"githubTokenTooltip": {
+		"message": "GitHub ടോക്കൻ ചേർക്കാൻ എന്ത് ശുപാർശ ചെയ്യുന്നത്? സ്ക്രം ഹെൽപർ GitHub ടോക്കൻ ഇല്ലാതെ പ്രവർത്തിക്കുന്നു, എന്നാൽ നല്ലതായ അനുഭവത്തിന് പ്രത്യക്ഷ ആക്സസ് ടോക്കൻ ചേർക്കാൻ ശുപാർശ ചെയ്യുന്നു."
+	},
+	"gitlabTokenLabel": {
+		"message": "നിങ്ങളുടെ GitLab ടോക്കൺ"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "സ്വകാര്യ പ്രോജക്ടുകൾ ആക്സസ് ചെയ്യാൻ ആവശ്യമാണ്"
+	},
+	"gitlabTokenTooltip": {
+		"message": "GitLab ടോക്കൻ ചേർക്കാൻ എന്ത് ശുപാർശ ചെയ്യുന്നത്? സ്ക്രം ഹെൽപർ പബ്ലിക് പ്രോജക്ടുകൾക്കായി GitLab ടോക്കൻ ഇല്ലാതെ പ്രവർത്തിക്കുന്നു, എന്നാൽ നല്ലതായ അനുഭവത്തിന് പ്രത്യക്ഷ ആക്സസ് ടോക്കൻ ചേർക്കാൻ ശുപാർശ ചെയ്യുന്നു."
+	},
+	"showCommitsLabel": {
+		"message": "ഓപ്പൺ / ഡ്രാഫ്റ്റ് PRകളിലെ കമ്മിറ്റുകൾ കാണിക്കുക"
+	},
+	"showCommitsTooltip": {
+		"message": "GitHub ടോക്കൺ ആവശ്യമാണ്, ദയവായി സെറ്റിംഗ്സിൽ ചേർക്കുക."
+	},
+	"onlyIssuesLabel": {
+		"message": "റിപ്പോർട്ടിൽ ഇഷ്യൂകൾ മാത്രം ഉൾപ്പെടുത്തുക"
+	},
+	"onlyIssuesTooltip": {
+		"message": "തിരഞ്ഞെടുത്താൽ, ഉപയോക്താവ് സൃഷ്ടിച്ചതോ ഏൽപ്പിച്ചതോ ആയ ഇഷ്യൂകൾ മാത്രം റിപ്പോർട്ടിൽ ഉൾപ്പെടും."
+	},
+	"onlyPRsLabel": {
+		"message": "റിപ്പോർട്ടിൽ PRകൾ മാത്രം ഉൾപ്പെടുത്തുക"
+	},
+	"onlyPRsTooltip": {
+		"message": "തിരഞ്ഞെടുത്താൽ, നിങ്ങൾ സൃഷ്ടിച്ച PRകൾ മാത്രം റിപ്പോർട്ടിൽ ഉൾപ്പെടും. റിവ്യൂ ചെയ്ത PRകൾ ഒഴിവാക്കപ്പെടും."
+	},
+	"cacheTTLLabel": {
+		"message": "കാഷ് TTL നൽകുക"
+	},
+	"cacheTTLUnit": {
+		"message": "(മിനിറ്റുകളിൽ)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "കാഷ് TTL മിനിറ്റുകളിൽ നൽകുക (ഡിഫോൾട്ട് 10 മിനിറ്റ്)"
+	},
+	"refreshDataButton": {
+		"message": "ഡാറ്റ പുതുക്കുക (കാഷ് ഒഴിവാക്കി)"
+	},
+	"refreshDataInfo": {
+		"message": "പുതിയ ഡാറ്റ ഉടൻ ശേഖരിക്കാൻ ഈ ബട്ടൺ ഉപയോഗിക്കുക."
+	},
+	"noteTitle": {
+		"message": "കുറിപ്പ്:"
+	},
+	"viewCodeButton": {
+		"message": "കോഡ് കാണുക"
+	},
+	"reportIssueButton": {
+		"message": "പ്രശ്നം റിപ്പോർട്ട് ചെയ്യുക"
+	},
+	"repoFilterLabel": {
+		"message": "റിപ്പോസിറ്ററികളിലൂടെ ഫിൽറ്റർ ചെയ്യുക"
+	},
+	"enableFilteringLabel": {
+		"message": "ഫിൽറ്ററിംഗ് സജീവമാക്കുക"
+	},
+	"tokenRequiredWarning": {
+		"message": "റിപ്പോസിറ്ററി ഫിൽറ്ററിംഗിന് GitHub ടോക്കൺ ആവശ്യമാണ്. ദയവായി സെറ്റിംഗ്സിൽ ചേർക്കുക."
+	},
+	"repoSearchPlaceholder": {
+		"message": "ചേർക്കാനുള്ള റിപ്പോസിറ്ററി തിരയുക..."
+	},
+	"repoPlaceholder": {
+		"message": "റിപ്പോസിറ്ററികളൊന്നും തിരഞ്ഞെടുത്തിട്ടില്ല (എല്ലാം ഉൾപ്പെടും)"
+	},
+	"repoCountNone": {
+		"message": "0 റിപ്പോസിറ്ററികൾ തിരഞ്ഞെടുത്തു"
+	},
+	"repoCount": {
+		"message": "$1 റിപ്പോസിറ്ററികൾ തിരഞ്ഞെടുത്തു"
+	},
+	"repoLoading": {
+		"message": "റിപ്പോസിറ്ററികൾ ലോഡ് ചെയ്യുന്നു..."
+	},
+	"repoLoaded": {
+		"message": "$1 റിപ്പോസിറ്ററികൾ ലോഡ് ചെയ്തു."
+	},
+	"repoNotFound": {
+		"message": "റിപ്പോസിറ്ററികൾ കണ്ടെത്തിയില്ല"
+	},
+	"repoRefetching": {
+		"message": "റിപ്പോസിറ്ററികൾ വീണ്ടും ശേഖരിക്കുന്നു..."
+	},
+	"repoLoadFailed": {
+		"message": "റിപ്പോസിറ്ററികൾ ലോഡ് ചെയ്യാൻ പരാജയപ്പെട്ടു."
+	},
+	"repoTokenPrivate": {
+		"message": "ടോക്കൺ അസാധുവാണ് അല്ലെങ്കിൽ സ്വകാര്യ റിപ്പോസിറ്ററികൾക്ക് അനുമതിയില്ല."
+	},
+	"repoRefetchFailed": {
+		"message": "റിപ്പോസിറ്ററികൾ വീണ്ടും ശേഖരിക്കാൻ പരാജയപ്പെട്ടു."
+	},
+	"orgSetMessage": {
+		"message": "സ്ഥാപനം വിജയകരമായി സെറ്റ് ചെയ്തു."
+	},
+	"orgClearedMessage": {
+		"message": "സ്ഥാപനം നീക്കം ചെയ്തു. എല്ലാ പ്രവർത്തനങ്ങളും ശേഖരിക്കാൻ 'റിപ്പോർട്ട് സൃഷ്ടിക്കുക' ക്ലിക്ക് ചെയ്യുക."
+	},
+	"orgNotFoundMessage": {
+		"message": "GitHub-ൽ സ്ഥാപനം കണ്ടെത്തിയില്ല."
+	},
+	"orgValidationErrorMessage": {
+		"message": "സ്ഥാപനം സ്ഥിരീകരിക്കുന്നതിൽ പിശക്."
+	},
+	"refreshingButton": {
+		"message": "പുതുക്കുന്നു..."
+	},
+	"cacheClearFailed": {
+		"message": "കാഷ് ക്ലിയർ ചെയ്യൽ പരാജയപ്പെട്ടു."
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "സൃഷ്ടിക്കുന്നു..."
+	},
+	"copiedButton": {
+		"message": "പകർത്തി!"
+	},
+	"orgChangedMessage": {
+		"message": "സംഘടന മാറി. GitHub പ്രവർത്തനങ്ങൾ ശേഖരിക്കാൻ റിപ്പോർട്ട് സൃഷ്ടിക്കുക ബട്ടൺ ക്ലിക്ക് ചെയ്യുക."
+	},
+	"cacheClearedMessage": {
+		"message": "കാഷ് വിജയകരമായി ക്ലിയർ ചെയ്തു. പുതിയ ഡാറ്റയ്ക്കായി \"റിപ്പോർട്ട് സൃഷ്ടിക്കുക\" ക്ലിക്ക് ചെയ്യുക."
+	},
+	"cacheExpiredMessage": {
+		"message": "കാഷ് കാലഹരണപ്പെട്ടു. പുതിയ ഡാറ്റ ലഭിക്കാൻ \"റിപ്പോർട്ട് സൃഷ്ടിക്കുക\" ക്ലിക്ക് ചെയ്യുക.",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "കാഷ് ക്ലിയർ ചെയ്തു!"
+	},
+	"extensionDisabledMessage": {
+		"message": "എക്സ്റ്റെൻഷൻ അപ്രാപ്തമാണ്. സ്ക്രം റിപ്പോർട്ടുകൾ സൃഷ്ടിക്കാൻ ഓപ്ഷനുകളിൽ നിന്ന് സജീവമാക്കുക."
+	},
+	"notePoint1": {
+		"message": "Pull request-കൾ നിങ്ങൾ മാത്രമല്ല, മറ്റ് സംഭാവനകർത്താക്കളുടെ ഏറ്റവും പുതിയ റിവ്യൂ പ്രവർത്തനത്തെ അടിസ്ഥാനമാക്കിയാണ് ശേഖരിക്കുന്നത്. പങ്കിടുന്നതിന് മുമ്പ് സൃഷ്ടിച്ച SCRUM റിപ്പോർട്ട് നിങ്ങളുടെ പ്രവർത്തനം ശരിയായി പ്രതിഫലിപ്പിക്കുന്നുവെന്ന് ഉറപ്പാക്കാൻ പരിശോധിച്ച് തിരുത്തുക."
+	},
+	"noteSeeIssue": {
+		"message": "ഈ ഇഷ്യൂ കാണുക"
+	},
+	"platformLabel": {
+		"message": "പ്ലാറ്റ്ഫോം"
+	},
+	"usernameLabel": {
+		"message": "നിങ്ങളുടെ ഉപയോക്തൃനാമം"
+	},
+	"onlyRevPRsLabel": {
+		"message": "റിപ്പോർട്ടിൽ റിവ്യൂ ചെയ്ത PRകൾ മാത്രം ഉൾപ്പെടുത്തുക"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "തിരഞ്ഞെടുത്താൽ, നിങ്ങൾ റിവ്യൂ ചെയ്ത PRകൾ മാത്രം റിപ്പോർട്ടിൽ ഉൾപ്പെടും."
+	},
+	"usernameRequiredError": {
+		"message": "റിപ്പോർട്ട് സൃഷ്ടിക്കാൻ നിങ്ങളുടെ ഉപയോക്തൃനാമം നൽകുക."
+	},
+	"unknownPlatformError": {
+		"message": "അജ്ഞാതമായ പ്ലാറ്റ്ഫോം തിരഞ്ഞെടുത്തു."
+	},
+	"gitlabFetchingError": {
+		"message": "GitLab ഡാറ്റ ശേഖരിക്കുന്നതിൽ പിശകുണ്ടായി."
+	},
+	"reportGenerationError": {
+		"message": "റിപ്പോർട്ട് സൃഷ്ടിക്കുന്നതിൽ പിശകുണ്ടായി."
+	},
+	"githubUserNotFoundError": {
+		"message": "GitHub ഉപയോക്താവ് \"$1\" കണ്ടെത്തിയില്ല (404). ഉപയോക്തൃനാമം പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
+	},
+	"githubUserValidationError": {
+		"message": "GitHub ഉപയോക്താവ് സ്ഥിരീകരിക്കുന്നതിൽ പിശക്: $1 $2"
+	},
+	"invalidSearchQueryError": {
+		"message": "അസാധുവായ തിരയൽ ക്വറി അല്ലെങ്കിൽ തീയതി പരിധി. നിങ്ങളുടെ തീയതി പരിധി ഫോർമാറ്റ് പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
+	},
+	"githubIssuesFetchError": {
+		"message": "GitHub ഇഷ്യൂകൾ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
+	},
+	"githubPRReviewFetchError": {
+		"message": "GitHub PR റിവ്യൂ ഡാറ്റ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
+	},
+	"githubUserFetchError": {
+		"message": "GitHub ഉപയോക്തൃ ഡാറ്റ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
+	},
+	"invalidTokenError": {
+		"message": "അസാധുവായ അല്ലെങ്കിൽ കാലഹരണപ്പെട്ട GitHub ടോക്കൺ. Scrum Helper സെറ്റിംഗ്സിൽ നിങ്ങളുടെ ടോക്കൺ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
+	},
+	"displayModeNotice": {
+		"message": "അടുത്ത സമാരംഭത്തിൽ എക്സ്റ്റെൻഷൻ $1 മോഡിൽ തുറക്കും."
+	},
+	"repoFilteringGithubOnly": {
+		"message": "റിപ്പോസിറ്ററി ഫിൽറ്ററിംഗ് GitHub-ന് മാത്രമേ ലഭ്യമാകൂ."
+	},
+	"repoLoadingGithubOnly": {
+		"message": "റിപ്പോസിറ്ററി ലോഡിംഗ് GitHub-ന് മാത്രമേ ലഭ്യമാകൂ."
+	},
+	"repoFetchingGithubOnly": {
+		"message": "റിപ്പോസിറ്ററി ശേഖരണം GitHub-ന് മാത്രമേ ലഭ്യമാകൂ."
+	},
+	"loadingReposAutomatically": {
+		"message": "റിപ്പോസിറ്ററികൾ സ്വയമേവ ലോഡ് ചെയ്യുന്നു..."
+	},
+	"gitlabUserFetchError": {
+		"message": "GitLab ഉപയോക്താവിനെ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
+	},
+	"gitlabUserNotFoundError": {
+		"message": "GitLab ഉപയോക്താവ് '$1' കണ്ടെത്തിയില്ല"
+	},
+	"gitlabMembershipError": {
+		"message": "GitLab അംഗത്വ പ്രോജക്ടുകൾ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
+	},
+	"gitlabContributedError": {
+		"message": "GitLab സംഭാവന പ്രോജക്ടുകൾ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
+	},
+	"usernameMissingError": {
+		"message": "ഉപയോക്തൃനാമം ആവശ്യമാണ്."
+	},
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"generatingReportNotification": {
+		"message": "റിപ്പോർട്ട് തയ്യാറാക്കുന്നു..."
+	},
+	"copyingReportNotification": {
+		"message": "റിപ്പോർട്ട് പകർത്തുന്നു..."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "റിപ്പോർട്ട് ഇമെയിലിൽ ചേർക്കുന്നു..."
+	},
+	"insertedInEmailNotification": {
+		"message": "റിപ്പോർട്ട് ഇമെയിലിൽ ചേർത്തു!"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/my/messages.json
+++ b/src/_locales/my/messages.json
@@ -1,293 +1,317 @@
 {
-  "appName": {
-    "message": "Scrum Helper"
-  },
-  "appDescription": {
-    "message": "ရွေးချယ်ထားသောကာလတစ်ခုအတွက် သင်၏ Git လုပ်ဆောင်ချက်ကို အလိုအလျောက်ရယူခြင်းဖြင့် သင်၏ဖွံ့ဖြိုးတိုးတက်မှုကို အစီရင်ခံပါ။"
-  },
-  "disableLabel": {
-    "message": "ပိတ်ပါ။"
-  },
-  "enableLabel": {
-    "message": "ဖွင့်ပါ။"
-  },
-  "projectNameLabel": {
-    "message": "ပရောဂျက်အမည် (အီးမေးလ်အကြောင်းအရာတွင်သုံးသည်)။"
-  },
-  "projectNamePlaceholder": {
-    "message": "သင့်ပရောဂျက်အမည်ကို ထည့်သွင်းပါ။"
-  },
-  "githubUsernameLabel": {
-    "message": "သင်၏ Github အသုံးပြုသူအမည်"
-  },
-  "gitlabUsernameLabel": {
-    "message": "သင်၏ Gitlab အသုံးပြုသူအမည်"
-  },
-  "githubUsernamePlaceholder": {
-    "message": "သင်၏ contributions များကို ရယူရန်အတွက် လိုအပ်ပါသည်။"
-  },
-  "contributionsLabel": {
-    "message": "contributionsရရှိမည့်ကြာချိန် ："
-  },
-  "last1DayLabel": {
-    "message": "အရင်နေ့"
-  },
-  "startDateLabel": {
-    "message": "မှ :"
-  },
-  "endDateLabel": {
-    "message": "အထိ :"
-  },
-  "showOpenClosedLabel": {
-    "message": "PRs labelsကို ပြပါ။"
-  },
-  "blockersLabel": {
-    "message": "သင့်တိုးတက်မှုကို ရပ်တန့်စေသောအရာများ။"
-  },
-  "blockersPlaceholder": {
-    "message": "သင်၏တိုးတက်မှုကို ရပ်တန့်စေသောအရာများကိုထည့်ပါ။"
-  },
-  "scrumReportLabel": {
-    "message": "Scrum အစီရင်ခံစာ"
-  },
-  "generateReportButton": {
-    "message": "အစီရင်ခံစာထုတ်ပါ။"
-  },
-  "copyReportButton": {
-    "message": "အစီရင်ခံစာကူးယူပါ။"
-  },
-  "settingsOrgNameLabel": {
-    "message": "အဖွဲ့အစည်းအမည်"
-  },
-  "settingsOrgNamePlaceholder": {
-    "message": "အဖွဲ့အစည်းအမည်ကိုထည့်ပါ။"
-  },
-  "setButton": {
-    "message": "သတ်မှတ်မည်။"
-  },
-  "githubTokenLabel": {
-    "message": "သင်၏ Github တိုကင်"
-  },
-  "githubTokenPlaceholder": {
-    "message": "Authenticated requests ပြုလုပ်ရန်အတွက် လိုအပ်ပါသည်။"
-  },
-  "githubTokenTooltip": {
-    "message": "GitHub တိုကင်ထည့်ရန် အဘယ်ကြောင့် အကြံပြုရသနည်း။ Scrum Helper သည် GitHub တိုကင်မပါဘဲ အလုပ်လုပ်သော်လည်း ပိုမိုကောင်းမွန်သော အတွေ့အကြုံအတွက် ကိုယ်ပိုင်အသုံးပြုခွင့် တိုကင်တစ်ခုထည့်ခြင်းကို အကြံပြုပါသည်။"
-  },
-  "gitlabTokenLabel": {
-    "message": "သင်၏ Gitlab တိုကင်"
-  },
-  "gitlabTokenPlaceholder": {
-    "message": "ပုဂ္ဂလိကပရောဂျက်များကို ဝင်ရောက်အသုံးပြုရန် လိုအပ်ပါသည်။"
-  },
-  "gitlabTokenTooltip": {
-    "message": "Gitlab တိုကင်ထည့်ရန် အဘယ်ကြောင့် အကြံပြုရသနည်း။ Scrum Helper သည် အများပြည်သူကြည့်ရှုနိုင်သော ပရောဂျက်များအတွက် Gitlab တိုကင်မပါဘဲ အလုပ်လုပ်သော်လည်း၊ သီးခြား (ပုဂ္ဂလိက) ပရောဂျက်များနှင့် ပိုမိုကောင်းမွန်သော အတွေ့အကြုံအတွက် ကိုယ်ပိုင်အသုံးပြုခွင့် တိုကင်တစ်ခုထည့်ရန် အကြံပြုပါသည်။"
-  },
-  "showCommitsLabel": {
-    "message": "OpenPRများ/DraftPR များပေါ်မှ commits များကို ပြပါ။"
-  },
-  "showCommitsTooltip": {
-    "message": "Github Token လိုအပ်သည်၊ ၎င်းကို settingတွင် ရှာတွေ့နိုင်ပါသည်။"
-  },
-  "onlyIssuesLabel": {
-    "message": "အစီရင်ခံစာတွင် issuesများသာ ပါဝင်ပါသည်။"
-  },
-  "onlyIssuesTooltip": {
-    "message": "စစ်ဆေးပြီး ကြည့်ရှုပါက အစီရင်ခံစာတွင် အသုံးပြုသူအတွက် ဖန်တီးထားသော သို့မဟုတ် သတ်မှတ်ပေးထားသည့် ပြဿနာများသာ ပါဝင်မည်ဖြစ်သည်။"
-  },
-  "onlyPRsLabel": {
-    "message": "အစီရင်ခံစာတွင် PR များသာပါဝင်သည်။"
-  },
-  "onlyPRsTooltip": {
-    "message": "စစ်ဆေးပါက အစီရင်ခံစာတွင် အသုံးပြုသူ ဖန်တီးထားသည့် PR များသာ ပါဝင်မည်ဖြစ်သည်။ သုံးသပ်ထားသော PR များကို ဖယ်ထုတ်ထားပါမည်။"
-  },
-  "cacheTTLLabel": {
-    "message": "cache TTL ကိုထည့်ပါ။"
-  },
-  "cacheTTLUnit": {
-    "message": "(မိနစ်)"
-  },
-  "cacheTTLPlaceholder": {
-    "message": "cache TTL ထည့်သွင်းရာတွင် မိနစ်ကို အသုံးပြုပါ။ (ပုံသေ 10 မိနစ်)"
-  },
-  "refreshDataButton": {
-    "message": "ဒေတာကို ပြန်လည်စတင်ပါ (bypass cache)"
-  },
-  "refreshDataInfo": {
-    "message": "ဒေတာအသစ်များကို ချက်ချင်းရယူရန် ဤခလုတ်ကို အသုံးပြုပါ။"
-  },
-  "noteTitle": {
-    "message": "မှတ်စု မှတ်သားရန် :"
-  },
-  "viewCodeButton": {
-    "message": "Code ကြည့်ရန်"
-  },
-  "reportIssueButton": {
-    "message": "ပြဿနာကို သတင်းပို့ရန်"
-  },
-  "repoFilterLabel": {
-    "message": "repositoriesများအလိုက် စစ်ထုတ်ပါ။"
-  },
-  "enableFilteringLabel": {
-    "message": "filterကို enableလုပ်ပါ။"
-  },
-  "tokenRequiredWarning": {
-    "message": "Filteringအတွက် GitHub တိုကင်တစ်ခု လိုအပ်သည်။ settingတွင် တစ်ခုထည့်ပါ။"
-  },
-  "repoSearchPlaceholder": {
-    "message": "ထည့်သွင်းလိုသော repository ကိုရှာဖွေရန်..."
-  },
-  "repoPlaceholder": {
-    "message": "filterရန်အတွက် ရွေးချယ်ထားသော repository မရှိပါ။(all will be included)"
-  },
-  "repoCountNone": {
-    "message": "ရွေးချယ်ထားသော repositoryအရေအတွက်သည် 0 ဖြစ်သည်။"
-  },
-  "repoCount": {
-    "message": "ရွေးချယ်ထားသော repositoryအရေအတွက်သည် $1 ဖြစ်သည်။"
-  },
-  "repoLoading": {
-    "message": "repositoryကို ဖွင့်နေသည်....."
-  },
-  "repoLoaded": {
-    "message": "$1 repositoryကို ဖွင့်ပြီးပြီ။"
-  },
-  "repoNotFound": {
-    "message": "repository မတွေ့ပါ။"
-  },
-  "repoRefetching": {
-    "message": "repositoryများကို ပြန်လည်ရယူနေသည်..."
-  },
-  "repoLoadFailed": {
-    "message": "ဖွင့်၍မရပါ။"
-  },
-  "repoTokenPrivate": {
-    "message": "တိုကင်သည် မမှန်ကန်ပါ သို့မဟုတ် သီးသန့် repos အတွက် လုပ်ပိုင်ခွင့်မရှိပါ။"
-  },
-  "repoRefetchFailed": {
-    "message": "repositoryများကို ပြန်ယူရန် မအောင်မြင်ပါ။"
-  },
-  "orgSetMessage": {
-    "message": "အဖွဲ့အစည်းသတ်မှတ်ခြင်းသည် အောင်မြင်သည်။"
-  },
-  "orgClearedMessage": {
-    "message": "အဖွဲ့အစည်း ရှင်းလင်းပြီးသည်။ activitiesအားလုံးကိုရယူရန် 'အစီရင်ခံစာထုတ်လုပ်ရန်' ကိုနှိပ်ပါ။"
-  },
-  "orgNotFoundMessage": {
-    "message": "အဖွဲ့အစည်းကို GitHub တွင် ရှာမတွေ့ပါ။"
-  },
-  "orgValidationErrorMessage": {
-    "message": "အဖွဲ့အစည်းကို အတည်ပြုရာတွင် အမှားအယွင်းရှိသည်။"
-  },
-  "refreshingButton": {
-    "message": "refresh လုပ်နေသည်..."
-  },
-  "cacheClearFailed": {
-    "message": "cache ရှင်းလင်းခြင်း မအောင်မြင်ပါ။"
-  },
-  "madeWithLoveBy": {
-    "message": "Made with ❤️ by"
-  },
-  "generatingButton": {
-    "message": "generate လုပ်နေသည်..."
-  },
-  "copiedButton": {
-    "message": "copyကူးယူပြီးပါပြီ!"
-  },
-  "orgChangedMessage": {
-    "message": "အဖွဲ့အစည်းပြောင်းသွားသည်။ GitHub လုပ်ဆောင်ချက်များကို ရယူရန် Generate ခလုတ်ကို နှိပ်ပါ။"
-  },
-  "cacheClearedMessage": {
-    "message": "cacheကို အောင်မြင်စွာ ရှင်းလင်းပြီးပါပြီ။ ဒေတာအသစ်ရယူရန် \"အစီရင်ခံစာကို ထုတ်လုပ်ပါ\" ကိုနှိပ်ပါ။"
-  },
-  "cacheClearedButton": {
-    "message": "cache ရှင်းလင်းပြီးပါပြီ!"
-  },
-  "extensionDisabledMessage": {
-    "message": "Extensionကို ပိတ်ထားသည်။ scrum အစီရင်ခံစာများထုတ်လုပ်ရန် optionsမှ ၎င်းကိုဖွင့်ပါ။"
-  },
-  "notePoint1": {
-    "message": "PR ရယူခြင်းသည် သင်အပါအဝင် contributorများ၏ အနီးဆုံး လုပ်ဆောင်ချက်ပေါ်တွင် မူတည်သည်။ ကျေးဇူးပြု၍ မမျှဝေမီ SCRUM အစီရင်ခံစာကို သင်လိုချင်တဲ့အလုပ် မှန်မမှန် အတွက်ပြန်လည်သုံးသပ်ပြီး ချိန်ညှိပါ။"
-  },
-  "noteSeeIssue": {
-    "message": "ဒီissueကို ကြည့်ပါ။"
-  },
-  "platformLabel": {
-    "message": "Platform"
-  },
-  "onlyRevPRsLabel": {
-    "message": "အစီရင်ခံစာတွင် သုံးသပ်ထားသော PR များသာ ပါဝင်ပါသည်။"
-  },
-  "onlyRevPRsTooltip": {
-    "message": "၎င်းကိုစစ်ဆေးပါက၊ အစီရင်ခံစာတွင် သင်သုံးသပ်ထားသော PR များသာ ပါဝင်မည်ဖြစ်သည်။"
-  },
-  "usernameLabel": {
-    "message": "သင်၏အသုံးပြုသူအမည်"
-  },
-  "usernameRequiredError": {
-    "message": "အစီရင်ခံစာထုတ်လုပ်ရန် သင်၏အသုံးပြုသူအမည်ကို ထည့်သွင်းပါ။"
-  },
-  "unknownPlatformError": {
-    "message": "အမျိုးအမည်မသိ platformကို ရွေးချယ်ထားသည်။"
-  },
-  "gitlabFetchingError": {
-    "message": "GitLab ဒေတာကို ရယူနေစဉ် အမှားအယွင်းတစ်ခု ဖြစ်ပွားခဲ့သည်။"
-  },
-  "reportGenerationError": {
-    "message": "အစီရင်ခံစာကို ထုတ်လုပ်နေစဉ် အမှားအယွင်းတစ်ခု ဖြစ်ပွားခဲ့သည်။"
-  },
-  "githubUserNotFoundError": {
-    "message": "GitHub အသုံးပြုသူ \"$1\" ကို ရှာမတွေ့ပါ (404)။ အသုံးပြုသူအမည်ကို စစ်ဆေးပြီး ပြန်လည်ကြိုးစားပါ။"
-  },
-  "githubUserValidationError": {
-    "message": "GitHub အသုံးပြုသူကို အတည်ပြုရာတွင် အမှား: $1 $2"
-  },
-  "invalidSearchQueryError": {
-    "message": "မမှန်ကန်သော ရှာဖွေမှုမေးခွန်း သို့မဟုတ် ရက်စွဲအပိုင်းအခြား။ သင်၏ ရက်စွဲအပိုင်းအခြား ပုံစံကို အတည်ပြုပြီး ပြန်လည်ကြိုးစားပါ။"
-  },
-  "githubIssuesFetchError": {
-    "message": "GitHub issueများကို ရယူရာတွင် အမှား: $1 $2"
-  },
-  "githubPRReviewFetchError": {
-    "message": "GitHub PR သုံးသပ်ချက် ဒေတာကို ရယူရာတွင် အမှား: $1 $2"
-  },
-  "githubUserFetchError": {
-    "message": "GitHub အသုံးပြုသူ ဒေတာကို ရယူရာတွင် အမှား: $1 $2"
-  },
-  "invalidTokenError": {
-    "message": "မမှန်ကန်သော သို့မဟုတ် သက်တမ်းကုန်ဆုံးသွားသော GitHub တိုကင်။ Scrum Helper ဆက်တင်များတွင် သင်၏တိုကင်ကို စစ်ဆေးပြီး ပြန်လည်ကြိုးစားပါ။"
-  },
-  "displayModeNotice": {
-    "message": "နောက်တစ်ကြိမ် ဖွင့်လှစ်သည့်အခါ extensionသည် $1 မုဒ်ဖြင့် ဖွင့်မည်ဖြစ်သည်။"
-  },
-  "repoFilteringGithubOnly": {
-    "message": "Repository filteringသည် GitHub အတွက်သာ ရရှိနိုင်ပါသည်။"
-  },
-  "repoLoadingGithubOnly": {
-    "message": "Repository loadingသည် GitHub အတွက်သာ ရရှိနိုင်ပါသည်။"
-  },
-  "repoFetchingGithubOnly": {
-    "message": "Repository ရယူခြင်းသည် GitHub အတွက်သာ ရရှိနိုင်ပါသည်။"
-  },
-  "loadingReposAutomatically": {
-    "message": "Repositoriesများကို အလိုအလျောက် ဖွင့်နေသည်..."
-  },
-  "gitlabUserFetchError": {
-    "message": "GitLab အသုံးပြုသူကို ရယူရာတွင် အမှား: $1 $2"
-  },
-  "gitlabUserNotFoundError": {
-    "message": "GitLab အသုံးပြုသူ '$1' ကို ရှာမတွေ့ပါ"
-  },
-  "gitlabMembershipError": {
-    "message": "GitLab အဖွဲ့ဝင်ပရောဂျက်များကို ရယူရာတွင် အမှား: $1 $2"
-  },
-  "gitlabContributedError": {
-    "message": "GitLab ပံ့ပိုးထားသော ပရောဂျက်များကို ရယူရာတွင် အမှား: $1 $2"
-  },
-  "usernameMissingError": {
-    "message": "အသုံးပြုသူအမည် လိုအပ်သည်။"
-  },
-  "insertInEmailButton": {
-    "message": "အီးမေးလ်သို့ ထည့်ပါ"
-  }
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "ရွေးချယ်ထားသောကာလတစ်ခုအတွက် သင်၏ Git လုပ်ဆောင်ချက်ကို အလိုအလျောက်ရယူခြင်းဖြင့် သင်၏ဖွံ့ဖြိုးတိုးတက်မှုကို အစီရင်ခံပါ။"
+	},
+	"disableLabel": {
+		"message": "ပိတ်ပါ။"
+	},
+	"enableLabel": {
+		"message": "ဖွင့်ပါ။"
+	},
+	"projectNameLabel": {
+		"message": "ပရောဂျက်အမည် (အီးမေးလ်အကြောင်းအရာတွင်သုံးသည်)။"
+	},
+	"projectNamePlaceholder": {
+		"message": "သင့်ပရောဂျက်အမည်ကို ထည့်သွင်းပါ။"
+	},
+	"githubUsernameLabel": {
+		"message": "သင်၏ Github အသုံးပြုသူအမည်"
+	},
+	"gitlabUsernameLabel": {
+		"message": "သင်၏ Gitlab အသုံးပြုသူအမည်"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "သင်၏ contributions များကို ရယူရန်အတွက် လိုအပ်ပါသည်။"
+	},
+	"contributionsLabel": {
+		"message": "contributionsရရှိမည့်ကြာချိန် ："
+	},
+	"last1DayLabel": {
+		"message": "အရင်နေ့"
+	},
+	"startDateLabel": {
+		"message": "မှ :"
+	},
+	"endDateLabel": {
+		"message": "အထိ :"
+	},
+	"showOpenClosedLabel": {
+		"message": "PRs labelsကို ပြပါ။"
+	},
+	"blockersLabel": {
+		"message": "သင့်တိုးတက်မှုကို ရပ်တန့်စေသောအရာများ။"
+	},
+	"blockersPlaceholder": {
+		"message": "သင်၏တိုးတက်မှုကို ရပ်တန့်စေသောအရာများကိုထည့်ပါ။"
+	},
+	"scrumReportLabel": {
+		"message": "Scrum အစီရင်ခံစာ"
+	},
+	"generateReportButton": {
+		"message": "အစီရင်ခံစာထုတ်ပါ။"
+	},
+	"copyReportButton": {
+		"message": "အစီရင်ခံစာကူးယူပါ။"
+	},
+	"settingsOrgNameLabel": {
+		"message": "အဖွဲ့အစည်းအမည်"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "အဖွဲ့အစည်းအမည်ကိုထည့်ပါ။"
+	},
+	"setButton": {
+		"message": "သတ်မှတ်မည်။"
+	},
+	"githubTokenLabel": {
+		"message": "သင်၏ Github တိုကင်"
+	},
+	"githubTokenPlaceholder": {
+		"message": "Authenticated requests ပြုလုပ်ရန်အတွက် လိုအပ်ပါသည်။"
+	},
+	"githubTokenTooltip": {
+		"message": "GitHub တိုကင်ထည့်ရန် အဘယ်ကြောင့် အကြံပြုရသနည်း။ Scrum Helper သည် GitHub တိုကင်မပါဘဲ အလုပ်လုပ်သော်လည်း ပိုမိုကောင်းမွန်သော အတွေ့အကြုံအတွက် ကိုယ်ပိုင်အသုံးပြုခွင့် တိုကင်တစ်ခုထည့်ခြင်းကို အကြံပြုပါသည်။"
+	},
+	"gitlabTokenLabel": {
+		"message": "သင်၏ Gitlab တိုကင်"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "ပုဂ္ဂလိကပရောဂျက်များကို ဝင်ရောက်အသုံးပြုရန် လိုအပ်ပါသည်။"
+	},
+	"gitlabTokenTooltip": {
+		"message": "Gitlab တိုကင်ထည့်ရန် အဘယ်ကြောင့် အကြံပြုရသနည်း။ Scrum Helper သည် အများပြည်သူကြည့်ရှုနိုင်သော ပရောဂျက်များအတွက် Gitlab တိုကင်မပါဘဲ အလုပ်လုပ်သော်လည်း၊ သီးခြား (ပုဂ္ဂလိက) ပရောဂျက်များနှင့် ပိုမိုကောင်းမွန်သော အတွေ့အကြုံအတွက် ကိုယ်ပိုင်အသုံးပြုခွင့် တိုကင်တစ်ခုထည့်ရန် အကြံပြုပါသည်။"
+	},
+	"showCommitsLabel": {
+		"message": "OpenPRများ/DraftPR များပေါ်မှ commits များကို ပြပါ။"
+	},
+	"showCommitsTooltip": {
+		"message": "Github Token လိုအပ်သည်၊ ၎င်းကို settingတွင် ရှာတွေ့နိုင်ပါသည်။"
+	},
+	"onlyIssuesLabel": {
+		"message": "အစီရင်ခံစာတွင် issuesများသာ ပါဝင်ပါသည်။"
+	},
+	"onlyIssuesTooltip": {
+		"message": "စစ်ဆေးပြီး ကြည့်ရှုပါက အစီရင်ခံစာတွင် အသုံးပြုသူအတွက် ဖန်တီးထားသော သို့မဟုတ် သတ်မှတ်ပေးထားသည့် ပြဿနာများသာ ပါဝင်မည်ဖြစ်သည်။"
+	},
+	"onlyPRsLabel": {
+		"message": "အစီရင်ခံစာတွင် PR များသာပါဝင်သည်။"
+	},
+	"onlyPRsTooltip": {
+		"message": "စစ်ဆေးပါက အစီရင်ခံစာတွင် အသုံးပြုသူ ဖန်တီးထားသည့် PR များသာ ပါဝင်မည်ဖြစ်သည်။ သုံးသပ်ထားသော PR များကို ဖယ်ထုတ်ထားပါမည်။"
+	},
+	"cacheTTLLabel": {
+		"message": "cache TTL ကိုထည့်ပါ။"
+	},
+	"cacheTTLUnit": {
+		"message": "(မိနစ်)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "cache TTL ထည့်သွင်းရာတွင် မိနစ်ကို အသုံးပြုပါ။ (ပုံသေ 10 မိနစ်)"
+	},
+	"refreshDataButton": {
+		"message": "ဒေတာကို ပြန်လည်စတင်ပါ (bypass cache)"
+	},
+	"refreshDataInfo": {
+		"message": "ဒေတာအသစ်များကို ချက်ချင်းရယူရန် ဤခလုတ်ကို အသုံးပြုပါ။"
+	},
+	"noteTitle": {
+		"message": "မှတ်စု မှတ်သားရန် :"
+	},
+	"viewCodeButton": {
+		"message": "Code ကြည့်ရန်"
+	},
+	"reportIssueButton": {
+		"message": "ပြဿနာကို သတင်းပို့ရန်"
+	},
+	"repoFilterLabel": {
+		"message": "repositoriesများအလိုက် စစ်ထုတ်ပါ။"
+	},
+	"enableFilteringLabel": {
+		"message": "filterကို enableလုပ်ပါ။"
+	},
+	"tokenRequiredWarning": {
+		"message": "Filteringအတွက် GitHub တိုကင်တစ်ခု လိုအပ်သည်။ settingတွင် တစ်ခုထည့်ပါ။"
+	},
+	"repoSearchPlaceholder": {
+		"message": "ထည့်သွင်းလိုသော repository ကိုရှာဖွေရန်..."
+	},
+	"repoPlaceholder": {
+		"message": "filterရန်အတွက် ရွေးချယ်ထားသော repository မရှိပါ။(all will be included)"
+	},
+	"repoCountNone": {
+		"message": "ရွေးချယ်ထားသော repositoryအရေအတွက်သည် 0 ဖြစ်သည်။"
+	},
+	"repoCount": {
+		"message": "ရွေးချယ်ထားသော repositoryအရေအတွက်သည် $1 ဖြစ်သည်။"
+	},
+	"repoLoading": {
+		"message": "repositoryကို ဖွင့်နေသည်....."
+	},
+	"repoLoaded": {
+		"message": "$1 repositoryကို ဖွင့်ပြီးပြီ။"
+	},
+	"repoNotFound": {
+		"message": "repository မတွေ့ပါ။"
+	},
+	"repoRefetching": {
+		"message": "repositoryများကို ပြန်လည်ရယူနေသည်..."
+	},
+	"repoLoadFailed": {
+		"message": "ဖွင့်၍မရပါ။"
+	},
+	"repoTokenPrivate": {
+		"message": "တိုကင်သည် မမှန်ကန်ပါ သို့မဟုတ် သီးသန့် repos အတွက် လုပ်ပိုင်ခွင့်မရှိပါ။"
+	},
+	"repoRefetchFailed": {
+		"message": "repositoryများကို ပြန်ယူရန် မအောင်မြင်ပါ။"
+	},
+	"orgSetMessage": {
+		"message": "အဖွဲ့အစည်းသတ်မှတ်ခြင်းသည် အောင်မြင်သည်။"
+	},
+	"orgClearedMessage": {
+		"message": "အဖွဲ့အစည်း ရှင်းလင်းပြီးသည်။ activitiesအားလုံးကိုရယူရန် 'အစီရင်ခံစာထုတ်လုပ်ရန်' ကိုနှိပ်ပါ။"
+	},
+	"orgNotFoundMessage": {
+		"message": "အဖွဲ့အစည်းကို GitHub တွင် ရှာမတွေ့ပါ။"
+	},
+	"orgValidationErrorMessage": {
+		"message": "အဖွဲ့အစည်းကို အတည်ပြုရာတွင် အမှားအယွင်းရှိသည်။"
+	},
+	"refreshingButton": {
+		"message": "refresh လုပ်နေသည်..."
+	},
+	"cacheClearFailed": {
+		"message": "cache ရှင်းလင်းခြင်း မအောင်မြင်ပါ။"
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "generate လုပ်နေသည်..."
+	},
+	"copiedButton": {
+		"message": "copyကူးယူပြီးပါပြီ!"
+	},
+	"orgChangedMessage": {
+		"message": "အဖွဲ့အစည်းပြောင်းသွားသည်။ GitHub လုပ်ဆောင်ချက်များကို ရယူရန် Generate ခလုတ်ကို နှိပ်ပါ။"
+	},
+	"cacheClearedMessage": {
+		"message": "cacheကို အောင်မြင်စွာ ရှင်းလင်းပြီးပါပြီ။ ဒေတာအသစ်ရယူရန် \"အစီရင်ခံစာကို ထုတ်လုပ်ပါ\" ကိုနှိပ်ပါ။"
+	},
+	"cacheClearedButton": {
+		"message": "cache ရှင်းလင်းပြီးပါပြီ!"
+	},
+	"extensionDisabledMessage": {
+		"message": "Extensionကို ပိတ်ထားသည်။ scrum အစီရင်ခံစာများထုတ်လုပ်ရန် optionsမှ ၎င်းကိုဖွင့်ပါ။"
+	},
+	"notePoint1": {
+		"message": "PR ရယူခြင်းသည် သင်အပါအဝင် contributorများ၏ အနီးဆုံး လုပ်ဆောင်ချက်ပေါ်တွင် မူတည်သည်။ ကျေးဇူးပြု၍ မမျှဝေမီ SCRUM အစီရင်ခံစာကို သင်လိုချင်တဲ့အလုပ် မှန်မမှန် အတွက်ပြန်လည်သုံးသပ်ပြီး ချိန်ညှိပါ။"
+	},
+	"noteSeeIssue": {
+		"message": "ဒီissueကို ကြည့်ပါ။"
+	},
+	"platformLabel": {
+		"message": "Platform"
+	},
+	"onlyRevPRsLabel": {
+		"message": "အစီရင်ခံစာတွင် သုံးသပ်ထားသော PR များသာ ပါဝင်ပါသည်။"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "၎င်းကိုစစ်ဆေးပါက၊ အစီရင်ခံစာတွင် သင်သုံးသပ်ထားသော PR များသာ ပါဝင်မည်ဖြစ်သည်။"
+	},
+	"usernameLabel": {
+		"message": "သင်၏အသုံးပြုသူအမည်"
+	},
+	"usernameRequiredError": {
+		"message": "အစီရင်ခံစာထုတ်လုပ်ရန် သင်၏အသုံးပြုသူအမည်ကို ထည့်သွင်းပါ။"
+	},
+	"unknownPlatformError": {
+		"message": "အမျိုးအမည်မသိ platformကို ရွေးချယ်ထားသည်။"
+	},
+	"gitlabFetchingError": {
+		"message": "GitLab ဒေတာကို ရယူနေစဉ် အမှားအယွင်းတစ်ခု ဖြစ်ပွားခဲ့သည်။"
+	},
+	"reportGenerationError": {
+		"message": "အစီရင်ခံစာကို ထုတ်လုပ်နေစဉ် အမှားအယွင်းတစ်ခု ဖြစ်ပွားခဲ့သည်။"
+	},
+	"githubUserNotFoundError": {
+		"message": "GitHub အသုံးပြုသူ \"$1\" ကို ရှာမတွေ့ပါ (404)။ အသုံးပြုသူအမည်ကို စစ်ဆေးပြီး ပြန်လည်ကြိုးစားပါ။"
+	},
+	"githubUserValidationError": {
+		"message": "GitHub အသုံးပြုသူကို အတည်ပြုရာတွင် အမှား: $1 $2"
+	},
+	"invalidSearchQueryError": {
+		"message": "မမှန်ကန်သော ရှာဖွေမှုမေးခွန်း သို့မဟုတ် ရက်စွဲအပိုင်းအခြား။ သင်၏ ရက်စွဲအပိုင်းအခြား ပုံစံကို အတည်ပြုပြီး ပြန်လည်ကြိုးစားပါ။"
+	},
+	"githubIssuesFetchError": {
+		"message": "GitHub issueများကို ရယူရာတွင် အမှား: $1 $2"
+	},
+	"githubPRReviewFetchError": {
+		"message": "GitHub PR သုံးသပ်ချက် ဒေတာကို ရယူရာတွင် အမှား: $1 $2"
+	},
+	"githubUserFetchError": {
+		"message": "GitHub အသုံးပြုသူ ဒေတာကို ရယူရာတွင် အမှား: $1 $2"
+	},
+	"invalidTokenError": {
+		"message": "မမှန်ကန်သော သို့မဟုတ် သက်တမ်းကုန်ဆုံးသွားသော GitHub တိုကင်။ Scrum Helper ဆက်တင်များတွင် သင်၏တိုကင်ကို စစ်ဆေးပြီး ပြန်လည်ကြိုးစားပါ။"
+	},
+	"displayModeNotice": {
+		"message": "နောက်တစ်ကြိမ် ဖွင့်လှစ်သည့်အခါ extensionသည် $1 မုဒ်ဖြင့် ဖွင့်မည်ဖြစ်သည်။"
+	},
+	"repoFilteringGithubOnly": {
+		"message": "Repository filteringသည် GitHub အတွက်သာ ရရှိနိုင်ပါသည်။"
+	},
+	"repoLoadingGithubOnly": {
+		"message": "Repository loadingသည် GitHub အတွက်သာ ရရှိနိုင်ပါသည်။"
+	},
+	"repoFetchingGithubOnly": {
+		"message": "Repository ရယူခြင်းသည် GitHub အတွက်သာ ရရှိနိုင်ပါသည်။"
+	},
+	"loadingReposAutomatically": {
+		"message": "Repositoriesများကို အလိုအလျောက် ဖွင့်နေသည်..."
+	},
+	"gitlabUserFetchError": {
+		"message": "GitLab အသုံးပြုသူကို ရယူရာတွင် အမှား: $1 $2"
+	},
+	"gitlabUserNotFoundError": {
+		"message": "GitLab အသုံးပြုသူ '$1' ကို ရှာမတွေ့ပါ"
+	},
+	"gitlabMembershipError": {
+		"message": "GitLab အဖွဲ့ဝင်ပရောဂျက်များကို ရယူရာတွင် အမှား: $1 $2"
+	},
+	"gitlabContributedError": {
+		"message": "GitLab ပံ့ပိုးထားသော ပရောဂျက်များကို ရယူရာတွင် အမှား: $1 $2"
+	},
+	"usernameMissingError": {
+		"message": "အသုံးပြုသူအမည် လိုအပ်သည်။"
+	},
+	"insertInEmailButton": {
+		"message": "အီးမေးလ်သို့ ထည့်ပါ"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/nb/messages.json
+++ b/src/_locales/nb/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Rapporter utviklingsfremgangen din ved å automatisk hente Git-aktiviteten din for en valgt periode."
-    },
-    "disableLabel": {
-        "message": "Deaktiver"
-    },
-    "enableLabel": {
-        "message": "Aktiver"
-    },
-    "projectNameLabel": {
-        "message": "Prosjektnavn (brukes i e-postemne)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Skriv inn prosjektnavnet ditt"
-    },
-    "githubUsernameLabel": {
-        "message": "Ditt GitHub-brukernavn"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Ditt GitLab-brukernavn"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Påkrevd for å hente bidragene dine"
-    },
-    "contributionsLabel": {
-        "message": "Hent dine bidrag for:"
-    },
-    "last1DayLabel": {
-        "message": "Forrige dag"
-    },
-    "startDateLabel": {
-        "message": "Fra:"
-    },
-    "endDateLabel": {
-        "message": "Til:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Vis Åpen/Lukket-status"
-    },
-    "blockersLabel": {
-        "message": "Hva hindrer deg i å gjøre fremgang?"
-    },
-    "blockersPlaceholder": {
-        "message": "Skriv inn din grunn"
-    },
-    "scrumReportLabel": {
-        "message": "Scrum-rapport"
-    },
-    "generateReportButton": {
-        "message": "Generer rapport"
-    },
-    "copyReportButton": {
-        "message": "Kopier rapport"
-    },
-    "insertInEmailButton": {
-        "message": "Sett inn i e-post",
-        "description": "Text for the 'Insert to Email' button."
-    },
-    "settingsOrgNameLabel": {
-        "message": "Organisasjonsnavn"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Skriv inn organisasjonsnavn"
-    },
-    "setButton": {
-        "message": "Angi"
-    },
-    "githubTokenLabel": {
-        "message": "Ditt GitHub-token"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Påkrevd for autentiserte forespørsler"
-    },
-    "githubTokenTooltip": {
-        "message": "Hvorfor anbefales det å legge til et GitHub-token? Scrum Helper fungerer uten et GitHub-token, men det anbefales å legge til et personlig tilgangstoken for en bedre opplevelse."
-    },
-    "gitlabTokenLabel": {
-        "message": "Ditt GitLab-token"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Påkrevd for private repositorier"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Hvorfor anbefales det å legge til et GitLab-token? Scrum Helper fungerer uten et GitLab-token for offentlige prosjekter, men det anbefales å legge til et personlig tilgangstoken for en bedre opplevelse."
-    },
-    "showCommitsLabel": {
-        "message": "Vis commits på åpne PR-er/utkast til PR-er"
-    },
-    "showCommitsTooltip": {
-        "message": "GitHub-token kreves. Legg det til i innstillingene."
-    },
-    "onlyIssuesLabel": {
-        "message": "Inkluder kun problemer i rapporten"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Hvis valgt, vil rapporten kun inkludere problemer opprettet eller tildelt brukeren."
-    },
-    "onlyPRsLabel": {
-        "message": "Inkluder kun PR-er i rapporten"
-    },
-    "onlyPRsTooltip": {
-        "message": "Hvis valgt, vil rapporten kun inkludere PR-er opprettet av brukeren; gjennomgåtte PR-er vil utelates."
-    },
-    "cacheTTLLabel": {
-        "message": "Angi cache-TTL"
-    },
-    "cacheTTLUnit": {
-        "message": "(i minutter)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Skriv inn cache-TTL i minutter (Standard: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Oppdater data (omgå cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Bruk denne knappen for å hente ferske data umiddelbart."
-    },
-    "noteTitle": {
-        "message": "Merk:"
-    },
-    "viewCodeButton": {
-        "message": "Se kode"
-    },
-    "reportIssueButton": {
-        "message": "Rapporter et problem"
-    },
-    "repoFilterLabel": {
-        "message": "Filtrer etter repositorier"
-    },
-    "enableFilteringLabel": {
-        "message": "Aktiver filtrering"
-    },
-    "tokenRequiredWarning": {
-        "message": "Et GitHub-token er påkrevd for repositoriefiltrering. Vennligst legg til ett i innstillingene."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Søk etter et repositorium for å legge til..."
-    },
-    "repoPlaceholder": {
-        "message": "Ingen repositorier valgt (alle vil bli inkludert)"
-    },
-    "repoCountNone": {
-        "message": "0 repositorier valgt"
-    },
-    "repoCount": {
-        "message": "$1 repositorier valgt"
-    },
-    "repoLoading": {
-        "message": "Laster repositorier..."
-    },
-    "repoLoaded": {
-        "message": "Lastet $1 repositorier."
-    },
-    "repoNotFound": {
-        "message": "Ingen repositorier funnet"
-    },
-    "repoRefetching": {
-        "message": "Henter repositorier på nytt..."
-    },
-    "repoLoadFailed": {
-        "message": "Kunne ikke laste repositorier."
-    },
-    "repoTokenPrivate": {
-        "message": "Tokenet er ugyldig eller har ikke rettigheter for private repositorier."
-    },
-    "repoRefetchFailed": {
-        "message": "Kunne ikke hente repositorier på nytt."
-    },
-    "orgSetMessage": {
-        "message": "Organisasjon satt."
-    },
-    "orgClearedMessage": {
-        "message": "Organisasjon fjernet. Klikk 'Generer rapport' for å hente alle aktiviteter."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organisasjon ikke funnet på GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Feil ved validering av organisasjon."
-    },
-    "refreshingButton": {
-        "message": "Oppdaterer..."
-    },
-    "cacheClearFailed": {
-        "message": "Tømming av cache mislyktes."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Genererer..."
-    },
-    "copiedButton": {
-        "message": "Kopiert!"
-    },
-    "orgChangedMessage": {
-        "message": "Organisasjon endret. Klikk 'Generer rapport' for å hente GitHub-aktiviteter."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache tømt. Klikk 'Generer rapport' for å hente ferske data."
-    },
-    "cacheExpiredMessage": {
-        "message": "Hurtigbufferen har utløpt. Klikk \"Generer\" for å hente nye data.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Cache tømt!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Utvidelsen er deaktivert. Aktiver den fra innstillingene for å generere scrum-rapporter."
-    },
-    "notePoint1": {
-        "message": "Pull-forespørsler hentes basert på den siste gjennomgangsaktiviteten til enhver bidragsyter, ikke bare din egen. Vennligst gjennomgå og juster den genererte SCRUM-rapporten for å sikre at den nøyaktig gjenspeiler arbeidet ditt før du deler den."
-    },
-    "noteSeeIssue": {
-        "message": "Se dette problemet"
-    },
-    "platformLabel": {
-        "message": "Plattform"
-    },
-    "usernameLabel": {
-        "message": "Ditt brukernavn"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Inkluder kun gjennomgåtte PR-er i rapporten"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Hvis valgt, vil rapporten kun inkludere PR-er gjennomgått av deg."
-    },
-    "usernameRequiredError": {
-        "message": "Vennligst skriv inn brukernavn for å generere rapport."
-    },
-    "unknownPlatformError": {
-        "message": "Ukjent plattform valgt."
-    },
-    "gitlabFetchingError": {
-        "message": "En feil oppstod under henting av GitLab-data."
-    },
-    "reportGenerationError": {
-        "message": "En feil oppstod under generering av rapporten."
-    },
-    "githubUserNotFoundError": {
-        "message": "GitHub-bruker \"$1\" ikke funnet (404). Sjekk brukernavnet og prøv igjen."
-    },
-    "githubUserValidationError": {
-        "message": "Feil ved validering av GitHub-bruker: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Ugyldig søkespørring eller datoperiode. Sjekk formatet og prøv igjen."
-    },
-    "githubIssuesFetchError": {
-        "message": "Feil ved henting av GitHub-issues: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Feil ved henting av GitHub PR-review-data: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Feil ved henting av GitHub-brukerdata: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Ugyldig eller utløpt GitHub-token. Sjekk tokenet i Scrum Helper-innstillingene og prøv igjen."
-    },
-    "displayModeNotice": {
-        "message": "Utvidelsen åpnes i $1-modus ved neste oppstart."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Repositoriefiltrering er kun tilgjengelig for GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Repositorielasting er kun tilgjengelig for GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Repositoriehenting er kun tilgjengelig for GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Laster repositorier automatisk..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Feil ved henting av GitLab-bruker: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "GitLab-bruker '$1' ikke funnet"
-    },
-    "gitlabMembershipError": {
-        "message": "Feil ved henting av GitLab-medlemskapsprosjekter: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Feil ved henting av GitLab-bidragsprosjekter: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Brukernavn påkrevd."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Genererer rapport..."
-    },
-    "copyingReportNotification": {
-        "message": "Kopierer rapport..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Setter inn rapport i e-post..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Rapport satt inn i e-post!"
-    }
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "Rapporter utviklingsfremgangen din ved å automatisk hente Git-aktiviteten din for en valgt periode."
+	},
+	"disableLabel": {
+		"message": "Deaktiver"
+	},
+	"enableLabel": {
+		"message": "Aktiver"
+	},
+	"projectNameLabel": {
+		"message": "Prosjektnavn (brukes i e-postemne)"
+	},
+	"projectNamePlaceholder": {
+		"message": "Skriv inn prosjektnavnet ditt"
+	},
+	"githubUsernameLabel": {
+		"message": "Ditt GitHub-brukernavn"
+	},
+	"gitlabUsernameLabel": {
+		"message": "Ditt GitLab-brukernavn"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "Påkrevd for å hente bidragene dine"
+	},
+	"contributionsLabel": {
+		"message": "Hent dine bidrag for:"
+	},
+	"last1DayLabel": {
+		"message": "Forrige dag"
+	},
+	"startDateLabel": {
+		"message": "Fra:"
+	},
+	"endDateLabel": {
+		"message": "Til:"
+	},
+	"showOpenClosedLabel": {
+		"message": "Vis Åpen/Lukket-status"
+	},
+	"blockersLabel": {
+		"message": "Hva hindrer deg i å gjøre fremgang?"
+	},
+	"blockersPlaceholder": {
+		"message": "Skriv inn din grunn"
+	},
+	"scrumReportLabel": {
+		"message": "Scrum-rapport"
+	},
+	"generateReportButton": {
+		"message": "Generer rapport"
+	},
+	"copyReportButton": {
+		"message": "Kopier rapport"
+	},
+	"insertInEmailButton": {
+		"message": "Sett inn i e-post",
+		"description": "Text for the 'Insert to Email' button."
+	},
+	"settingsOrgNameLabel": {
+		"message": "Organisasjonsnavn"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "Skriv inn organisasjonsnavn"
+	},
+	"setButton": {
+		"message": "Angi"
+	},
+	"githubTokenLabel": {
+		"message": "Ditt GitHub-token"
+	},
+	"githubTokenPlaceholder": {
+		"message": "Påkrevd for autentiserte forespørsler"
+	},
+	"githubTokenTooltip": {
+		"message": "Hvorfor anbefales det å legge til et GitHub-token? Scrum Helper fungerer uten et GitHub-token, men det anbefales å legge til et personlig tilgangstoken for en bedre opplevelse."
+	},
+	"gitlabTokenLabel": {
+		"message": "Ditt GitLab-token"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "Påkrevd for private repositorier"
+	},
+	"gitlabTokenTooltip": {
+		"message": "Hvorfor anbefales det å legge til et GitLab-token? Scrum Helper fungerer uten et GitLab-token for offentlige prosjekter, men det anbefales å legge til et personlig tilgangstoken for en bedre opplevelse."
+	},
+	"showCommitsLabel": {
+		"message": "Vis commits på åpne PR-er/utkast til PR-er"
+	},
+	"showCommitsTooltip": {
+		"message": "GitHub-token kreves. Legg det til i innstillingene."
+	},
+	"onlyIssuesLabel": {
+		"message": "Inkluder kun problemer i rapporten"
+	},
+	"onlyIssuesTooltip": {
+		"message": "Hvis valgt, vil rapporten kun inkludere problemer opprettet eller tildelt brukeren."
+	},
+	"onlyPRsLabel": {
+		"message": "Inkluder kun PR-er i rapporten"
+	},
+	"onlyPRsTooltip": {
+		"message": "Hvis valgt, vil rapporten kun inkludere PR-er opprettet av brukeren; gjennomgåtte PR-er vil utelates."
+	},
+	"cacheTTLLabel": {
+		"message": "Angi cache-TTL"
+	},
+	"cacheTTLUnit": {
+		"message": "(i minutter)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "Skriv inn cache-TTL i minutter (Standard: 10)"
+	},
+	"refreshDataButton": {
+		"message": "Oppdater data (omgå cache)"
+	},
+	"refreshDataInfo": {
+		"message": "Bruk denne knappen for å hente ferske data umiddelbart."
+	},
+	"noteTitle": {
+		"message": "Merk:"
+	},
+	"viewCodeButton": {
+		"message": "Se kode"
+	},
+	"reportIssueButton": {
+		"message": "Rapporter et problem"
+	},
+	"repoFilterLabel": {
+		"message": "Filtrer etter repositorier"
+	},
+	"enableFilteringLabel": {
+		"message": "Aktiver filtrering"
+	},
+	"tokenRequiredWarning": {
+		"message": "Et GitHub-token er påkrevd for repositoriefiltrering. Vennligst legg til ett i innstillingene."
+	},
+	"repoSearchPlaceholder": {
+		"message": "Søk etter et repositorium for å legge til..."
+	},
+	"repoPlaceholder": {
+		"message": "Ingen repositorier valgt (alle vil bli inkludert)"
+	},
+	"repoCountNone": {
+		"message": "0 repositorier valgt"
+	},
+	"repoCount": {
+		"message": "$1 repositorier valgt"
+	},
+	"repoLoading": {
+		"message": "Laster repositorier..."
+	},
+	"repoLoaded": {
+		"message": "Lastet $1 repositorier."
+	},
+	"repoNotFound": {
+		"message": "Ingen repositorier funnet"
+	},
+	"repoRefetching": {
+		"message": "Henter repositorier på nytt..."
+	},
+	"repoLoadFailed": {
+		"message": "Kunne ikke laste repositorier."
+	},
+	"repoTokenPrivate": {
+		"message": "Tokenet er ugyldig eller har ikke rettigheter for private repositorier."
+	},
+	"repoRefetchFailed": {
+		"message": "Kunne ikke hente repositorier på nytt."
+	},
+	"orgSetMessage": {
+		"message": "Organisasjon satt."
+	},
+	"orgClearedMessage": {
+		"message": "Organisasjon fjernet. Klikk 'Generer rapport' for å hente alle aktiviteter."
+	},
+	"orgNotFoundMessage": {
+		"message": "Organisasjon ikke funnet på GitHub."
+	},
+	"orgValidationErrorMessage": {
+		"message": "Feil ved validering av organisasjon."
+	},
+	"refreshingButton": {
+		"message": "Oppdaterer..."
+	},
+	"cacheClearFailed": {
+		"message": "Tømming av cache mislyktes."
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "Genererer..."
+	},
+	"copiedButton": {
+		"message": "Kopiert!"
+	},
+	"orgChangedMessage": {
+		"message": "Organisasjon endret. Klikk 'Generer rapport' for å hente GitHub-aktiviteter."
+	},
+	"cacheClearedMessage": {
+		"message": "Cache tømt. Klikk 'Generer rapport' for å hente ferske data."
+	},
+	"cacheExpiredMessage": {
+		"message": "Hurtigbufferen har utløpt. Klikk \"Generer\" for å hente nye data.",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "Cache tømt!"
+	},
+	"extensionDisabledMessage": {
+		"message": "Utvidelsen er deaktivert. Aktiver den fra innstillingene for å generere scrum-rapporter."
+	},
+	"notePoint1": {
+		"message": "Pull-forespørsler hentes basert på den siste gjennomgangsaktiviteten til enhver bidragsyter, ikke bare din egen. Vennligst gjennomgå og juster den genererte SCRUM-rapporten for å sikre at den nøyaktig gjenspeiler arbeidet ditt før du deler den."
+	},
+	"noteSeeIssue": {
+		"message": "Se dette problemet"
+	},
+	"platformLabel": {
+		"message": "Plattform"
+	},
+	"usernameLabel": {
+		"message": "Ditt brukernavn"
+	},
+	"onlyRevPRsLabel": {
+		"message": "Inkluder kun gjennomgåtte PR-er i rapporten"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "Hvis valgt, vil rapporten kun inkludere PR-er gjennomgått av deg."
+	},
+	"usernameRequiredError": {
+		"message": "Vennligst skriv inn brukernavn for å generere rapport."
+	},
+	"unknownPlatformError": {
+		"message": "Ukjent plattform valgt."
+	},
+	"gitlabFetchingError": {
+		"message": "En feil oppstod under henting av GitLab-data."
+	},
+	"reportGenerationError": {
+		"message": "En feil oppstod under generering av rapporten."
+	},
+	"githubUserNotFoundError": {
+		"message": "GitHub-bruker \"$1\" ikke funnet (404). Sjekk brukernavnet og prøv igjen."
+	},
+	"githubUserValidationError": {
+		"message": "Feil ved validering av GitHub-bruker: $1 $2"
+	},
+	"invalidSearchQueryError": {
+		"message": "Ugyldig søkespørring eller datoperiode. Sjekk formatet og prøv igjen."
+	},
+	"githubIssuesFetchError": {
+		"message": "Feil ved henting av GitHub-issues: $1 $2"
+	},
+	"githubPRReviewFetchError": {
+		"message": "Feil ved henting av GitHub PR-review-data: $1 $2"
+	},
+	"githubUserFetchError": {
+		"message": "Feil ved henting av GitHub-brukerdata: $1 $2"
+	},
+	"invalidTokenError": {
+		"message": "Ugyldig eller utløpt GitHub-token. Sjekk tokenet i Scrum Helper-innstillingene og prøv igjen."
+	},
+	"displayModeNotice": {
+		"message": "Utvidelsen åpnes i $1-modus ved neste oppstart."
+	},
+	"repoFilteringGithubOnly": {
+		"message": "Repositoriefiltrering er kun tilgjengelig for GitHub."
+	},
+	"repoLoadingGithubOnly": {
+		"message": "Repositorielasting er kun tilgjengelig for GitHub."
+	},
+	"repoFetchingGithubOnly": {
+		"message": "Repositoriehenting er kun tilgjengelig for GitHub."
+	},
+	"loadingReposAutomatically": {
+		"message": "Laster repositorier automatisk..."
+	},
+	"gitlabUserFetchError": {
+		"message": "Feil ved henting av GitLab-bruker: $1 $2"
+	},
+	"gitlabUserNotFoundError": {
+		"message": "GitLab-bruker '$1' ikke funnet"
+	},
+	"gitlabMembershipError": {
+		"message": "Feil ved henting av GitLab-medlemskapsprosjekter: $1 $2"
+	},
+	"gitlabContributedError": {
+		"message": "Feil ved henting av GitLab-bidragsprosjekter: $1 $2"
+	},
+	"usernameMissingError": {
+		"message": "Brukernavn påkrevd."
+	},
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"generatingReportNotification": {
+		"message": "Genererer rapport..."
+	},
+	"copyingReportNotification": {
+		"message": "Kopierer rapport..."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "Setter inn rapport i e-post..."
+	},
+	"insertedInEmailNotification": {
+		"message": "Rapport satt inn i e-post!"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/pt/messages.json
+++ b/src/_locales/pt/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Relate o seu progresso de desenvolvimento buscando automaticamente a sua atividade no Git para um período selecionado"
-    },
-    "disableLabel": {
-        "message": "Desativar"
-    },
-    "enableLabel": {
-        "message": "Ativar"
-    },
-    "projectNameLabel": {
-        "message": "Nome do Projeto (usado no assunto do e-mail)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Digite o nome do seu projeto"
-    },
-    "githubUsernameLabel": {
-        "message": "Seu nome de usuário do GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Seu nome de usuário do GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Necessário para buscar suas contribuições"
-    },
-    "contributionsLabel": {
-        "message": "Buscar suas contribuições entre:"
-    },
-    "last1DayLabel": {
-        "message": "Dia anterior"
-    },
-    "startDateLabel": {
-        "message": "De:"
-    },
-    "endDateLabel": {
-        "message": "Até:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Mostrar Rótulo Aberto/Fechado"
-    },
-    "blockersLabel": {
-        "message": "O que está impedindo você de progredir?"
-    },
-    "blockersPlaceholder": {
-        "message": "Digite o seu motivo"
-    },
-    "scrumReportLabel": {
-        "message": "Relatório Scrum"
-    },
-    "generateReportButton": {
-        "message": "Gerar"
-    },
-    "copyReportButton": {
-        "message": "Copiar"
-    },
-    "insertInEmailButton": {
-        "message": "Inserir no email"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nome da Organização"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Digite o nome da organização"
-    },
-    "setButton": {
-        "message": "Definir"
-    },
-    "githubTokenLabel": {
-        "message": "Seu Token do GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Necessário para fazer solicitações autenticadas"
-    },
-    "githubTokenTooltip": {
-        "message": "Por que é recomendado adicionar um token do GitHub? O Scrum Helper funciona sem um token do GitHub, mas adicionar um token de acesso pessoal é recomendado para uma melhor experiência."
-    },
-    "gitlabTokenLabel": {
-        "message": "Seu Token GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Necessário para repos privados"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Por que é recomendado adicionar um token do GitLab? O Scrum Helper funciona sem um token do GitLab para projetos públicos, mas adicionar um token de acesso pessoal é recomendado para uma melhor experiência."
-    },
-    "showCommitsLabel": {
-        "message": "Mostrar commits em PRs abertos/ rascunhos de PRs"
-    },
-    "showCommitsTooltip": {
-        "message": "Token do GitHub necessário, adicione-o nas configurações."
-    },
-    "onlyIssuesLabel": {
-        "message": "Incluir apenas problemas no relatório"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas os problemas criados ou atribuídos ao usuário."
-    },
-    "onlyPRsLabel": {
-        "message": "Incluir apenas PRs no relatório"
-    },
-    "onlyPRsTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas PRs criadas pelo usuário; as PRs revisadas serão excluídas."
-    },
-    "cacheTTLLabel": {
-        "message": "Digite o TTL do cache",
-        "description": "Rótulo para a entrada de tempo de vida do cache."
-    },
-    "cacheTTLUnit": {
-        "message": "(em minutos)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Escreva o TTL do cache em minutos (Padrão 10 minutos)"
-    },
-    "refreshDataButton": {
-        "message": "Atualizar Dados (ignorar cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Use este botão para buscar dados novos imediatamente."
-    },
-    "noteTitle": {
-        "message": "Nota:"
-    },
-    "viewCodeButton": {
-        "message": "Ver Código"
-    },
-    "reportIssueButton": {
-        "message": "Relatar Problema"
-    },
-    "repoFilterLabel": {
-        "message": "Filtrar por repositórios"
-    },
-    "enableFilteringLabel": {
-        "message": "Ativar filtragem"
-    },
-    "tokenRequiredWarning": {
-        "message": "Um token do GitHub é necessário para filtragem de repositórios. Por favor, adicione um nas configurações."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Pesquisar um repositório para adicionar..."
-    },
-    "repoPlaceholder": {
-        "message": "Nenhum repositório selecionado (todos serão incluídos)"
-    },
-    "repoCountNone": {
-        "message": "0 repositórios selecionados"
-    },
-    "repoCount": {
-        "message": "$1 repositórios selecionados"
-    },
-    "repoLoading": {
-        "message": "Carregando repositórios..."
-    },
-    "repoLoaded": {
-        "message": "Carregados $1 repositórios."
-    },
-    "repoNotFound": {
-        "message": "Nenhum repositório encontrado"
-    },
-    "repoRefetching": {
-        "message": "Recarregando repositórios..."
-    },
-    "repoLoadFailed": {
-        "message": "Falha ao carregar repositórios."
-    },
-    "repoTokenPrivate": {
-        "message": "Token é inválido ou não tem direitos para repositórios privados."
-    },
-    "repoRefetchFailed": {
-        "message": "Falha ao recarregar repositórios."
-    },
-    "orgSetMessage": {
-        "message": "Organização configurada com sucesso."
-    },
-    "orgClearedMessage": {
-        "message": "Organização removida. Clique em 'Gerar Relatório' para buscar todas as atividades."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organização não encontrada no GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Erro ao validar a organização."
-    },
-    "refreshingButton": {
-        "message": "Atualizando..."
-    },
-    "cacheClearFailed": {
-        "message": "Falha ao limpar o cache."
-    },
-    "madeWithLoveBy": {
-        "message": "Feito com ❤️ por"
-    },
-    "generatingButton": {
-        "message": "Gerando..."
-    },
-    "copiedButton": {
-        "message": "Copiado!"
-    },
-    "orgChangedMessage": {
-        "message": "Organização alterada. Clique no botão Gerar para buscar as atividades do GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache limpo com sucesso. Clique em \"Gerar Relatório\" para buscar dados novos."
-    },
-    "cacheExpiredMessage": {
-        "message": "O cache expirou. Clique em \"Gerar\" para buscar dados novos.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Cache Limpo!"
-    },
-    "extensionDisabledMessage": {
-        "message": "A extensão está desativada. Ative-a nas opções para gerar relatórios scrum."
-    },
-    "notePoint1": {
-        "message": "As solicitações de pull são buscadas com base na atividade de revisão mais recente de qualquer contribuidor, não apenas na sua. Revise e ajuste o relatório SCRUM gerado para garantir que ele reflita com precisão o seu trabalho antes de compartilhá-lo."
-    },
-    "noteSeeIssue": {
-        "message": "Veja este problema"
-    },
-    "platformLabel": {
-        "message": "Plataforma"
-    },
-    "usernameLabel": {
-        "message": "Seu nome de usuário"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Incluir apenas PRs revisadas no relatório"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas PRs revisadas por você."
-    },
-    "usernameRequiredError": {
-        "message": "Por favor, digite seu nome de usuário para gerar o relatório."
-    },
-    "unknownPlatformError": {
-        "message": "Plataforma desconhecida selecionada."
-    },
-    "gitlabFetchingError": {
-        "message": "Ocorreu um erro ao buscar os dados do GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Ocorreu um erro ao gerar o relatório."
-    },
-    "githubUserNotFoundError": {
-        "message": "Usuário do GitHub \"$1\" não encontrado (404). Verifique o nome de usuário e tente novamente."
-    },
-    "githubUserValidationError": {
-        "message": "Erro ao validar o usuário do GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Consulta de busca ou intervalo de datas inválido. Verifique o formato e tente novamente."
-    },
-    "githubIssuesFetchError": {
-        "message": "Erro ao buscar issues do GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Erro ao buscar dados de revisão de PR do GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Erro ao buscar dados do usuário do GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Token do GitHub inválido ou expirado. Verifique seu token nas configurações do Scrum Helper e tente novamente."
-    },
-    "displayModeNotice": {
-        "message": "A extensão será aberta no modo $1 no próximo lançamento."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Filtragem de repositórios disponível apenas para o GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Carregamento de repositórios disponível apenas para o GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Busca de repositórios disponível apenas para o GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Carregando repositórios automaticamente..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Erro ao buscar usuário do GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Usuário do GitLab '$1' não encontrado"
-    },
-    "gitlabMembershipError": {
-        "message": "Erro ao buscar projetos de associação do GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Erro ao buscar projetos contribuídos do GitLab: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Nome de usuário obrigatório."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Gerando relatório..."
-    },
-    "copyingReportNotification": {
-        "message": "Copiando relatório..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Inserindo relatório no e-mail..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Relatório inserido no e-mail!"
-    }
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "Relate o seu progresso de desenvolvimento buscando automaticamente a sua atividade no Git para um período selecionado"
+	},
+	"disableLabel": {
+		"message": "Desativar"
+	},
+	"enableLabel": {
+		"message": "Ativar"
+	},
+	"projectNameLabel": {
+		"message": "Nome do Projeto (usado no assunto do e-mail)"
+	},
+	"projectNamePlaceholder": {
+		"message": "Digite o nome do seu projeto"
+	},
+	"githubUsernameLabel": {
+		"message": "Seu nome de usuário do GitHub"
+	},
+	"gitlabUsernameLabel": {
+		"message": "Seu nome de usuário do GitLab"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "Necessário para buscar suas contribuições"
+	},
+	"contributionsLabel": {
+		"message": "Buscar suas contribuições entre:"
+	},
+	"last1DayLabel": {
+		"message": "Dia anterior"
+	},
+	"startDateLabel": {
+		"message": "De:"
+	},
+	"endDateLabel": {
+		"message": "Até:"
+	},
+	"showOpenClosedLabel": {
+		"message": "Mostrar Rótulo Aberto/Fechado"
+	},
+	"blockersLabel": {
+		"message": "O que está impedindo você de progredir?"
+	},
+	"blockersPlaceholder": {
+		"message": "Digite o seu motivo"
+	},
+	"scrumReportLabel": {
+		"message": "Relatório Scrum"
+	},
+	"generateReportButton": {
+		"message": "Gerar"
+	},
+	"copyReportButton": {
+		"message": "Copiar"
+	},
+	"insertInEmailButton": {
+		"message": "Inserir no email"
+	},
+	"settingsOrgNameLabel": {
+		"message": "Nome da Organização"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "Digite o nome da organização"
+	},
+	"setButton": {
+		"message": "Definir"
+	},
+	"githubTokenLabel": {
+		"message": "Seu Token do GitHub"
+	},
+	"githubTokenPlaceholder": {
+		"message": "Necessário para fazer solicitações autenticadas"
+	},
+	"githubTokenTooltip": {
+		"message": "Por que é recomendado adicionar um token do GitHub? O Scrum Helper funciona sem um token do GitHub, mas adicionar um token de acesso pessoal é recomendado para uma melhor experiência."
+	},
+	"gitlabTokenLabel": {
+		"message": "Seu Token GitLab"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "Necessário para repos privados"
+	},
+	"gitlabTokenTooltip": {
+		"message": "Por que é recomendado adicionar um token do GitLab? O Scrum Helper funciona sem um token do GitLab para projetos públicos, mas adicionar um token de acesso pessoal é recomendado para uma melhor experiência."
+	},
+	"showCommitsLabel": {
+		"message": "Mostrar commits em PRs abertos/ rascunhos de PRs"
+	},
+	"showCommitsTooltip": {
+		"message": "Token do GitHub necessário, adicione-o nas configurações."
+	},
+	"onlyIssuesLabel": {
+		"message": "Incluir apenas problemas no relatório"
+	},
+	"onlyIssuesTooltip": {
+		"message": "Se marcado, o relatório incluirá apenas os problemas criados ou atribuídos ao usuário."
+	},
+	"onlyPRsLabel": {
+		"message": "Incluir apenas PRs no relatório"
+	},
+	"onlyPRsTooltip": {
+		"message": "Se marcado, o relatório incluirá apenas PRs criadas pelo usuário; as PRs revisadas serão excluídas."
+	},
+	"cacheTTLLabel": {
+		"message": "Digite o TTL do cache",
+		"description": "Rótulo para a entrada de tempo de vida do cache."
+	},
+	"cacheTTLUnit": {
+		"message": "(em minutos)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "Escreva o TTL do cache em minutos (Padrão 10 minutos)"
+	},
+	"refreshDataButton": {
+		"message": "Atualizar Dados (ignorar cache)"
+	},
+	"refreshDataInfo": {
+		"message": "Use este botão para buscar dados novos imediatamente."
+	},
+	"noteTitle": {
+		"message": "Nota:"
+	},
+	"viewCodeButton": {
+		"message": "Ver Código"
+	},
+	"reportIssueButton": {
+		"message": "Relatar Problema"
+	},
+	"repoFilterLabel": {
+		"message": "Filtrar por repositórios"
+	},
+	"enableFilteringLabel": {
+		"message": "Ativar filtragem"
+	},
+	"tokenRequiredWarning": {
+		"message": "Um token do GitHub é necessário para filtragem de repositórios. Por favor, adicione um nas configurações."
+	},
+	"repoSearchPlaceholder": {
+		"message": "Pesquisar um repositório para adicionar..."
+	},
+	"repoPlaceholder": {
+		"message": "Nenhum repositório selecionado (todos serão incluídos)"
+	},
+	"repoCountNone": {
+		"message": "0 repositórios selecionados"
+	},
+	"repoCount": {
+		"message": "$1 repositórios selecionados"
+	},
+	"repoLoading": {
+		"message": "Carregando repositórios..."
+	},
+	"repoLoaded": {
+		"message": "Carregados $1 repositórios."
+	},
+	"repoNotFound": {
+		"message": "Nenhum repositório encontrado"
+	},
+	"repoRefetching": {
+		"message": "Recarregando repositórios..."
+	},
+	"repoLoadFailed": {
+		"message": "Falha ao carregar repositórios."
+	},
+	"repoTokenPrivate": {
+		"message": "Token é inválido ou não tem direitos para repositórios privados."
+	},
+	"repoRefetchFailed": {
+		"message": "Falha ao recarregar repositórios."
+	},
+	"orgSetMessage": {
+		"message": "Organização configurada com sucesso."
+	},
+	"orgClearedMessage": {
+		"message": "Organização removida. Clique em 'Gerar Relatório' para buscar todas as atividades."
+	},
+	"orgNotFoundMessage": {
+		"message": "Organização não encontrada no GitHub."
+	},
+	"orgValidationErrorMessage": {
+		"message": "Erro ao validar a organização."
+	},
+	"refreshingButton": {
+		"message": "Atualizando..."
+	},
+	"cacheClearFailed": {
+		"message": "Falha ao limpar o cache."
+	},
+	"madeWithLoveBy": {
+		"message": "Feito com ❤️ por"
+	},
+	"generatingButton": {
+		"message": "Gerando..."
+	},
+	"copiedButton": {
+		"message": "Copiado!"
+	},
+	"orgChangedMessage": {
+		"message": "Organização alterada. Clique no botão Gerar para buscar as atividades do GitHub."
+	},
+	"cacheClearedMessage": {
+		"message": "Cache limpo com sucesso. Clique em \"Gerar Relatório\" para buscar dados novos."
+	},
+	"cacheExpiredMessage": {
+		"message": "O cache expirou. Clique em \"Gerar\" para buscar dados novos.",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "Cache Limpo!"
+	},
+	"extensionDisabledMessage": {
+		"message": "A extensão está desativada. Ative-a nas opções para gerar relatórios scrum."
+	},
+	"notePoint1": {
+		"message": "As solicitações de pull são buscadas com base na atividade de revisão mais recente de qualquer contribuidor, não apenas na sua. Revise e ajuste o relatório SCRUM gerado para garantir que ele reflita com precisão o seu trabalho antes de compartilhá-lo."
+	},
+	"noteSeeIssue": {
+		"message": "Veja este problema"
+	},
+	"platformLabel": {
+		"message": "Plataforma"
+	},
+	"usernameLabel": {
+		"message": "Seu nome de usuário"
+	},
+	"onlyRevPRsLabel": {
+		"message": "Incluir apenas PRs revisadas no relatório"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "Se marcado, o relatório incluirá apenas PRs revisadas por você."
+	},
+	"usernameRequiredError": {
+		"message": "Por favor, digite seu nome de usuário para gerar o relatório."
+	},
+	"unknownPlatformError": {
+		"message": "Plataforma desconhecida selecionada."
+	},
+	"gitlabFetchingError": {
+		"message": "Ocorreu um erro ao buscar os dados do GitLab."
+	},
+	"reportGenerationError": {
+		"message": "Ocorreu um erro ao gerar o relatório."
+	},
+	"githubUserNotFoundError": {
+		"message": "Usuário do GitHub \"$1\" não encontrado (404). Verifique o nome de usuário e tente novamente."
+	},
+	"githubUserValidationError": {
+		"message": "Erro ao validar o usuário do GitHub: $1 $2"
+	},
+	"invalidSearchQueryError": {
+		"message": "Consulta de busca ou intervalo de datas inválido. Verifique o formato e tente novamente."
+	},
+	"githubIssuesFetchError": {
+		"message": "Erro ao buscar issues do GitHub: $1 $2"
+	},
+	"githubPRReviewFetchError": {
+		"message": "Erro ao buscar dados de revisão de PR do GitHub: $1 $2"
+	},
+	"githubUserFetchError": {
+		"message": "Erro ao buscar dados do usuário do GitHub: $1 $2"
+	},
+	"invalidTokenError": {
+		"message": "Token do GitHub inválido ou expirado. Verifique seu token nas configurações do Scrum Helper e tente novamente."
+	},
+	"displayModeNotice": {
+		"message": "A extensão será aberta no modo $1 no próximo lançamento."
+	},
+	"repoFilteringGithubOnly": {
+		"message": "Filtragem de repositórios disponível apenas para o GitHub."
+	},
+	"repoLoadingGithubOnly": {
+		"message": "Carregamento de repositórios disponível apenas para o GitHub."
+	},
+	"repoFetchingGithubOnly": {
+		"message": "Busca de repositórios disponível apenas para o GitHub."
+	},
+	"loadingReposAutomatically": {
+		"message": "Carregando repositórios automaticamente..."
+	},
+	"gitlabUserFetchError": {
+		"message": "Erro ao buscar usuário do GitLab: $1 $2"
+	},
+	"gitlabUserNotFoundError": {
+		"message": "Usuário do GitLab '$1' não encontrado"
+	},
+	"gitlabMembershipError": {
+		"message": "Erro ao buscar projetos de associação do GitLab: $1 $2"
+	},
+	"gitlabContributedError": {
+		"message": "Erro ao buscar projetos contribuídos do GitLab: $1 $2"
+	},
+	"usernameMissingError": {
+		"message": "Nome de usuário obrigatório."
+	},
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"generatingReportNotification": {
+		"message": "Gerando relatório..."
+	},
+	"copyingReportNotification": {
+		"message": "Copiando relatório..."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "Inserindo relatório no e-mail..."
+	},
+	"insertedInEmailNotification": {
+		"message": "Relatório inserido no e-mail!"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Relate seu progresso de desenvolvimento buscando automaticamente sua atividade no Git para um período selecionado."
-    },
-    "disableLabel": {
-        "message": "Desativar"
-    },
-    "enableLabel": {
-        "message": "Ativar"
-    },
-    "projectNameLabel": {
-        "message": "Nome do Projeto (usado no assunto do e-mail)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Digite o nome do seu projeto"
-    },
-    "githubUsernameLabel": {
-        "message": "Seu nome de usuário do GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Seu nome de usuário do GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Necessário para buscar suas contribuições"
-    },
-    "contributionsLabel": {
-        "message": "Buscar suas contribuições de:"
-    },
-    "last1DayLabel": {
-        "message": "Dia anterior"
-    },
-    "startDateLabel": {
-        "message": "De:"
-    },
-    "endDateLabel": {
-        "message": "Até:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Mostrar status Aberto/Fechado"
-    },
-    "blockersLabel": {
-        "message": "O que está impedindo seu progresso?"
-    },
-    "blockersPlaceholder": {
-        "message": "Digite o motivo"
-    },
-    "scrumReportLabel": {
-        "message": "Relatório Scrum"
-    },
-    "generateReportButton": {
-        "message": "Gerar"
-    },
-    "copyReportButton": {
-        "message": "Copiar"
-    },
-    "insertInEmailButton": {
-        "message": "Inserir no e-mail"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nome da Organização"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Digite o nome da organização"
-    },
-    "setButton": {
-        "message": "Definir"
-    },
-    "githubTokenLabel": {
-        "message": "Seu Token do GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Necessário para solicitações autenticadas"
-    },
-    "githubTokenTooltip": {
-        "message": "Por que é recomendado adicionar um token do GitHub? O Scrum Helper funciona sem um token do GitHub, mas é recomendado adicionar um token de acesso pessoal para uma melhor experiência."
-    },
-    "gitlabTokenLabel": {
-        "message": "Seu Token GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Necessário para repos privados"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Por que é recomendado adicionar um token do GitLab? O Scrum Helper funciona sem um token do GitLab para projetos públicos, mas é recomendado adicionar um token de acesso pessoal para uma melhor experiência."
-    },
-    "showCommitsLabel": {
-        "message": "Mostrar commits em PRs abertos/ rascunhos de PRs"
-    },
-    "showCommitsTooltip": {
-        "message": "Token do Github necessário, adicione-o nas configurações."
-    },
-    "onlyIssuesLabel": {
-        "message": "Incluir apenas issues no relatório"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas as issues criadas ou atribuídas ao usuário."
-    },
-    "onlyPRsLabel": {
-        "message": "Incluir apenas PRs no relatório"
-    },
-    "onlyPRsTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas PRs criadas pelo usuário; as PRs revisadas serão excluídas."
-    },
-    "cacheTTLLabel": {
-        "message": "Digite o TTL do cache",
-        "description": "Rótulo para a entrada de tempo de vida do cache."
-    },
-    "cacheTTLUnit": {
-        "message": "(em minutos)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Digite o TTL do cache em minutos (Padrão: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Atualizar Dados (ignorar cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Use este botão para buscar dados novos imediatamente."
-    },
-    "noteTitle": {
-        "message": "Nota:"
-    },
-    "viewCodeButton": {
-        "message": "Ver código"
-    },
-    "reportIssueButton": {
-        "message": "Relatar um problema"
-    },
-    "repoFilterLabel": {
-        "message": "Filtrar por repositórios"
-    },
-    "enableFilteringLabel": {
-        "message": "Ativar filtragem"
-    },
-    "tokenRequiredWarning": {
-        "message": "Um token do GitHub é necessário para filtrar repositórios. Adicione um nas configurações."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Buscar um repositório para adicionar..."
-    },
-    "repoPlaceholder": {
-        "message": "Nenhum repositório selecionado (todos serão incluídos)"
-    },
-    "repoCountNone": {
-        "message": "0 repositórios selecionados"
-    },
-    "repoCount": {
-        "message": "$1 repositórios selecionados"
-    },
-    "repoLoading": {
-        "message": "Carregando repositórios..."
-    },
-    "repoLoaded": {
-        "message": "$1 repositórios carregados."
-    },
-    "repoNotFound": {
-        "message": "Nenhum repositório encontrado"
-    },
-    "repoRefetching": {
-        "message": "Recarregando repositórios..."
-    },
-    "repoLoadFailed": {
-        "message": "Falha ao carregar repositórios."
-    },
-    "repoTokenPrivate": {
-        "message": "O token é inválido ou não tem permissão para repositórios privados."
-    },
-    "repoRefetchFailed": {
-        "message": "Falha ao recarregar repositórios."
-    },
-    "orgSetMessage": {
-        "message": "Organização definida com sucesso."
-    },
-    "orgClearedMessage": {
-        "message": "Organização removida. Clique em 'Gerar Relatório' para buscar todas as atividades."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organização não encontrada no GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Erro ao validar a organização."
-    },
-    "refreshingButton": {
-        "message": "Atualizando..."
-    },
-    "cacheClearFailed": {
-        "message": "Falha ao limpar o cache."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Gerando..."
-    },
-    "copiedButton": {
-        "message": "Copiado!"
-    },
-    "orgChangedMessage": {
-        "message": "Organização alterada. Clique em 'Gerar Relatório' para buscar as atividades do GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache limpo com sucesso. Clique em 'Gerar Relatório' para buscar dados novos."
-    },
-    "cacheExpiredMessage": {
-        "message": "O cache expirou. Clique em \"Gerar\" para buscar dados novos.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Cache Limpo!"
-    },
-    "extensionDisabledMessage": {
-        "message": "A extensão está desativada. Ative-a nos ajustes para gerar relatórios scrum."
-    },
-    "notePoint1": {
-        "message": "As solicitações de pull são buscadas com base na atividade de revisão mais recente de qualquer contribuidor, não apenas na sua. Revise e ajuste o relatório SCRUM gerado para garantir que ele reflita com precisão o seu trabalho antes de compartilhá-lo."
-    },
-    "noteSeeIssue": {
-        "message": "Veja este issue"
-    },
-    "platformLabel": {
-        "message": "Plataforma"
-    },
-    "usernameLabel": {
-        "message": "Seu nome de usuário"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Incluir apenas PRs revisadas no relatório"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas PRs revisadas por você."
-    },
-    "usernameRequiredError": {
-        "message": "Por favor, digite seu nome de usuário para gerar o relatório."
-    },
-    "unknownPlatformError": {
-        "message": "Plataforma desconhecida selecionada."
-    },
-    "gitlabFetchingError": {
-        "message": "Ocorreu um erro ao buscar os dados do GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Ocorreu um erro ao gerar o relatório."
-    },
-    "githubUserNotFoundError": {
-        "message": "Usuário do GitHub \"$1\" não encontrado (404). Verifique o nome de usuário e tente novamente."
-    },
-    "githubUserValidationError": {
-        "message": "Erro ao validar o usuário do GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Consulta de busca ou intervalo de datas inválido. Verifique o formato e tente novamente."
-    },
-    "githubIssuesFetchError": {
-        "message": "Erro ao buscar issues do GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Erro ao buscar dados de revisão de PR do GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Erro ao buscar dados do usuário do GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Token do GitHub inválido ou expirado. Verifique seu token nas configurações do Scrum Helper e tente novamente."
-    },
-    "displayModeNotice": {
-        "message": "A extensão será aberta no modo $1 no próximo lançamento."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Filtragem de repositórios disponível apenas para o GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Carregamento de repositórios disponível apenas para o GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Busca de repositórios disponível apenas para o GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Carregando repositórios automaticamente..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Erro ao buscar usuário do GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Usuário do GitLab '$1' não encontrado"
-    },
-    "gitlabMembershipError": {
-        "message": "Erro ao buscar projetos de associação do GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Erro ao buscar projetos contribuídos do GitLab: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Nome de usuário obrigatório."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Gerando relatório..."
-    },
-    "copyingReportNotification": {
-        "message": "Copiando relatório..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Inserindo relatório no e-mail..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Relatório inserido no e-mail!"
-    }
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "Relate seu progresso de desenvolvimento buscando automaticamente sua atividade no Git para um período selecionado."
+	},
+	"disableLabel": {
+		"message": "Desativar"
+	},
+	"enableLabel": {
+		"message": "Ativar"
+	},
+	"projectNameLabel": {
+		"message": "Nome do Projeto (usado no assunto do e-mail)"
+	},
+	"projectNamePlaceholder": {
+		"message": "Digite o nome do seu projeto"
+	},
+	"githubUsernameLabel": {
+		"message": "Seu nome de usuário do GitHub"
+	},
+	"gitlabUsernameLabel": {
+		"message": "Seu nome de usuário do GitLab"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "Necessário para buscar suas contribuições"
+	},
+	"contributionsLabel": {
+		"message": "Buscar suas contribuições de:"
+	},
+	"last1DayLabel": {
+		"message": "Dia anterior"
+	},
+	"startDateLabel": {
+		"message": "De:"
+	},
+	"endDateLabel": {
+		"message": "Até:"
+	},
+	"showOpenClosedLabel": {
+		"message": "Mostrar status Aberto/Fechado"
+	},
+	"blockersLabel": {
+		"message": "O que está impedindo seu progresso?"
+	},
+	"blockersPlaceholder": {
+		"message": "Digite o motivo"
+	},
+	"scrumReportLabel": {
+		"message": "Relatório Scrum"
+	},
+	"generateReportButton": {
+		"message": "Gerar"
+	},
+	"copyReportButton": {
+		"message": "Copiar"
+	},
+	"insertInEmailButton": {
+		"message": "Inserir no e-mail"
+	},
+	"settingsOrgNameLabel": {
+		"message": "Nome da Organização"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "Digite o nome da organização"
+	},
+	"setButton": {
+		"message": "Definir"
+	},
+	"githubTokenLabel": {
+		"message": "Seu Token do GitHub"
+	},
+	"githubTokenPlaceholder": {
+		"message": "Necessário para solicitações autenticadas"
+	},
+	"githubTokenTooltip": {
+		"message": "Por que é recomendado adicionar um token do GitHub? O Scrum Helper funciona sem um token do GitHub, mas é recomendado adicionar um token de acesso pessoal para uma melhor experiência."
+	},
+	"gitlabTokenLabel": {
+		"message": "Seu Token GitLab"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "Necessário para repos privados"
+	},
+	"gitlabTokenTooltip": {
+		"message": "Por que é recomendado adicionar um token do GitLab? O Scrum Helper funciona sem um token do GitLab para projetos públicos, mas é recomendado adicionar um token de acesso pessoal para uma melhor experiência."
+	},
+	"showCommitsLabel": {
+		"message": "Mostrar commits em PRs abertos/ rascunhos de PRs"
+	},
+	"showCommitsTooltip": {
+		"message": "Token do Github necessário, adicione-o nas configurações."
+	},
+	"onlyIssuesLabel": {
+		"message": "Incluir apenas issues no relatório"
+	},
+	"onlyIssuesTooltip": {
+		"message": "Se marcado, o relatório incluirá apenas as issues criadas ou atribuídas ao usuário."
+	},
+	"onlyPRsLabel": {
+		"message": "Incluir apenas PRs no relatório"
+	},
+	"onlyPRsTooltip": {
+		"message": "Se marcado, o relatório incluirá apenas PRs criadas pelo usuário; as PRs revisadas serão excluídas."
+	},
+	"cacheTTLLabel": {
+		"message": "Digite o TTL do cache",
+		"description": "Rótulo para a entrada de tempo de vida do cache."
+	},
+	"cacheTTLUnit": {
+		"message": "(em minutos)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "Digite o TTL do cache em minutos (Padrão: 10)"
+	},
+	"refreshDataButton": {
+		"message": "Atualizar Dados (ignorar cache)"
+	},
+	"refreshDataInfo": {
+		"message": "Use este botão para buscar dados novos imediatamente."
+	},
+	"noteTitle": {
+		"message": "Nota:"
+	},
+	"viewCodeButton": {
+		"message": "Ver código"
+	},
+	"reportIssueButton": {
+		"message": "Relatar um problema"
+	},
+	"repoFilterLabel": {
+		"message": "Filtrar por repositórios"
+	},
+	"enableFilteringLabel": {
+		"message": "Ativar filtragem"
+	},
+	"tokenRequiredWarning": {
+		"message": "Um token do GitHub é necessário para filtrar repositórios. Adicione um nas configurações."
+	},
+	"repoSearchPlaceholder": {
+		"message": "Buscar um repositório para adicionar..."
+	},
+	"repoPlaceholder": {
+		"message": "Nenhum repositório selecionado (todos serão incluídos)"
+	},
+	"repoCountNone": {
+		"message": "0 repositórios selecionados"
+	},
+	"repoCount": {
+		"message": "$1 repositórios selecionados"
+	},
+	"repoLoading": {
+		"message": "Carregando repositórios..."
+	},
+	"repoLoaded": {
+		"message": "$1 repositórios carregados."
+	},
+	"repoNotFound": {
+		"message": "Nenhum repositório encontrado"
+	},
+	"repoRefetching": {
+		"message": "Recarregando repositórios..."
+	},
+	"repoLoadFailed": {
+		"message": "Falha ao carregar repositórios."
+	},
+	"repoTokenPrivate": {
+		"message": "O token é inválido ou não tem permissão para repositórios privados."
+	},
+	"repoRefetchFailed": {
+		"message": "Falha ao recarregar repositórios."
+	},
+	"orgSetMessage": {
+		"message": "Organização definida com sucesso."
+	},
+	"orgClearedMessage": {
+		"message": "Organização removida. Clique em 'Gerar Relatório' para buscar todas as atividades."
+	},
+	"orgNotFoundMessage": {
+		"message": "Organização não encontrada no GitHub."
+	},
+	"orgValidationErrorMessage": {
+		"message": "Erro ao validar a organização."
+	},
+	"refreshingButton": {
+		"message": "Atualizando..."
+	},
+	"cacheClearFailed": {
+		"message": "Falha ao limpar o cache."
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "Gerando..."
+	},
+	"copiedButton": {
+		"message": "Copiado!"
+	},
+	"orgChangedMessage": {
+		"message": "Organização alterada. Clique em 'Gerar Relatório' para buscar as atividades do GitHub."
+	},
+	"cacheClearedMessage": {
+		"message": "Cache limpo com sucesso. Clique em 'Gerar Relatório' para buscar dados novos."
+	},
+	"cacheExpiredMessage": {
+		"message": "O cache expirou. Clique em \"Gerar\" para buscar dados novos.",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "Cache Limpo!"
+	},
+	"extensionDisabledMessage": {
+		"message": "A extensão está desativada. Ative-a nos ajustes para gerar relatórios scrum."
+	},
+	"notePoint1": {
+		"message": "As solicitações de pull são buscadas com base na atividade de revisão mais recente de qualquer contribuidor, não apenas na sua. Revise e ajuste o relatório SCRUM gerado para garantir que ele reflita com precisão o seu trabalho antes de compartilhá-lo."
+	},
+	"noteSeeIssue": {
+		"message": "Veja este issue"
+	},
+	"platformLabel": {
+		"message": "Plataforma"
+	},
+	"usernameLabel": {
+		"message": "Seu nome de usuário"
+	},
+	"onlyRevPRsLabel": {
+		"message": "Incluir apenas PRs revisadas no relatório"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "Se marcado, o relatório incluirá apenas PRs revisadas por você."
+	},
+	"usernameRequiredError": {
+		"message": "Por favor, digite seu nome de usuário para gerar o relatório."
+	},
+	"unknownPlatformError": {
+		"message": "Plataforma desconhecida selecionada."
+	},
+	"gitlabFetchingError": {
+		"message": "Ocorreu um erro ao buscar os dados do GitLab."
+	},
+	"reportGenerationError": {
+		"message": "Ocorreu um erro ao gerar o relatório."
+	},
+	"githubUserNotFoundError": {
+		"message": "Usuário do GitHub \"$1\" não encontrado (404). Verifique o nome de usuário e tente novamente."
+	},
+	"githubUserValidationError": {
+		"message": "Erro ao validar o usuário do GitHub: $1 $2"
+	},
+	"invalidSearchQueryError": {
+		"message": "Consulta de busca ou intervalo de datas inválido. Verifique o formato e tente novamente."
+	},
+	"githubIssuesFetchError": {
+		"message": "Erro ao buscar issues do GitHub: $1 $2"
+	},
+	"githubPRReviewFetchError": {
+		"message": "Erro ao buscar dados de revisão de PR do GitHub: $1 $2"
+	},
+	"githubUserFetchError": {
+		"message": "Erro ao buscar dados do usuário do GitHub: $1 $2"
+	},
+	"invalidTokenError": {
+		"message": "Token do GitHub inválido ou expirado. Verifique seu token nas configurações do Scrum Helper e tente novamente."
+	},
+	"displayModeNotice": {
+		"message": "A extensão será aberta no modo $1 no próximo lançamento."
+	},
+	"repoFilteringGithubOnly": {
+		"message": "Filtragem de repositórios disponível apenas para o GitHub."
+	},
+	"repoLoadingGithubOnly": {
+		"message": "Carregamento de repositórios disponível apenas para o GitHub."
+	},
+	"repoFetchingGithubOnly": {
+		"message": "Busca de repositórios disponível apenas para o GitHub."
+	},
+	"loadingReposAutomatically": {
+		"message": "Carregando repositórios automaticamente..."
+	},
+	"gitlabUserFetchError": {
+		"message": "Erro ao buscar usuário do GitLab: $1 $2"
+	},
+	"gitlabUserNotFoundError": {
+		"message": "Usuário do GitLab '$1' não encontrado"
+	},
+	"gitlabMembershipError": {
+		"message": "Erro ao buscar projetos de associação do GitLab: $1 $2"
+	},
+	"gitlabContributedError": {
+		"message": "Erro ao buscar projetos contribuídos do GitLab: $1 $2"
+	},
+	"usernameMissingError": {
+		"message": "Nome de usuário obrigatório."
+	},
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"generatingReportNotification": {
+		"message": "Gerando relatório..."
+	},
+	"copyingReportNotification": {
+		"message": "Copiando relatório..."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "Inserindo relatório no e-mail..."
+	},
+	"insertedInEmailNotification": {
+		"message": "Relatório inserido no e-mail!"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Сообщайте о своем прогрессе в разработке, автоматически получая данные о вашей активности в Git за выбранный период."
-    },
-    "disableLabel": {
-        "message": "Отключить"
-    },
-    "enableLabel": {
-        "message": "Включить"
-    },
-    "projectNameLabel": {
-        "message": "Название проекта (используется в теме письма)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Введите название вашего проекта"
-    },
-    "githubUsernameLabel": {
-        "message": "Ваше имя пользователя GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Ваше имя пользователя GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Требуется для получения ваших вкладов"
-    },
-    "contributionsLabel": {
-        "message": "Получить ваши вклады за:"
-    },
-    "last1DayLabel": {
-        "message": "Предыдущий день"
-    },
-    "startDateLabel": {
-        "message": "С:"
-    },
-    "endDateLabel": {
-        "message": "До:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Показывать статус Открыто/Закрыто"
-    },
-    "blockersLabel": {
-        "message": "Что мешает вашему прогрессу?"
-    },
-    "blockersPlaceholder": {
-        "message": "Введите причину"
-    },
-    "scrumReportLabel": {
-        "message": "Scrum-отчет"
-    },
-    "generateReportButton": {
-        "message": "Создать"
-    },
-    "copyReportButton": {
-        "message": "Копировать"
-    },
-    "insertInEmailButton": {
-        "message": "Вставить в письмо"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Название организации"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Введите название организации"
-    },
-    "setButton": {
-        "message": "Установить"
-    },
-    "githubTokenLabel": {
-        "message": "Ваш токен GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Требуется для аутентифицированных запросов"
-    },
-    "githubTokenTooltip": {
-        "message": "Зачем рекомендуется добавлять токен GitHub? Scrum Helper работает без токена GitHub, но для лучшего опыта рекомендуется добавить токен личного доступа."
-    },
-    "gitlabTokenLabel": {
-        "message": "Ваш токен GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Требуется для приватных репо"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Зачем рекомендуется добавлять токен GitLab? Scrum Helper работает без токена GitLab для публичных проектов, но для лучшего опыта рекомендуется добавить токен личного доступа."
-    },
-    "showCommitsLabel": {
-        "message": "Показывать коммиты в открытых PR/ черновиках PR"
-    },
-    "showCommitsTooltip": {
-        "message": "Требуется токен Github, добавьте его в настройках."
-    },
-    "onlyIssuesLabel": {
-        "message": "Включить в отчет только задачи"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Если флажок установлен, в отчет будут включены только задачи, созданные пользователем или назначенные ему."
-    },
-    "onlyPRsLabel": {
-        "message": "Включать в отчёт только PR"
-    },
-    "onlyPRsTooltip": {
-        "message": "Если отмечено, отчёт будет включать только pull request'ы, созданные пользователем; проверенные PR будут исключены."
-    },
-    "cacheTTLLabel": {
-        "message": "Введите TTL кеша",
-        "description": "Метка для ввода времени жизни кеша."
-    },
-    "cacheTTLUnit": {
-        "message": "(в минутах)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Укажите TTL кэша в минутах (по умолчанию: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Обновить данные (в обход кэша)"
-    },
-    "refreshDataInfo": {
-        "message": "Используйте эту кнопку для немедленного получения свежих данных."
-    },
-    "noteTitle": {
-        "message": "Примечание:"
-    },
-    "viewCodeButton": {
-        "message": "Посмотреть код"
-    },
-    "reportIssueButton": {
-        "message": "Сообщить о проблеме"
-    },
-    "repoFilterLabel": {
-        "message": "Фильтровать по репозиториям"
-    },
-    "enableFilteringLabel": {
-        "message": "Включить фильтрацию"
-    },
-    "tokenRequiredWarning": {
-        "message": "Для фильтрации репозиториев требуется токен GitHub. Пожалуйста, добавьте его в настройках."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Найти репозиторий для добавления..."
-    },
-    "repoPlaceholder": {
-        "message": "Репозитории не выбраны (будут включены все)"
-    },
-    "repoCountNone": {
-        "message": "0 репозиториев выбрано"
-    },
-    "repoCount": {
-        "message": "$1 репозиториев выбрано"
-    },
-    "repoLoading": {
-        "message": "Загрузка репозиториев..."
-    },
-    "repoLoaded": {
-        "message": "Загружено $1 репозиториев."
-    },
-    "repoNotFound": {
-        "message": "Репозитории не найдены"
-    },
-    "repoRefetching": {
-        "message": "Перезагрузка репозиториев..."
-    },
-    "repoLoadFailed": {
-        "message": "Не удалось загрузить репозитории."
-    },
-    "repoTokenPrivate": {
-        "message": "Токен недействителен или не имеет прав для частных репозиториев."
-    },
-    "repoRefetchFailed": {
-        "message": "Не удалось перезагрузить репозитории."
-    },
-    "orgSetMessage": {
-        "message": "Организация успешно установлена."
-    },
-    "orgClearedMessage": {
-        "message": "Организация удалена. Нажмите 'Создать отчет', чтобы получить все действия."
-    },
-    "orgNotFoundMessage": {
-        "message": "Организация не найдена на GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Ошибка при проверке организации."
-    },
-    "refreshingButton": {
-        "message": "Обновление..."
-    },
-    "cacheClearFailed": {
-        "message": "Не удалось очистить кэш."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Создание..."
-    },
-    "copiedButton": {
-        "message": "Скопировано!"
-    },
-    "orgChangedMessage": {
-        "message": "Организация изменена. Нажмите 'Создать отчет', чтобы получить данные о действиях в GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Кэш успешно очищен. Нажмите 'Создать отчет', чтобы получить свежие данные."
-    },
-    "cacheExpiredMessage": {
-        "message": "Кэш истёк. Нажмите \"Создать\", чтобы получить новые данные.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Кэш очищен!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Расширение отключено. Включите его в настройках, чтобы создавать scrum-отчеты."
-    },
-    "notePoint1": {
-        "message": "Pull-реквесты извлекаются на основе последней активности по проверке любого участника, а не только вашей. Пожалуйста, просмотрите и скорректируйте сгенерированный отчет SCRUM, чтобы убедиться, что он точно отражает вашу работу, прежде чем делиться им."
-    },
-    "noteSeeIssue": {
-        "message": "Смотрите эту проблему"
-    },
-    "platformLabel": {
-        "message": "Платформа"
-    },
-    "usernameLabel": {
-        "message": "Ваше имя пользователя"
-    },
-    "usernameRequiredError": {
-        "message": "Пожалуйста, введите имя пользователя для создания отчета."
-    },
-    "unknownPlatformError": {
-        "message": "Выбрана неизвестная платформа."
-    },
-    "gitlabFetchingError": {
-        "message": "Произошла ошибка при получении данных GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Произошла ошибка при создании отчета."
-    },
-    "githubUserNotFoundError": {
-        "message": "Пользователь GitHub \"$1\" не найден (404). Проверьте имя пользователя и попробуйте снова."
-    },
-    "githubUserValidationError": {
-        "message": "Ошибка при проверке пользователя GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Недопустимый поисковый запрос или диапазон дат. Проверьте формат и попробуйте снова."
-    },
-    "githubIssuesFetchError": {
-        "message": "Ошибка при получении задач GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Ошибка при получении данных проверки PR GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Ошибка при получении данных пользователя GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Недействительный или истекший токен GitHub. Проверьте токен в настройках Scrum Helper и попробуйте снова."
-    },
-    "displayModeNotice": {
-        "message": "Расширение откроется в режиме $1 при следующем запуске."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Фильтрация репозиториев доступна только для GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Загрузка репозиториев доступна только для GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Получение репозиториев доступно только для GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Репозитории загружаются автоматически..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Ошибка при получении пользователя GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Пользователь GitLab '$1' не найден"
-    },
-    "gitlabMembershipError": {
-        "message": "Ошибка при получении проектов членства GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Ошибка при получении проектов с вкладом GitLab: $1 $2"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Включить в отчет только проверенные PR"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Если отмечено, отчёт будет включать только PR, проверенные вами."
-    },
-    "usernameMissingError": {
-        "message": "Требуется имя пользователя."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Создание отчёта..."
-    },
-    "copyingReportNotification": {
-        "message": "Копирование отчёта..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Вставка отчёта в письмо..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Отчёт вставлен в письмо!"
-    }
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "Сообщайте о своем прогрессе в разработке, автоматически получая данные о вашей активности в Git за выбранный период."
+	},
+	"disableLabel": {
+		"message": "Отключить"
+	},
+	"enableLabel": {
+		"message": "Включить"
+	},
+	"projectNameLabel": {
+		"message": "Название проекта (используется в теме письма)"
+	},
+	"projectNamePlaceholder": {
+		"message": "Введите название вашего проекта"
+	},
+	"githubUsernameLabel": {
+		"message": "Ваше имя пользователя GitHub"
+	},
+	"gitlabUsernameLabel": {
+		"message": "Ваше имя пользователя GitLab"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "Требуется для получения ваших вкладов"
+	},
+	"contributionsLabel": {
+		"message": "Получить ваши вклады за:"
+	},
+	"last1DayLabel": {
+		"message": "Предыдущий день"
+	},
+	"startDateLabel": {
+		"message": "С:"
+	},
+	"endDateLabel": {
+		"message": "До:"
+	},
+	"showOpenClosedLabel": {
+		"message": "Показывать статус Открыто/Закрыто"
+	},
+	"blockersLabel": {
+		"message": "Что мешает вашему прогрессу?"
+	},
+	"blockersPlaceholder": {
+		"message": "Введите причину"
+	},
+	"scrumReportLabel": {
+		"message": "Scrum-отчет"
+	},
+	"generateReportButton": {
+		"message": "Создать"
+	},
+	"copyReportButton": {
+		"message": "Копировать"
+	},
+	"insertInEmailButton": {
+		"message": "Вставить в письмо"
+	},
+	"settingsOrgNameLabel": {
+		"message": "Название организации"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "Введите название организации"
+	},
+	"setButton": {
+		"message": "Установить"
+	},
+	"githubTokenLabel": {
+		"message": "Ваш токен GitHub"
+	},
+	"githubTokenPlaceholder": {
+		"message": "Требуется для аутентифицированных запросов"
+	},
+	"githubTokenTooltip": {
+		"message": "Зачем рекомендуется добавлять токен GitHub? Scrum Helper работает без токена GitHub, но для лучшего опыта рекомендуется добавить токен личного доступа."
+	},
+	"gitlabTokenLabel": {
+		"message": "Ваш токен GitLab"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "Требуется для приватных репо"
+	},
+	"gitlabTokenTooltip": {
+		"message": "Зачем рекомендуется добавлять токен GitLab? Scrum Helper работает без токена GitLab для публичных проектов, но для лучшего опыта рекомендуется добавить токен личного доступа."
+	},
+	"showCommitsLabel": {
+		"message": "Показывать коммиты в открытых PR/ черновиках PR"
+	},
+	"showCommitsTooltip": {
+		"message": "Требуется токен Github, добавьте его в настройках."
+	},
+	"onlyIssuesLabel": {
+		"message": "Включить в отчет только задачи"
+	},
+	"onlyIssuesTooltip": {
+		"message": "Если флажок установлен, в отчет будут включены только задачи, созданные пользователем или назначенные ему."
+	},
+	"onlyPRsLabel": {
+		"message": "Включать в отчёт только PR"
+	},
+	"onlyPRsTooltip": {
+		"message": "Если отмечено, отчёт будет включать только pull request'ы, созданные пользователем; проверенные PR будут исключены."
+	},
+	"cacheTTLLabel": {
+		"message": "Введите TTL кеша",
+		"description": "Метка для ввода времени жизни кеша."
+	},
+	"cacheTTLUnit": {
+		"message": "(в минутах)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "Укажите TTL кэша в минутах (по умолчанию: 10)"
+	},
+	"refreshDataButton": {
+		"message": "Обновить данные (в обход кэша)"
+	},
+	"refreshDataInfo": {
+		"message": "Используйте эту кнопку для немедленного получения свежих данных."
+	},
+	"noteTitle": {
+		"message": "Примечание:"
+	},
+	"viewCodeButton": {
+		"message": "Посмотреть код"
+	},
+	"reportIssueButton": {
+		"message": "Сообщить о проблеме"
+	},
+	"repoFilterLabel": {
+		"message": "Фильтровать по репозиториям"
+	},
+	"enableFilteringLabel": {
+		"message": "Включить фильтрацию"
+	},
+	"tokenRequiredWarning": {
+		"message": "Для фильтрации репозиториев требуется токен GitHub. Пожалуйста, добавьте его в настройках."
+	},
+	"repoSearchPlaceholder": {
+		"message": "Найти репозиторий для добавления..."
+	},
+	"repoPlaceholder": {
+		"message": "Репозитории не выбраны (будут включены все)"
+	},
+	"repoCountNone": {
+		"message": "0 репозиториев выбрано"
+	},
+	"repoCount": {
+		"message": "$1 репозиториев выбрано"
+	},
+	"repoLoading": {
+		"message": "Загрузка репозиториев..."
+	},
+	"repoLoaded": {
+		"message": "Загружено $1 репозиториев."
+	},
+	"repoNotFound": {
+		"message": "Репозитории не найдены"
+	},
+	"repoRefetching": {
+		"message": "Перезагрузка репозиториев..."
+	},
+	"repoLoadFailed": {
+		"message": "Не удалось загрузить репозитории."
+	},
+	"repoTokenPrivate": {
+		"message": "Токен недействителен или не имеет прав для частных репозиториев."
+	},
+	"repoRefetchFailed": {
+		"message": "Не удалось перезагрузить репозитории."
+	},
+	"orgSetMessage": {
+		"message": "Организация успешно установлена."
+	},
+	"orgClearedMessage": {
+		"message": "Организация удалена. Нажмите 'Создать отчет', чтобы получить все действия."
+	},
+	"orgNotFoundMessage": {
+		"message": "Организация не найдена на GitHub."
+	},
+	"orgValidationErrorMessage": {
+		"message": "Ошибка при проверке организации."
+	},
+	"refreshingButton": {
+		"message": "Обновление..."
+	},
+	"cacheClearFailed": {
+		"message": "Не удалось очистить кэш."
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "Создание..."
+	},
+	"copiedButton": {
+		"message": "Скопировано!"
+	},
+	"orgChangedMessage": {
+		"message": "Организация изменена. Нажмите 'Создать отчет', чтобы получить данные о действиях в GitHub."
+	},
+	"cacheClearedMessage": {
+		"message": "Кэш успешно очищен. Нажмите 'Создать отчет', чтобы получить свежие данные."
+	},
+	"cacheExpiredMessage": {
+		"message": "Кэш истёк. Нажмите \"Создать\", чтобы получить новые данные.",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "Кэш очищен!"
+	},
+	"extensionDisabledMessage": {
+		"message": "Расширение отключено. Включите его в настройках, чтобы создавать scrum-отчеты."
+	},
+	"notePoint1": {
+		"message": "Pull-реквесты извлекаются на основе последней активности по проверке любого участника, а не только вашей. Пожалуйста, просмотрите и скорректируйте сгенерированный отчет SCRUM, чтобы убедиться, что он точно отражает вашу работу, прежде чем делиться им."
+	},
+	"noteSeeIssue": {
+		"message": "Смотрите эту проблему"
+	},
+	"platformLabel": {
+		"message": "Платформа"
+	},
+	"usernameLabel": {
+		"message": "Ваше имя пользователя"
+	},
+	"usernameRequiredError": {
+		"message": "Пожалуйста, введите имя пользователя для создания отчета."
+	},
+	"unknownPlatformError": {
+		"message": "Выбрана неизвестная платформа."
+	},
+	"gitlabFetchingError": {
+		"message": "Произошла ошибка при получении данных GitLab."
+	},
+	"reportGenerationError": {
+		"message": "Произошла ошибка при создании отчета."
+	},
+	"githubUserNotFoundError": {
+		"message": "Пользователь GitHub \"$1\" не найден (404). Проверьте имя пользователя и попробуйте снова."
+	},
+	"githubUserValidationError": {
+		"message": "Ошибка при проверке пользователя GitHub: $1 $2"
+	},
+	"invalidSearchQueryError": {
+		"message": "Недопустимый поисковый запрос или диапазон дат. Проверьте формат и попробуйте снова."
+	},
+	"githubIssuesFetchError": {
+		"message": "Ошибка при получении задач GitHub: $1 $2"
+	},
+	"githubPRReviewFetchError": {
+		"message": "Ошибка при получении данных проверки PR GitHub: $1 $2"
+	},
+	"githubUserFetchError": {
+		"message": "Ошибка при получении данных пользователя GitHub: $1 $2"
+	},
+	"invalidTokenError": {
+		"message": "Недействительный или истекший токен GitHub. Проверьте токен в настройках Scrum Helper и попробуйте снова."
+	},
+	"displayModeNotice": {
+		"message": "Расширение откроется в режиме $1 при следующем запуске."
+	},
+	"repoFilteringGithubOnly": {
+		"message": "Фильтрация репозиториев доступна только для GitHub."
+	},
+	"repoLoadingGithubOnly": {
+		"message": "Загрузка репозиториев доступна только для GitHub."
+	},
+	"repoFetchingGithubOnly": {
+		"message": "Получение репозиториев доступно только для GitHub."
+	},
+	"loadingReposAutomatically": {
+		"message": "Репозитории загружаются автоматически..."
+	},
+	"gitlabUserFetchError": {
+		"message": "Ошибка при получении пользователя GitLab: $1 $2"
+	},
+	"gitlabUserNotFoundError": {
+		"message": "Пользователь GitLab '$1' не найден"
+	},
+	"gitlabMembershipError": {
+		"message": "Ошибка при получении проектов членства GitLab: $1 $2"
+	},
+	"gitlabContributedError": {
+		"message": "Ошибка при получении проектов с вкладом GitLab: $1 $2"
+	},
+	"onlyRevPRsLabel": {
+		"message": "Включить в отчет только проверенные PR"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "Если отмечено, отчёт будет включать только PR, проверенные вами."
+	},
+	"usernameMissingError": {
+		"message": "Требуется имя пользователя."
+	},
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"generatingReportNotification": {
+		"message": "Создание отчёта..."
+	},
+	"copyingReportNotification": {
+		"message": "Копирование отчёта..."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "Вставка отчёта в письмо..."
+	},
+	"insertedInEmailNotification": {
+		"message": "Отчёт вставлен в письмо!"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/ta/messages.json
+++ b/src/_locales/ta/messages.json
@@ -1,236 +1,260 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "தேர்ந்தெடுக்கப்பட்ட காலப்பகுதிக்கான உங்கள் Git செயல்பாட்டைத் தானாகவே பெற்று, உங்கள் மேம்பாட்டு முன்னேற்றத்தைப் புகாரளியுங்கள்."
-    },
-    "disableLabel": {
-        "message": "முடக்கு"
-    },
-    "enableLabel": {
-        "message": "இயக்கு"
-    },
-    "projectNameLabel": {
-        "message": "திட்டப் பெயர் (மின்னஞ்சல் தலைப்பில் பயன்படுத்தப்படும்)"
-    },
-    "projectNamePlaceholder": {
-        "message": "உங்கள் திட்டப் பெயரை உள்ளிடவும்"
-    },
-    "githubUsernameLabel": {
-        "message": "உங்கள் GitHub பயனர்பெயர்"
-    },
-    "gitlabUsernameLabel": {
-        "message": "உங்கள் GitLab பயனர்பெயர்"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "உங்கள் பங்களிப்புகளை பெற தேவையானது"
-    },
-    "contributionsLabel": {
-        "message": "பங்களிப்புகளை பெற காலகட்டம்:"
-    },
-    "last1DayLabel": {
-        "message": "முந்தைய நாள்"
-    },
-    "startDateLabel": {
-        "message": "தொடக்கம்:"
-    },
-    "endDateLabel": {
-        "message": "முடிவு:"
-    },
-    "showOpenClosedLabel": {
-        "message": "PR லேபல்களைக் காட்டு"
-    },
-    "blockersLabel": {
-        "message": "உங்கள் முன்னேற்றத்தை தடுப்பது என்ன?"
-    },
-    "blockersPlaceholder": {
-        "message": "உங்கள் காரணத்தை உள்ளிடவும்"
-    },
-    "scrumReportLabel": {
-        "message": "Scrum அறிக்கை"
-    },
-    "generateReportButton": {
-        "message": "உருவாக்கு"
-    },
-    "copyReportButton": {
-        "message": "நகலெடு"
-    },
-    "insertInEmailButton": {
-        "message": "மின்னஞ்சலில் செருகு"
-    },
-    "settingsOrgNameLabel": {
-        "message": "நிறுவன பெயர்"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "நிறுவன பெயரை உள்ளிடவும்"
-    },
-    "setButton": {
-        "message": "அமை"
-    },
-    "githubTokenLabel": {
-        "message": "உங்கள் GitHub டோக்கன்"
-    },
-    "githubTokenPlaceholder": {
-        "message": "அங்கீகரிக்கப்பட்ட கோரிக்கைகளுக்கு தேவையானது"
-    },
-    "githubTokenTooltip": {
-        "message": "GitHub டோக்கன் சேர்க்க ஏன் பரிந்துரைக்கப்படுகிறது? Scrum Helper GitHub டோக்கன் இல்லாமலும் செயல்படும், ஆனால் சிறந்த அனுபவத்திற்காக தனிப்பட்ட அணுகல் டோக்கன் சேர்க்க பரிந்துரைக்கப்படுகிறது."
-    },
-    "gitlabTokenLabel": {
-        "message": "உங்கள் GitLab டோக்கன்"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "தனிப்பட்ட திட்டங்களை அணுக தேவையானது"
-    },
-    "gitlabTokenTooltip": {
-        "message": "GitLab டோக்கன் சேர்க்க ஏன் பரிந்துரைக்கப்படுகிறது? Scrum Helper பொது திட்டங்களுக்கு GitLab டோக்கன் இல்லாமலும் செயல்படும், ஆனால் சிறந்த அனுபவத்திற்காக தனிப்பட்ட அணுகல் டோக்கன் சேர்க்க பரிந்துரைக்கப்படுகிறது."
-    },
-    "showCommitsLabel": {
-        "message": "திறந்த PR / வரைவு PR களில் commits காட்டு"
-    },
-    "showCommitsTooltip": {
-        "message": "GitHub டோக்கன் தேவை, அமைப்புகளில் சேர்க்கவும்."
-    },
-    "onlyIssuesLabel": {
-        "message": "அறிக்கையில் சிக்கல்களை மட்டும் சேர்"
-    },
-    "onlyIssuesTooltip": {
-        "message": "தேர்ந்தெடுக்கப்பட்டால், அறிக்கையில் பயனரால் உருவாக்கப்பட்ட அல்லது ஒதுக்கப்பட்ட சிக்கல்கள் மட்டுமே இருக்கும்."
-    },
-    "onlyPRsLabel": {
-        "message": "அறிக்கையில் PR களை மட்டும் சேர்"
-    },
-    "onlyPRsTooltip": {
-        "message": "தேர்ந்தெடுக்கப்பட்டால், அறிக்கையில் பயனரால் உருவாக்கப்பட்ட PR கள் மட்டுமே இருக்கும். மதிப்பாய்வு செய்யப்பட்ட PR கள் விலக்கப்படும்."
-    },
-    "cacheTTLLabel": {
-        "message": "தற்காலிக சேமிப்பு TTL ஐ உள்ளிடவும்"
-    },
-    "cacheTTLUnit": {
-        "message": "(நிமிடங்களில்)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "தற்காலிக சேமிப்பு TTL ஐ நிமிடங்களில் உள்ளிடவும் (இயல்புநிலை: 10 நிமிடங்கள்)"
-    },
-    "refreshDataButton": {
-        "message": "தரவை புதுப்பி (தற்காலிக சேமிப்பை புறக்கணி)"
-    },
-    "refreshDataInfo": {
-        "message": "புதிய தரவை உடனடியாக பெற இந்த பொத்தானை பயன்படுத்தவும்."
-    },
-    "noteTitle": {
-        "message": "குறிப்பு:"
-    },
-    "viewCodeButton": {
-        "message": "குறியீட்டைக் காண்"
-    },
-    "reportIssueButton": {
-        "message": "சிக்கலை அறிவி"
-    },
-    "repoFilterLabel": {
-        "message": "களஞ்சியங்களால் வடிகட்டு"
-    },
-    "enableFilteringLabel": {
-        "message": "வடிகட்டலை இயக்கு"
-    },
-    "tokenRequiredWarning": {
-        "message": "களஞ்சியங்களை வடிகட்ட GitHub டோக்கன் தேவை. அமைப்புகளில் ஒன்றை சேர்க்கவும்."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "திறந்த அல்லது வரைவு PR களில் commits காட்ட GitHub டோக்கன் தேவை. அமைப்புகளில் ஒன்றை சேர்க்கவும்."
-    },
-    "repoSearchPlaceholder": {
-        "message": "சேர்க்க களஞ்சியத்தை தேடவும்..."
-    },
-    "repoPlaceholder": {
-        "message": "களஞ்சியங்கள் தேர்ந்தெடுக்கப்படவில்லை (அனைத்தும் சேர்க்கப்படும்)"
-    },
-    "repoCountNone": {
-        "message": "0 களஞ்சியங்கள் தேர்ந்தெடுக்கப்பட்டன"
-    },
-    "repoCount": {
-        "message": "$1 களஞ்சியங்கள் தேர்ந்தெடுக்கப்பட்டன"
-    },
-    "repoLoading": {
-        "message": "களஞ்சியங்கள் ஏற்றப்படுகின்றன..."
-    },
-    "repoLoaded": {
-        "message": "$1 களஞ்சியங்கள் ஏற்றப்பட்டன."
-    },
-    "repoNotFound": {
-        "message": "களஞ்சியங்கள் எதுவும் கிடைக்கவில்லை"
-    },
-    "repoRefetching": {
-        "message": "களஞ்சியங்கள் மீண்டும் பெறப்படுகின்றன..."
-    },
-    "repoLoadFailed": {
-        "message": "களஞ்சியங்களை ஏற்றுவதில் தோல்வி."
-    },
-    "repoTokenPrivate": {
-        "message": "டோக்கன் தவறானது அல்லது தனிப்பட்ட களஞ்சியங்களுக்கான உரிமைகள் இல்லை."
-    },
-    "repoRefetchFailed": {
-        "message": "களஞ்சியங்களை மீண்டும் பெறுவதில் தோல்வி."
-    },
-    "orgSetMessage": {
-        "message": "நிறுவனம் வெற்றிகரமாக அமைக்கப்பட்டது."
-    },
-    "orgClearedMessage": {
-        "message": "நிறுவனம் அழிக்கப்பட்டது. அனைத்து செயல்பாடுகளையும் பெற 'உருவாக்கு' என்பதை கிளிக் செய்யவும்."
-    },
-    "orgNotFoundMessage": {
-        "message": "GitHub இல் நிறுவனம் கிடைக்கவில்லை."
-    },
-    "orgValidationErrorMessage": {
-        "message": "நிறுவனத்தை சரிபார்க்கும்போது பிழை."
-    },
-    "refreshingButton": {
-        "message": "புதுப்பிக்கிறது..."
-    },
-    "cacheClearFailed": {
-        "message": "தற்காலிக சேமிப்பை அழிப்பதில் தோல்வி."
-    },
-    "madeWithLoveBy": {
-        "message": "❤️ உடன் உருவாக்கியவர்"
-    },
-    "generatingButton": {
-        "message": "உருவாக்குகிறது..."
-    },
-    "copiedButton": {
-        "message": "நகலெடுக்கப்பட்டது!"
-    },
-    "orgChangedMessage": {
-        "message": "நிறுவனம் மாற்றப்பட்டது. GitHub செயல்பாடுகளை பெற 'உருவாக்கு' பொத்தானை கிளிக் செய்யவும்."
-    },
-    "cacheClearedMessage": {
-        "message": "தற்காலிக சேமிப்பு வெற்றிகரமாக அழிக்கப்பட்டது. புதிய தரவை பெற «உருவாக்கு» என்பதை கிளிக் செய்யவும்."
-    },
-    "cacheExpiredMessage": {
-        "message": "தற்காலிக சேமிப்பு காலாவதியானது. புதிய தரவை பெற «உருவாக்கு» என்பதை கிளிக் செய்யவும்."
-    },
-    "cacheClearedButton": {
-        "message": "தற்காலிக சேமிப்பு அழிக்கப்பட்டது!"
-    },
-    "extensionDisabledMessage": {
-        "message": "நீட்டிப்பு முடக்கப்பட்டுள்ளது. Scrum அறிக்கைகளை உருவாக்க விருப்பங்களில் இருந்து இயக்கவும்."
-    },
-    "notePoint1": {
-        "message": "Pull requests உங்களது மட்டுமல்ல, எந்தவொரு பங்களிப்பாளரின் சமீபத்திய மதிப்பாய்வு செயல்பாட்டின் அடிப்படையில் பெறப்படுகின்றன. பகிர்வதற்கு முன்பு உங்கள் பணியை துல்லியமாக பிரதிபலிக்கிறதா என்பதை உறுதிப்படுத்த உருவாக்கப்பட்ட SCRUM அறிக்கையை மதிப்பாய்வு செய்து சரிசெய்யவும்."
-    },
-    "noteSeeIssue": {
-        "message": "இந்த சிக்கலைப் பாருங்கள்"
-    },
-    "platformLabel": {
-        "message": "தளம்"
-    },
-    "usernameLabel": {
-        "message": "உங்கள் பயனர்பெயர்"
-    },
-    "onlyRevPRsLabel": {
-        "message": "அறிக்கையில் மதிப்பாய்வு செய்யப்பட்ட PR களை மட்டும் சேர்"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "தேர்ந்தெடுக்கப்பட்டால், அறிக்கையில் நீங்கள் மதிப்பாய்வு செய்த PR கள் மட்டுமே இருக்கும்."
-    }
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "தேர்ந்தெடுக்கப்பட்ட காலப்பகுதிக்கான உங்கள் Git செயல்பாட்டைத் தானாகவே பெற்று, உங்கள் மேம்பாட்டு முன்னேற்றத்தைப் புகாரளியுங்கள்."
+	},
+	"disableLabel": {
+		"message": "முடக்கு"
+	},
+	"enableLabel": {
+		"message": "இயக்கு"
+	},
+	"projectNameLabel": {
+		"message": "திட்டப் பெயர் (மின்னஞ்சல் தலைப்பில் பயன்படுத்தப்படும்)"
+	},
+	"projectNamePlaceholder": {
+		"message": "உங்கள் திட்டப் பெயரை உள்ளிடவும்"
+	},
+	"githubUsernameLabel": {
+		"message": "உங்கள் GitHub பயனர்பெயர்"
+	},
+	"gitlabUsernameLabel": {
+		"message": "உங்கள் GitLab பயனர்பெயர்"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "உங்கள் பங்களிப்புகளை பெற தேவையானது"
+	},
+	"contributionsLabel": {
+		"message": "பங்களிப்புகளை பெற காலகட்டம்:"
+	},
+	"last1DayLabel": {
+		"message": "முந்தைய நாள்"
+	},
+	"startDateLabel": {
+		"message": "தொடக்கம்:"
+	},
+	"endDateLabel": {
+		"message": "முடிவு:"
+	},
+	"showOpenClosedLabel": {
+		"message": "PR லேபல்களைக் காட்டு"
+	},
+	"blockersLabel": {
+		"message": "உங்கள் முன்னேற்றத்தை தடுப்பது என்ன?"
+	},
+	"blockersPlaceholder": {
+		"message": "உங்கள் காரணத்தை உள்ளிடவும்"
+	},
+	"scrumReportLabel": {
+		"message": "Scrum அறிக்கை"
+	},
+	"generateReportButton": {
+		"message": "உருவாக்கு"
+	},
+	"copyReportButton": {
+		"message": "நகலெடு"
+	},
+	"insertInEmailButton": {
+		"message": "மின்னஞ்சலில் செருகு"
+	},
+	"settingsOrgNameLabel": {
+		"message": "நிறுவன பெயர்"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "நிறுவன பெயரை உள்ளிடவும்"
+	},
+	"setButton": {
+		"message": "அமை"
+	},
+	"githubTokenLabel": {
+		"message": "உங்கள் GitHub டோக்கன்"
+	},
+	"githubTokenPlaceholder": {
+		"message": "அங்கீகரிக்கப்பட்ட கோரிக்கைகளுக்கு தேவையானது"
+	},
+	"githubTokenTooltip": {
+		"message": "GitHub டோக்கன் சேர்க்க ஏன் பரிந்துரைக்கப்படுகிறது? Scrum Helper GitHub டோக்கன் இல்லாமலும் செயல்படும், ஆனால் சிறந்த அனுபவத்திற்காக தனிப்பட்ட அணுகல் டோக்கன் சேர்க்க பரிந்துரைக்கப்படுகிறது."
+	},
+	"gitlabTokenLabel": {
+		"message": "உங்கள் GitLab டோக்கன்"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "தனிப்பட்ட திட்டங்களை அணுக தேவையானது"
+	},
+	"gitlabTokenTooltip": {
+		"message": "GitLab டோக்கன் சேர்க்க ஏன் பரிந்துரைக்கப்படுகிறது? Scrum Helper பொது திட்டங்களுக்கு GitLab டோக்கன் இல்லாமலும் செயல்படும், ஆனால் சிறந்த அனுபவத்திற்காக தனிப்பட்ட அணுகல் டோக்கன் சேர்க்க பரிந்துரைக்கப்படுகிறது."
+	},
+	"showCommitsLabel": {
+		"message": "திறந்த PR / வரைவு PR களில் commits காட்டு"
+	},
+	"showCommitsTooltip": {
+		"message": "GitHub டோக்கன் தேவை, அமைப்புகளில் சேர்க்கவும்."
+	},
+	"onlyIssuesLabel": {
+		"message": "அறிக்கையில் சிக்கல்களை மட்டும் சேர்"
+	},
+	"onlyIssuesTooltip": {
+		"message": "தேர்ந்தெடுக்கப்பட்டால், அறிக்கையில் பயனரால் உருவாக்கப்பட்ட அல்லது ஒதுக்கப்பட்ட சிக்கல்கள் மட்டுமே இருக்கும்."
+	},
+	"onlyPRsLabel": {
+		"message": "அறிக்கையில் PR களை மட்டும் சேர்"
+	},
+	"onlyPRsTooltip": {
+		"message": "தேர்ந்தெடுக்கப்பட்டால், அறிக்கையில் பயனரால் உருவாக்கப்பட்ட PR கள் மட்டுமே இருக்கும். மதிப்பாய்வு செய்யப்பட்ட PR கள் விலக்கப்படும்."
+	},
+	"cacheTTLLabel": {
+		"message": "தற்காலிக சேமிப்பு TTL ஐ உள்ளிடவும்"
+	},
+	"cacheTTLUnit": {
+		"message": "(நிமிடங்களில்)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "தற்காலிக சேமிப்பு TTL ஐ நிமிடங்களில் உள்ளிடவும் (இயல்புநிலை: 10 நிமிடங்கள்)"
+	},
+	"refreshDataButton": {
+		"message": "தரவை புதுப்பி (தற்காலிக சேமிப்பை புறக்கணி)"
+	},
+	"refreshDataInfo": {
+		"message": "புதிய தரவை உடனடியாக பெற இந்த பொத்தானை பயன்படுத்தவும்."
+	},
+	"noteTitle": {
+		"message": "குறிப்பு:"
+	},
+	"viewCodeButton": {
+		"message": "குறியீட்டைக் காண்"
+	},
+	"reportIssueButton": {
+		"message": "சிக்கலை அறிவி"
+	},
+	"repoFilterLabel": {
+		"message": "களஞ்சியங்களால் வடிகட்டு"
+	},
+	"enableFilteringLabel": {
+		"message": "வடிகட்டலை இயக்கு"
+	},
+	"tokenRequiredWarning": {
+		"message": "களஞ்சியங்களை வடிகட்ட GitHub டோக்கன் தேவை. அமைப்புகளில் ஒன்றை சேர்க்கவும்."
+	},
+	"tokenRequiredShowCommitsWarning": {
+		"message": "திறந்த அல்லது வரைவு PR களில் commits காட்ட GitHub டோக்கன் தேவை. அமைப்புகளில் ஒன்றை சேர்க்கவும்."
+	},
+	"repoSearchPlaceholder": {
+		"message": "சேர்க்க களஞ்சியத்தை தேடவும்..."
+	},
+	"repoPlaceholder": {
+		"message": "களஞ்சியங்கள் தேர்ந்தெடுக்கப்படவில்லை (அனைத்தும் சேர்க்கப்படும்)"
+	},
+	"repoCountNone": {
+		"message": "0 களஞ்சியங்கள் தேர்ந்தெடுக்கப்பட்டன"
+	},
+	"repoCount": {
+		"message": "$1 களஞ்சியங்கள் தேர்ந்தெடுக்கப்பட்டன"
+	},
+	"repoLoading": {
+		"message": "களஞ்சியங்கள் ஏற்றப்படுகின்றன..."
+	},
+	"repoLoaded": {
+		"message": "$1 களஞ்சியங்கள் ஏற்றப்பட்டன."
+	},
+	"repoNotFound": {
+		"message": "களஞ்சியங்கள் எதுவும் கிடைக்கவில்லை"
+	},
+	"repoRefetching": {
+		"message": "களஞ்சியங்கள் மீண்டும் பெறப்படுகின்றன..."
+	},
+	"repoLoadFailed": {
+		"message": "களஞ்சியங்களை ஏற்றுவதில் தோல்வி."
+	},
+	"repoTokenPrivate": {
+		"message": "டோக்கன் தவறானது அல்லது தனிப்பட்ட களஞ்சியங்களுக்கான உரிமைகள் இல்லை."
+	},
+	"repoRefetchFailed": {
+		"message": "களஞ்சியங்களை மீண்டும் பெறுவதில் தோல்வி."
+	},
+	"orgSetMessage": {
+		"message": "நிறுவனம் வெற்றிகரமாக அமைக்கப்பட்டது."
+	},
+	"orgClearedMessage": {
+		"message": "நிறுவனம் அழிக்கப்பட்டது. அனைத்து செயல்பாடுகளையும் பெற 'உருவாக்கு' என்பதை கிளிக் செய்யவும்."
+	},
+	"orgNotFoundMessage": {
+		"message": "GitHub இல் நிறுவனம் கிடைக்கவில்லை."
+	},
+	"orgValidationErrorMessage": {
+		"message": "நிறுவனத்தை சரிபார்க்கும்போது பிழை."
+	},
+	"refreshingButton": {
+		"message": "புதுப்பிக்கிறது..."
+	},
+	"cacheClearFailed": {
+		"message": "தற்காலிக சேமிப்பை அழிப்பதில் தோல்வி."
+	},
+	"madeWithLoveBy": {
+		"message": "❤️ உடன் உருவாக்கியவர்"
+	},
+	"generatingButton": {
+		"message": "உருவாக்குகிறது..."
+	},
+	"copiedButton": {
+		"message": "நகலெடுக்கப்பட்டது!"
+	},
+	"orgChangedMessage": {
+		"message": "நிறுவனம் மாற்றப்பட்டது. GitHub செயல்பாடுகளை பெற 'உருவாக்கு' பொத்தானை கிளிக் செய்யவும்."
+	},
+	"cacheClearedMessage": {
+		"message": "தற்காலிக சேமிப்பு வெற்றிகரமாக அழிக்கப்பட்டது. புதிய தரவை பெற «உருவாக்கு» என்பதை கிளிக் செய்யவும்."
+	},
+	"cacheExpiredMessage": {
+		"message": "தற்காலிக சேமிப்பு காலாவதியானது. புதிய தரவை பெற «உருவாக்கு» என்பதை கிளிக் செய்யவும்."
+	},
+	"cacheClearedButton": {
+		"message": "தற்காலிக சேமிப்பு அழிக்கப்பட்டது!"
+	},
+	"extensionDisabledMessage": {
+		"message": "நீட்டிப்பு முடக்கப்பட்டுள்ளது. Scrum அறிக்கைகளை உருவாக்க விருப்பங்களில் இருந்து இயக்கவும்."
+	},
+	"notePoint1": {
+		"message": "Pull requests உங்களது மட்டுமல்ல, எந்தவொரு பங்களிப்பாளரின் சமீபத்திய மதிப்பாய்வு செயல்பாட்டின் அடிப்படையில் பெறப்படுகின்றன. பகிர்வதற்கு முன்பு உங்கள் பணியை துல்லியமாக பிரதிபலிக்கிறதா என்பதை உறுதிப்படுத்த உருவாக்கப்பட்ட SCRUM அறிக்கையை மதிப்பாய்வு செய்து சரிசெய்யவும்."
+	},
+	"noteSeeIssue": {
+		"message": "இந்த சிக்கலைப் பாருங்கள்"
+	},
+	"platformLabel": {
+		"message": "தளம்"
+	},
+	"usernameLabel": {
+		"message": "உங்கள் பயனர்பெயர்"
+	},
+	"onlyRevPRsLabel": {
+		"message": "அறிக்கையில் மதிப்பாய்வு செய்யப்பட்ட PR களை மட்டும் சேர்"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "தேர்ந்தெடுக்கப்பட்டால், அறிக்கையில் நீங்கள் மதிப்பாய்வு செய்த PR கள் மட்டுமே இருக்கும்."
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/te/messages.json
+++ b/src/_locales/te/messages.json
@@ -1,258 +1,282 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "ఎంచుకున్న కాలవ్యవధికి మీ Git కార్యకలాపాలను స్వయంచాలకంగా తెచ్చి, మీ అభివృద్ధి పురోగతిని నివేదించండి"
-    },
-    "disableLabel": {
-        "message": "అచేతనం"
-    },
-    "enableLabel": {
-        "message": "సక్రియం"
-    },
-    "projectNameLabel": {
-        "message": "ప్రాజెక్ట్ పేరు (ఇమెయిల్ విషయంలో వాడబడుతుంది)"
-    },
-    "projectNamePlaceholder": {
-        "message": "మీ ప్రాజెక్ట్ పేరును నమోదు చేయండి"
-    },
-    "githubUsernameLabel": {
-        "message": "మీ GitHub వాడుకరి పేరు"
-    },
-    "gitlabUsernameLabel": {
-        "message": "మీ GitLab వాడుకరి పేరు"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "మీ సహకారాలను తెచ్చుకోవడానికి అవసరం"
-    },
-    "contributionsLabel": {
-        "message": "మీ సహకారాలను ఇక్కడ నుండి తెచ్చుకోండి:"
-    },
-    "last1DayLabel": {
-        "message": "గత రోజు"
-    },
-    "startDateLabel": {
-        "message": "నుండి:"
-    },
-    "endDateLabel": {
-        "message": "వరకు:"
-    },
-    "showOpenClosedLabel": {
-        "message": "PR లేబుళ్లు చూపించు"
-    },
-    "blockersLabel": {
-        "message": "మీరు ఏమి కారణంగా ముందుకు సాగలేకపోతున్నారు?"
-    },
-    "blockersPlaceholder": {
-        "message": "మీ కారణం ఇక్కడ రాయండి"
-    },
-    "scrumReportLabel": {
-        "message": "స్క్రమ్ నివేదిక"
-    },
-    "generateReportButton": {
-        "message": "సృష్టించు"
-    },
-    "copyReportButton": {
-        "message": "కాపీ"
-    },
-    "insertInEmailButton": {
-        "message": "ఇమెయిల్‌లో చేర్చు"
-    },
-    "settingsOrgNameLabel": {
-        "message": "సంస్థ పేరు"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "సంస్థ పేరును నమోదు చేయండి"
-    },
-    "setButton": {
-        "message": "సెట్ చేయి"
-    },
-    "githubTokenLabel": {
-        "message": "మీ GitHub టోకెన్"
-    },
-    "githubTokenPlaceholder": {
-        "message": "ఆథెంటికేటెడ్ అభ్యర్థనలకు అవసరం"
-    },
-    "githubTokenTooltip": {
-        "message": "GitHub టోకెన్‌ను జోడించడం ఎందుకు సిఫారసు చేయబడుతుంది? Scrum Helper GitHub టోకెన్ లేకుండా పనిచేస్తుంది, కాని మెరుగైన అనుభవం కోసం ఒక ఖాతా ఆక్సెస్ టోకెన్‌ను జోడించడం సిఫారసు చేయబడుతుంది."
-    },
-    "gitlabTokenLabel": {
-        "message": "మీ GitLab టోకెన్"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "ప్రైవేట్ రెపోస్ కోసం అవసరం"
-    },
-    "gitlabTokenTooltip": {
-        "message": "GitLab టోకెన్‌ను జోడించడం ఎందుకు సిఫారసు చేయబడుతుంది? Scrum Helper పబ్లిక్ ప్రాజెక్ట్‌ల కోసం GitLab టోకెన్ లేకుండా పనిచేస్తుంది, కానీ మెరుగైన అనుభవం కోసం ఒక ఖాతా ఆక్సెస్ టోకెన్‌ను జోడించడం సిఫారసు చేయబడుతుంది."
-    },
-    "showCommitsLabel": {
-        "message": "ఓపెన్ PRలు / డ్రాఫ్ట్ PRలపై కమిట్లు చూపించు"
-    },
-    "showCommitsTooltip": {
-        "message": "GitHub టోకెన్ అవసరం — దయచేసి సెట్టింగ్స్‌లో జోడించండి."
-    },
-    "onlyIssuesLabel": {
-        "message": "నివేదికలో ఇష్యూలను మాత్రమే చేర్చు"
-    },
-    "onlyIssuesTooltip": {
-        "message": "ఎంచుకుంటే, నివేదికలో వాడుకరికి కేటాయించబడిన లేదా సృష్టించబడిన ఇష్యూలు మాత్రమే చూపబడతాయి."
-    },
-    "onlyPRsLabel": {
-        "message": "నివేదికలో PRలను మాత్రమే చేర్చు"
-    },
-    "onlyPRsTooltip": {
-        "message": "ఎంచుకుంటే, నివేదికలో మీరు సృష్టించిన PRలు మాత్రమే ఉంటాయి. సమీక్షించిన PRలు తప్పించబడతాయి."
-    },
-    "cacheTTLLabel": {
-        "message": "క్యాష్ TTL ను నమోదు చేయండి"
-    },
-    "cacheTTLUnit": {
-        "message": "(నిమిషాలలో)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "క్యాష్ TTL ని నిమిషాలలో రాయండి (డిఫాల్ట్ 10 నిమిషాలు)"
-    },
-    "refreshDataButton": {
-        "message": "డేటా రీఫ్రెష్ చేయండి (క్యాష్‌ను దాటవేయండి)"
-    },
-    "refreshDataInfo": {
-        "message": "తాజా డేటాను వెంటనే తెచ్చుకోవడానికి ఈ బటన్‌ను ఉపయోగించండి."
-    },
-    "noteTitle": {
-        "message": "గమనిక:"
-    },
-    "viewCodeButton": {
-        "message": "కోడ్ చూడండి"
-    },
-    "reportIssueButton": {
-        "message": "సమస్యను నివేదించండి"
-    },
-    "repoFilterLabel": {
-        "message": "రిపోజిటరీల ద్వారా ఫిల్టర్ చేయండి"
-    },
-    "enableFilteringLabel": {
-        "message": "ఫిల్టరింగ్‌ని ప్రారంభించండి"
-    },
-    "tokenRequiredWarning": {
-        "message": "రిపోజిటరీ ఫిల్టరింగ్ కోసం GitHub టోకెన్ అవసరం. దయచేసి సెట్టింగ్‌లలో ఒకదాన్ని జోడించండి."
-    },
-    "repoSearchPlaceholder": {
-        "message": "రిపోజిటరీల కోసం శోధించండి..."
-    },
-    "repoPlaceholder": {
-        "message": "ఎంచుకున్న రిపోజిటరీలు లేవు (అన్నీ చేర్చబడతాయి)"
-    },
-    "repoCountNone": {
-        "message": "0 రిపోజిటరీలు ఎంచుకోబడ్డాయి"
-    },
-    "repoCount": {
-        "message": "$1 రిపోజిటరీలు ఎంపిక చేయబడ్డాయి"
-    },
-    "repoLoading": {
-        "message": "రిపోజిటరీలు లోడ్ అవుతున్నాయి..."
-    },
-    "repoLoaded": {
-        "message": "$1 రిపోజిటరీలు లోడ్ అయ్యాయి."
-    },
-    "repoNotFound": {
-        "message": "రిపోజిటరీలు కనబడలేదు"
-    },
-    "repoRefetching": {
-        "message": "రిపోజిటరీలను మళ్లీ తెచ్చుకుంటున్నారు..."
-    },
-    "repoLoadFailed": {
-        "message": "రిపోజిటరీలను లోడ్ చేయలేకపోయాం."
-    },
-    "repoTokenPrivate": {
-        "message": "టోకెన్ చెల్లదు లేదా ప్రైవేట్ రిపోజిటరీలకు అనుమతి లేదు."
-    },
-    "repoRefetchFailed": {
-        "message": "రిపోజిటరీలను మళ్లీ తెచ్చుకోవడం విఫలమైంది."
-    },
-    "orgSetMessage": {
-        "message": "సంస్థ విజయవంతంగా సెట్ చేయబడింది."
-    },
-    "orgClearedMessage": {
-        "message": "సంస్థ తొలగించబడింది. అన్ని కార్యకలాపాలు తెచ్చుకోవడానికి 'నివేదికను రూపొందించు' పై క్లిక్ చేయండి."
-    },
-    "orgNotFoundMessage": {
-        "message": "GitHub లో సంస్థ కనుగొనబడలేదు."
-    },
-    "orgValidationErrorMessage": {
-        "message": "సంస్థను ధృవీకరించడంలో లోపం."
-    },
-    "refreshingButton": {
-        "message": "రిఫ్రెష్ అవుతోంది..."
-    },
-    "cacheClearFailed": {
-        "message": "క్యాష్ క్లియర్ చేయడం విఫలమైంది."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "జనరేట్ అవుతోంది..."
-    },
-    "copiedButton": {
-        "message": "కాపీ అయింది!"
-    },
-    "orgChangedMessage": {
-        "message": "సంస్థ మార్చబడింది. GitHub కార్యకలాపాలను తెచ్చుకోవడానికి 'నివేదికను రూపొందించు' పై క్లిక్ చేయండి."
-    },
-    "cacheClearedMessage": {
-        "message": "క్యాష్ విజయవంతంగా క్లియర్ చేయబడింది. తాజా డేటా కోసం \"నివేదికను రూపొందించు\" పై క్లిక్ చేయండి."
-    },
-    "cacheExpiredMessage": {
-        "message": "క్యాష్ గడువు ముగిసింది. తాజా డేటా పొందడానికి \"నివేదికను రూపొందించు\" పై క్లిక్ చేయండి.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "కాష్ తొలగించబడింది!"
-    },
-    "extensionDisabledMessage": {
-        "message": "ఎక్స్‌టెన్షన్ నిలిపివేయబడింది. స్క్రమ్ నివేదికలు రూపొందించేందుకు సెట్టింగ్స్‌లో ఎనేబుల్ చేయండి."
-    },
-    "notePoint1": {
-        "message": "పుల్ రిక్వెస్ట్‌లు మీ స్వంత సమీక్షా కార్యాచరణ ఆధారంగా మాత్రమే కాకుండా, ఏ సహకారుని ద్వారా కూడా తీసుకోబడతాయి. పంచుకునే ముందు మీ పనిని ఖచ్చితంగా ప్రతిబింబిస్తుందని నిర్ధారించుకోవడానికి ఉత్పన్నమైన SCRUM నివేదికను సమీక్షించండి మరియు సర్దుబాటు చేయండి."
-    },
-    "noteSeeIssue": {
-        "message": "ఈ ఇష్యూ చూడండి"
-    },
-    "platformLabel": {
-        "message": "ప్లాట్‌ఫారమ్"
-    },
-    "usernameLabel": {
-        "message": "మీ యూజర్‌నేమ్"
-    },
-    "onlyRevPRsLabel": {
-        "message": "నివేదికలో మీరు సమీక్షించిన PRలను మాత్రమే చేర్చు"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "ఎంచుకుంటే, నివేదికలో మీరు సమీక్షించిన PRలు మాత్రమే చూపబడతాయి."
-    },
-    "usernameMissingError": {
-        "message": "యూజర్‌నేమ్ అవసరం."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "నివేదిక తయారవుతోంది..."
-    },
-    "copyingReportNotification": {
-        "message": "నివేదిక కాపీ చేయబడింది!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "నివేదిక ఇమెయిల్‌లో చేర్చబడుతోంది..."
-    },
-    "insertedInEmailNotification": {
-        "message": "నివేదిక ఇమెయిల్‌లో చేర్చబడింది!"
-    }
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "ఎంచుకున్న కాలవ్యవధికి మీ Git కార్యకలాపాలను స్వయంచాలకంగా తెచ్చి, మీ అభివృద్ధి పురోగతిని నివేదించండి"
+	},
+	"disableLabel": {
+		"message": "అచేతనం"
+	},
+	"enableLabel": {
+		"message": "సక్రియం"
+	},
+	"projectNameLabel": {
+		"message": "ప్రాజెక్ట్ పేరు (ఇమెయిల్ విషయంలో వాడబడుతుంది)"
+	},
+	"projectNamePlaceholder": {
+		"message": "మీ ప్రాజెక్ట్ పేరును నమోదు చేయండి"
+	},
+	"githubUsernameLabel": {
+		"message": "మీ GitHub వాడుకరి పేరు"
+	},
+	"gitlabUsernameLabel": {
+		"message": "మీ GitLab వాడుకరి పేరు"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "మీ సహకారాలను తెచ్చుకోవడానికి అవసరం"
+	},
+	"contributionsLabel": {
+		"message": "మీ సహకారాలను ఇక్కడ నుండి తెచ్చుకోండి:"
+	},
+	"last1DayLabel": {
+		"message": "గత రోజు"
+	},
+	"startDateLabel": {
+		"message": "నుండి:"
+	},
+	"endDateLabel": {
+		"message": "వరకు:"
+	},
+	"showOpenClosedLabel": {
+		"message": "PR లేబుళ్లు చూపించు"
+	},
+	"blockersLabel": {
+		"message": "మీరు ఏమి కారణంగా ముందుకు సాగలేకపోతున్నారు?"
+	},
+	"blockersPlaceholder": {
+		"message": "మీ కారణం ఇక్కడ రాయండి"
+	},
+	"scrumReportLabel": {
+		"message": "స్క్రమ్ నివేదిక"
+	},
+	"generateReportButton": {
+		"message": "సృష్టించు"
+	},
+	"copyReportButton": {
+		"message": "కాపీ"
+	},
+	"insertInEmailButton": {
+		"message": "ఇమెయిల్‌లో చేర్చు"
+	},
+	"settingsOrgNameLabel": {
+		"message": "సంస్థ పేరు"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "సంస్థ పేరును నమోదు చేయండి"
+	},
+	"setButton": {
+		"message": "సెట్ చేయి"
+	},
+	"githubTokenLabel": {
+		"message": "మీ GitHub టోకెన్"
+	},
+	"githubTokenPlaceholder": {
+		"message": "ఆథెంటికేటెడ్ అభ్యర్థనలకు అవసరం"
+	},
+	"githubTokenTooltip": {
+		"message": "GitHub టోకెన్‌ను జోడించడం ఎందుకు సిఫారసు చేయబడుతుంది? Scrum Helper GitHub టోకెన్ లేకుండా పనిచేస్తుంది, కాని మెరుగైన అనుభవం కోసం ఒక ఖాతా ఆక్సెస్ టోకెన్‌ను జోడించడం సిఫారసు చేయబడుతుంది."
+	},
+	"gitlabTokenLabel": {
+		"message": "మీ GitLab టోకెన్"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "ప్రైవేట్ రెపోస్ కోసం అవసరం"
+	},
+	"gitlabTokenTooltip": {
+		"message": "GitLab టోకెన్‌ను జోడించడం ఎందుకు సిఫారసు చేయబడుతుంది? Scrum Helper పబ్లిక్ ప్రాజెక్ట్‌ల కోసం GitLab టోకెన్ లేకుండా పనిచేస్తుంది, కానీ మెరుగైన అనుభవం కోసం ఒక ఖాతా ఆక్సెస్ టోకెన్‌ను జోడించడం సిఫారసు చేయబడుతుంది."
+	},
+	"showCommitsLabel": {
+		"message": "ఓపెన్ PRలు / డ్రాఫ్ట్ PRలపై కమిట్లు చూపించు"
+	},
+	"showCommitsTooltip": {
+		"message": "GitHub టోకెన్ అవసరం — దయచేసి సెట్టింగ్స్‌లో జోడించండి."
+	},
+	"onlyIssuesLabel": {
+		"message": "నివేదికలో ఇష్యూలను మాత్రమే చేర్చు"
+	},
+	"onlyIssuesTooltip": {
+		"message": "ఎంచుకుంటే, నివేదికలో వాడుకరికి కేటాయించబడిన లేదా సృష్టించబడిన ఇష్యూలు మాత్రమే చూపబడతాయి."
+	},
+	"onlyPRsLabel": {
+		"message": "నివేదికలో PRలను మాత్రమే చేర్చు"
+	},
+	"onlyPRsTooltip": {
+		"message": "ఎంచుకుంటే, నివేదికలో మీరు సృష్టించిన PRలు మాత్రమే ఉంటాయి. సమీక్షించిన PRలు తప్పించబడతాయి."
+	},
+	"cacheTTLLabel": {
+		"message": "క్యాష్ TTL ను నమోదు చేయండి"
+	},
+	"cacheTTLUnit": {
+		"message": "(నిమిషాలలో)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "క్యాష్ TTL ని నిమిషాలలో రాయండి (డిఫాల్ట్ 10 నిమిషాలు)"
+	},
+	"refreshDataButton": {
+		"message": "డేటా రీఫ్రెష్ చేయండి (క్యాష్‌ను దాటవేయండి)"
+	},
+	"refreshDataInfo": {
+		"message": "తాజా డేటాను వెంటనే తెచ్చుకోవడానికి ఈ బటన్‌ను ఉపయోగించండి."
+	},
+	"noteTitle": {
+		"message": "గమనిక:"
+	},
+	"viewCodeButton": {
+		"message": "కోడ్ చూడండి"
+	},
+	"reportIssueButton": {
+		"message": "సమస్యను నివేదించండి"
+	},
+	"repoFilterLabel": {
+		"message": "రిపోజిటరీల ద్వారా ఫిల్టర్ చేయండి"
+	},
+	"enableFilteringLabel": {
+		"message": "ఫిల్టరింగ్‌ని ప్రారంభించండి"
+	},
+	"tokenRequiredWarning": {
+		"message": "రిపోజిటరీ ఫిల్టరింగ్ కోసం GitHub టోకెన్ అవసరం. దయచేసి సెట్టింగ్‌లలో ఒకదాన్ని జోడించండి."
+	},
+	"repoSearchPlaceholder": {
+		"message": "రిపోజిటరీల కోసం శోధించండి..."
+	},
+	"repoPlaceholder": {
+		"message": "ఎంచుకున్న రిపోజిటరీలు లేవు (అన్నీ చేర్చబడతాయి)"
+	},
+	"repoCountNone": {
+		"message": "0 రిపోజిటరీలు ఎంచుకోబడ్డాయి"
+	},
+	"repoCount": {
+		"message": "$1 రిపోజిటరీలు ఎంపిక చేయబడ్డాయి"
+	},
+	"repoLoading": {
+		"message": "రిపోజిటరీలు లోడ్ అవుతున్నాయి..."
+	},
+	"repoLoaded": {
+		"message": "$1 రిపోజిటరీలు లోడ్ అయ్యాయి."
+	},
+	"repoNotFound": {
+		"message": "రిపోజిటరీలు కనబడలేదు"
+	},
+	"repoRefetching": {
+		"message": "రిపోజిటరీలను మళ్లీ తెచ్చుకుంటున్నారు..."
+	},
+	"repoLoadFailed": {
+		"message": "రిపోజిటరీలను లోడ్ చేయలేకపోయాం."
+	},
+	"repoTokenPrivate": {
+		"message": "టోకెన్ చెల్లదు లేదా ప్రైవేట్ రిపోజిటరీలకు అనుమతి లేదు."
+	},
+	"repoRefetchFailed": {
+		"message": "రిపోజిటరీలను మళ్లీ తెచ్చుకోవడం విఫలమైంది."
+	},
+	"orgSetMessage": {
+		"message": "సంస్థ విజయవంతంగా సెట్ చేయబడింది."
+	},
+	"orgClearedMessage": {
+		"message": "సంస్థ తొలగించబడింది. అన్ని కార్యకలాపాలు తెచ్చుకోవడానికి 'నివేదికను రూపొందించు' పై క్లిక్ చేయండి."
+	},
+	"orgNotFoundMessage": {
+		"message": "GitHub లో సంస్థ కనుగొనబడలేదు."
+	},
+	"orgValidationErrorMessage": {
+		"message": "సంస్థను ధృవీకరించడంలో లోపం."
+	},
+	"refreshingButton": {
+		"message": "రిఫ్రెష్ అవుతోంది..."
+	},
+	"cacheClearFailed": {
+		"message": "క్యాష్ క్లియర్ చేయడం విఫలమైంది."
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "జనరేట్ అవుతోంది..."
+	},
+	"copiedButton": {
+		"message": "కాపీ అయింది!"
+	},
+	"orgChangedMessage": {
+		"message": "సంస్థ మార్చబడింది. GitHub కార్యకలాపాలను తెచ్చుకోవడానికి 'నివేదికను రూపొందించు' పై క్లిక్ చేయండి."
+	},
+	"cacheClearedMessage": {
+		"message": "క్యాష్ విజయవంతంగా క్లియర్ చేయబడింది. తాజా డేటా కోసం \"నివేదికను రూపొందించు\" పై క్లిక్ చేయండి."
+	},
+	"cacheExpiredMessage": {
+		"message": "క్యాష్ గడువు ముగిసింది. తాజా డేటా పొందడానికి \"నివేదికను రూపొందించు\" పై క్లిక్ చేయండి.",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "కాష్ తొలగించబడింది!"
+	},
+	"extensionDisabledMessage": {
+		"message": "ఎక్స్‌టెన్షన్ నిలిపివేయబడింది. స్క్రమ్ నివేదికలు రూపొందించేందుకు సెట్టింగ్స్‌లో ఎనేబుల్ చేయండి."
+	},
+	"notePoint1": {
+		"message": "పుల్ రిక్వెస్ట్‌లు మీ స్వంత సమీక్షా కార్యాచరణ ఆధారంగా మాత్రమే కాకుండా, ఏ సహకారుని ద్వారా కూడా తీసుకోబడతాయి. పంచుకునే ముందు మీ పనిని ఖచ్చితంగా ప్రతిబింబిస్తుందని నిర్ధారించుకోవడానికి ఉత్పన్నమైన SCRUM నివేదికను సమీక్షించండి మరియు సర్దుబాటు చేయండి."
+	},
+	"noteSeeIssue": {
+		"message": "ఈ ఇష్యూ చూడండి"
+	},
+	"platformLabel": {
+		"message": "ప్లాట్‌ఫారమ్"
+	},
+	"usernameLabel": {
+		"message": "మీ యూజర్‌నేమ్"
+	},
+	"onlyRevPRsLabel": {
+		"message": "నివేదికలో మీరు సమీక్షించిన PRలను మాత్రమే చేర్చు"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "ఎంచుకుంటే, నివేదికలో మీరు సమీక్షించిన PRలు మాత్రమే చూపబడతాయి."
+	},
+	"usernameMissingError": {
+		"message": "యూజర్‌నేమ్ అవసరం."
+	},
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"generatingReportNotification": {
+		"message": "నివేదిక తయారవుతోంది..."
+	},
+	"copyingReportNotification": {
+		"message": "నివేదిక కాపీ చేయబడింది!"
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "నివేదిక ఇమెయిల్‌లో చేర్చబడుతోంది..."
+	},
+	"insertedInEmailNotification": {
+		"message": "నివేదిక ఇమెయిల్‌లో చేర్చబడింది!"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Звітуйте про свій прогрес у розробці, автоматично отримуючи вашу активність у Git за вибраний період."
-    },
-    "disableLabel": {
-        "message": "Вимкнути"
-    },
-    "enableLabel": {
-        "message": "Увімкнути"
-    },
-    "projectNameLabel": {
-        "message": "Назва проекту (використовується в темі електронного листа)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Введіть назву вашого проекту"
-    },
-    "githubUsernameLabel": {
-        "message": "Ваше ім'я користувача GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Ваше ім'я користувача GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Потрібно для отримання ваших внесків"
-    },
-    "contributionsLabel": {
-        "message": "Отримати ваші внески за:"
-    },
-    "last1DayLabel": {
-        "message": "Попередній день"
-    },
-    "startDateLabel": {
-        "message": "З:"
-    },
-    "endDateLabel": {
-        "message": "По:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Показувати статус Відкрито/Закрито"
-    },
-    "blockersLabel": {
-        "message": "Що заважає вашому прогресу?"
-    },
-    "blockersPlaceholder": {
-        "message": "Введіть вашу причину"
-    },
-    "scrumReportLabel": {
-        "message": "Звіт Scrum"
-    },
-    "generateReportButton": {
-        "message": "Створити звіт"
-    },
-    "copyReportButton": {
-        "message": "Копіювати звіт"
-    },
-    "insertInEmailButton": {
-        "message": "Вставити в електронний лист",
-        "description": "Text for the 'Insert to Email' button."
-    },
-    "settingsOrgNameLabel": {
-        "message": "Назва організації"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Введіть назву організації"
-    },
-    "setButton": {
-        "message": "Встановити"
-    },
-    "githubTokenLabel": {
-        "message": "Ваш токен GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Потрібно для автентифікованих запитів"
-    },
-    "githubTokenTooltip": {
-        "message": "Чому рекомендується додати токен GitHub? Scrum Helper працює без токена GitHub, але додавання особистого токена доступу рекомендується для кращого досвіду."
-    },
-    "gitlabTokenLabel": {
-        "message": "Ваш токен GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Потрібно для доступу до приватних проектів"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Чому рекомендується додати токен GitLab? Scrum Helper працює без токена GitLab для публічних проектів, але додавання особистого токена доступу рекомендується для кращого досвіду."
-    },
-    "showCommitsLabel": {
-        "message": "Показувати коміти у відкритих PR/ чернетках PR"
-    },
-    "showCommitsTooltip": {
-        "message": "Потрібен токен GitHub, додайте його в налаштуваннях."
-    },
-    "onlyIssuesLabel": {
-        "message": "Включати до звіту лише проблеми"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Якщо позначено, звіт включатиме лише проблеми, створені користувачем або призначені йому."
-    },
-    "onlyPRsLabel": {
-        "message": "Включати до звіту лише PR"
-    },
-    "onlyPRsTooltip": {
-        "message": "Якщо позначено, звіт включатиме лише pull requests, створені користувачем; переглянуті PR будуть виключені."
-    },
-    "cacheTTLLabel": {
-        "message": "Введіть TTL кешу"
-    },
-    "cacheTTLUnit": {
-        "message": "(у хвилинах)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Введіть TTL кешу в хвилинах (За замовчуванням: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Оновити дані (обійти кеш)"
-    },
-    "refreshDataInfo": {
-        "message": "Використовуйте цю кнопку, щоб негайно отримати свіжі дані."
-    },
-    "noteTitle": {
-        "message": "Примітка:"
-    },
-    "viewCodeButton": {
-        "message": "Переглянути код"
-    },
-    "reportIssueButton": {
-        "message": "Повідомити про проблему"
-    },
-    "repoFilterLabel": {
-        "message": "Фільтрувати за репозиторіями"
-    },
-    "enableFilteringLabel": {
-        "message": "Увімкнути фільтрацію"
-    },
-    "tokenRequiredWarning": {
-        "message": "Для фільтрації репозиторіїв потрібен токен GitHub. Будь ласка, додайте його в налаштуваннях."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Шукати репозиторій для додавання..."
-    },
-    "repoPlaceholder": {
-        "message": "Репозиторії не вибрано (будуть включені всі)"
-    },
-    "repoCountNone": {
-        "message": "Вибрано 0 репозиторіїв"
-    },
-    "repoCount": {
-        "message": "Вибрано $1 репозиторіїв"
-    },
-    "repoLoading": {
-        "message": "Завантаження репозиторіїв..."
-    },
-    "repoLoaded": {
-        "message": "Завантажено $1 репозиторіїв."
-    },
-    "repoNotFound": {
-        "message": "Репозиторіїв не знайдено"
-    },
-    "repoRefetching": {
-        "message": "Повторне завантаження репозиторіїв..."
-    },
-    "repoLoadFailed": {
-        "message": "Не вдалося завантажити репозиторії."
-    },
-    "repoTokenPrivate": {
-        "message": "Токен недійсний або не має прав для приватних репозиторіїв."
-    },
-    "repoRefetchFailed": {
-        "message": "Не вдалося повторно завантажити репозиторії."
-    },
-    "orgSetMessage": {
-        "message": "Організацію встановлено успішно."
-    },
-    "orgClearedMessage": {
-        "message": "Організацію очищено. Натисніть 'Створити звіт', щоб отримати всі активності."
-    },
-    "orgNotFoundMessage": {
-        "message": "Організацію не знайдено на GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Помилка під час перевірки організації."
-    },
-    "refreshingButton": {
-        "message": "Оновлення..."
-    },
-    "cacheClearFailed": {
-        "message": "Не вдалося очистити кеш."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Створення..."
-    },
-    "copiedButton": {
-        "message": "Скопійовано!"
-    },
-    "orgChangedMessage": {
-        "message": "Організацію змінено. Натисніть 'Створити звіт', щоб отримати активності GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Кеш успішно очищено. Натисніть 'Створити звіт', щоб отримати свіжі дані."
-    },
-    "cacheExpiredMessage": {
-        "message": "Кеш закінчився. Натисніть \"Створити\", щоб отримати нові дані.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Кеш очищено!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Розширення вимкнено. Увімкніть його в налаштуваннях, щоб створювати звіти scrum."
-    },
-    "notePoint1": {
-        "message": "Pull-запити отримуються на основі останньої активності рецензування будь-якого учасника, а не лише вашої. Будь ласка, перегляньте та відкоригуйте згенерований звіт SCRUM, щоб переконатися, що він точно відображає вашу роботу, перш ніж ділитися ним."
-    },
-    "noteSeeIssue": {
-        "message": "Дивіться цю проблему"
-    },
-    "platformLabel": {
-        "message": "Платформа"
-    },
-    "usernameLabel": {
-        "message": "Ваше ім'я користувача"
-    },
-    "usernameRequiredError": {
-        "message": "Будь ласка, введіть ім'я користувача для створення звіту."
-    },
-    "unknownPlatformError": {
-        "message": "Вибрано невідому платформу."
-    },
-    "gitlabFetchingError": {
-        "message": "Сталася помилка під час отримання даних GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Сталася помилка під час створення звіту."
-    },
-    "githubUserNotFoundError": {
-        "message": "Користувача GitHub \"$1\" не знайдено (404). Перевірте ім'я користувача і спробуйте ще раз."
-    },
-    "githubUserValidationError": {
-        "message": "Помилка під час перевірки користувача GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Недійсний пошуковий запит або діапазон дат. Перевірте формат і спробуйте ще раз."
-    },
-    "githubIssuesFetchError": {
-        "message": "Помилка під час отримання задач GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Помилка під час отримання даних перевірки PR GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Помилка під час отримання даних користувача GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Недійсний або прострочений токен GitHub. Перевірте токен у налаштуваннях Scrum Helper і спробуйте ще раз."
-    },
-    "displayModeNotice": {
-        "message": "Розширення відкриється в режимі $1 при наступному запуску."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Фільтрація репозиторіїв доступна лише для GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Завантаження репозиторіїв доступне лише для GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Отримання репозиторіїв доступне лише для GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Репозиторії завантажуються автоматично..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Помилка під час отримання користувача GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Користувача GitLab '$1' не знайдено"
-    },
-    "gitlabMembershipError": {
-        "message": "Помилка під час отримання проектів членства GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Помилка під час отримання проектів з внеском GitLab: $1 $2"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Включати до звіту лише переглянуті PR"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Якщо позначено, звіт включатиме лише PR, переглянуті вами."
-    },
-    "usernameMissingError": {
-        "message": "Потрібне ім'я користувача."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Генерація звіту..."
-    },
-    "copyingReportNotification": {
-        "message": "Копіювання звіту..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Вставка звіту в лист..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Звіт вставлено в лист!"
-    }
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "Звітуйте про свій прогрес у розробці, автоматично отримуючи вашу активність у Git за вибраний період."
+	},
+	"disableLabel": {
+		"message": "Вимкнути"
+	},
+	"enableLabel": {
+		"message": "Увімкнути"
+	},
+	"projectNameLabel": {
+		"message": "Назва проекту (використовується в темі електронного листа)"
+	},
+	"projectNamePlaceholder": {
+		"message": "Введіть назву вашого проекту"
+	},
+	"githubUsernameLabel": {
+		"message": "Ваше ім'я користувача GitHub"
+	},
+	"gitlabUsernameLabel": {
+		"message": "Ваше ім'я користувача GitLab"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "Потрібно для отримання ваших внесків"
+	},
+	"contributionsLabel": {
+		"message": "Отримати ваші внески за:"
+	},
+	"last1DayLabel": {
+		"message": "Попередній день"
+	},
+	"startDateLabel": {
+		"message": "З:"
+	},
+	"endDateLabel": {
+		"message": "По:"
+	},
+	"showOpenClosedLabel": {
+		"message": "Показувати статус Відкрито/Закрито"
+	},
+	"blockersLabel": {
+		"message": "Що заважає вашому прогресу?"
+	},
+	"blockersPlaceholder": {
+		"message": "Введіть вашу причину"
+	},
+	"scrumReportLabel": {
+		"message": "Звіт Scrum"
+	},
+	"generateReportButton": {
+		"message": "Створити звіт"
+	},
+	"copyReportButton": {
+		"message": "Копіювати звіт"
+	},
+	"insertInEmailButton": {
+		"message": "Вставити в електронний лист",
+		"description": "Text for the 'Insert to Email' button."
+	},
+	"settingsOrgNameLabel": {
+		"message": "Назва організації"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "Введіть назву організації"
+	},
+	"setButton": {
+		"message": "Встановити"
+	},
+	"githubTokenLabel": {
+		"message": "Ваш токен GitHub"
+	},
+	"githubTokenPlaceholder": {
+		"message": "Потрібно для автентифікованих запитів"
+	},
+	"githubTokenTooltip": {
+		"message": "Чому рекомендується додати токен GitHub? Scrum Helper працює без токена GitHub, але додавання особистого токена доступу рекомендується для кращого досвіду."
+	},
+	"gitlabTokenLabel": {
+		"message": "Ваш токен GitLab"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "Потрібно для доступу до приватних проектів"
+	},
+	"gitlabTokenTooltip": {
+		"message": "Чому рекомендується додати токен GitLab? Scrum Helper працює без токена GitLab для публічних проектів, але додавання особистого токена доступу рекомендується для кращого досвіду."
+	},
+	"showCommitsLabel": {
+		"message": "Показувати коміти у відкритих PR/ чернетках PR"
+	},
+	"showCommitsTooltip": {
+		"message": "Потрібен токен GitHub, додайте його в налаштуваннях."
+	},
+	"onlyIssuesLabel": {
+		"message": "Включати до звіту лише проблеми"
+	},
+	"onlyIssuesTooltip": {
+		"message": "Якщо позначено, звіт включатиме лише проблеми, створені користувачем або призначені йому."
+	},
+	"onlyPRsLabel": {
+		"message": "Включати до звіту лише PR"
+	},
+	"onlyPRsTooltip": {
+		"message": "Якщо позначено, звіт включатиме лише pull requests, створені користувачем; переглянуті PR будуть виключені."
+	},
+	"cacheTTLLabel": {
+		"message": "Введіть TTL кешу"
+	},
+	"cacheTTLUnit": {
+		"message": "(у хвилинах)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "Введіть TTL кешу в хвилинах (За замовчуванням: 10)"
+	},
+	"refreshDataButton": {
+		"message": "Оновити дані (обійти кеш)"
+	},
+	"refreshDataInfo": {
+		"message": "Використовуйте цю кнопку, щоб негайно отримати свіжі дані."
+	},
+	"noteTitle": {
+		"message": "Примітка:"
+	},
+	"viewCodeButton": {
+		"message": "Переглянути код"
+	},
+	"reportIssueButton": {
+		"message": "Повідомити про проблему"
+	},
+	"repoFilterLabel": {
+		"message": "Фільтрувати за репозиторіями"
+	},
+	"enableFilteringLabel": {
+		"message": "Увімкнути фільтрацію"
+	},
+	"tokenRequiredWarning": {
+		"message": "Для фільтрації репозиторіїв потрібен токен GitHub. Будь ласка, додайте його в налаштуваннях."
+	},
+	"repoSearchPlaceholder": {
+		"message": "Шукати репозиторій для додавання..."
+	},
+	"repoPlaceholder": {
+		"message": "Репозиторії не вибрано (будуть включені всі)"
+	},
+	"repoCountNone": {
+		"message": "Вибрано 0 репозиторіїв"
+	},
+	"repoCount": {
+		"message": "Вибрано $1 репозиторіїв"
+	},
+	"repoLoading": {
+		"message": "Завантаження репозиторіїв..."
+	},
+	"repoLoaded": {
+		"message": "Завантажено $1 репозиторіїв."
+	},
+	"repoNotFound": {
+		"message": "Репозиторіїв не знайдено"
+	},
+	"repoRefetching": {
+		"message": "Повторне завантаження репозиторіїв..."
+	},
+	"repoLoadFailed": {
+		"message": "Не вдалося завантажити репозиторії."
+	},
+	"repoTokenPrivate": {
+		"message": "Токен недійсний або не має прав для приватних репозиторіїв."
+	},
+	"repoRefetchFailed": {
+		"message": "Не вдалося повторно завантажити репозиторії."
+	},
+	"orgSetMessage": {
+		"message": "Організацію встановлено успішно."
+	},
+	"orgClearedMessage": {
+		"message": "Організацію очищено. Натисніть 'Створити звіт', щоб отримати всі активності."
+	},
+	"orgNotFoundMessage": {
+		"message": "Організацію не знайдено на GitHub."
+	},
+	"orgValidationErrorMessage": {
+		"message": "Помилка під час перевірки організації."
+	},
+	"refreshingButton": {
+		"message": "Оновлення..."
+	},
+	"cacheClearFailed": {
+		"message": "Не вдалося очистити кеш."
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "Створення..."
+	},
+	"copiedButton": {
+		"message": "Скопійовано!"
+	},
+	"orgChangedMessage": {
+		"message": "Організацію змінено. Натисніть 'Створити звіт', щоб отримати активності GitHub."
+	},
+	"cacheClearedMessage": {
+		"message": "Кеш успішно очищено. Натисніть 'Створити звіт', щоб отримати свіжі дані."
+	},
+	"cacheExpiredMessage": {
+		"message": "Кеш закінчився. Натисніть \"Створити\", щоб отримати нові дані.",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "Кеш очищено!"
+	},
+	"extensionDisabledMessage": {
+		"message": "Розширення вимкнено. Увімкніть його в налаштуваннях, щоб створювати звіти scrum."
+	},
+	"notePoint1": {
+		"message": "Pull-запити отримуються на основі останньої активності рецензування будь-якого учасника, а не лише вашої. Будь ласка, перегляньте та відкоригуйте згенерований звіт SCRUM, щоб переконатися, що він точно відображає вашу роботу, перш ніж ділитися ним."
+	},
+	"noteSeeIssue": {
+		"message": "Дивіться цю проблему"
+	},
+	"platformLabel": {
+		"message": "Платформа"
+	},
+	"usernameLabel": {
+		"message": "Ваше ім'я користувача"
+	},
+	"usernameRequiredError": {
+		"message": "Будь ласка, введіть ім'я користувача для створення звіту."
+	},
+	"unknownPlatformError": {
+		"message": "Вибрано невідому платформу."
+	},
+	"gitlabFetchingError": {
+		"message": "Сталася помилка під час отримання даних GitLab."
+	},
+	"reportGenerationError": {
+		"message": "Сталася помилка під час створення звіту."
+	},
+	"githubUserNotFoundError": {
+		"message": "Користувача GitHub \"$1\" не знайдено (404). Перевірте ім'я користувача і спробуйте ще раз."
+	},
+	"githubUserValidationError": {
+		"message": "Помилка під час перевірки користувача GitHub: $1 $2"
+	},
+	"invalidSearchQueryError": {
+		"message": "Недійсний пошуковий запит або діапазон дат. Перевірте формат і спробуйте ще раз."
+	},
+	"githubIssuesFetchError": {
+		"message": "Помилка під час отримання задач GitHub: $1 $2"
+	},
+	"githubPRReviewFetchError": {
+		"message": "Помилка під час отримання даних перевірки PR GitHub: $1 $2"
+	},
+	"githubUserFetchError": {
+		"message": "Помилка під час отримання даних користувача GitHub: $1 $2"
+	},
+	"invalidTokenError": {
+		"message": "Недійсний або прострочений токен GitHub. Перевірте токен у налаштуваннях Scrum Helper і спробуйте ще раз."
+	},
+	"displayModeNotice": {
+		"message": "Розширення відкриється в режимі $1 при наступному запуску."
+	},
+	"repoFilteringGithubOnly": {
+		"message": "Фільтрація репозиторіїв доступна лише для GitHub."
+	},
+	"repoLoadingGithubOnly": {
+		"message": "Завантаження репозиторіїв доступне лише для GitHub."
+	},
+	"repoFetchingGithubOnly": {
+		"message": "Отримання репозиторіїв доступне лише для GitHub."
+	},
+	"loadingReposAutomatically": {
+		"message": "Репозиторії завантажуються автоматично..."
+	},
+	"gitlabUserFetchError": {
+		"message": "Помилка під час отримання користувача GitLab: $1 $2"
+	},
+	"gitlabUserNotFoundError": {
+		"message": "Користувача GitLab '$1' не знайдено"
+	},
+	"gitlabMembershipError": {
+		"message": "Помилка під час отримання проектів членства GitLab: $1 $2"
+	},
+	"gitlabContributedError": {
+		"message": "Помилка під час отримання проектів з внеском GitLab: $1 $2"
+	},
+	"onlyRevPRsLabel": {
+		"message": "Включати до звіту лише переглянуті PR"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "Якщо позначено, звіт включатиме лише PR, переглянуті вами."
+	},
+	"usernameMissingError": {
+		"message": "Потрібне ім'я користувача."
+	},
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"generatingReportNotification": {
+		"message": "Генерація звіту..."
+	},
+	"copyingReportNotification": {
+		"message": "Копіювання звіту..."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "Вставка звіту в лист..."
+	},
+	"insertedInEmailNotification": {
+		"message": "Звіт вставлено в лист!"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Báo cáo tiến độ phát triển của bạn bằng cách tự động lấy hoạt động Git trong một khoảng thời gian đã chọn."
-    },
-    "disableLabel": {
-        "message": "Tắt"
-    },
-    "enableLabel": {
-        "message": "Bật"
-    },
-    "projectNameLabel": {
-        "message": "Tên dự án (sử dụng trong chủ đề email)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Nhập tên dự án của bạn"
-    },
-    "githubUsernameLabel": {
-        "message": "Tên người dùng GitHub của bạn"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Tên người dùng GitLab của bạn"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Bắt buộc để lấy các đóng góp của bạn"
-    },
-    "contributionsLabel": {
-        "message": "Lấy đóng góp của bạn trong:"
-    },
-    "last1DayLabel": {
-        "message": "Ngày trước"
-    },
-    "startDateLabel": {
-        "message": "Từ:"
-    },
-    "endDateLabel": {
-        "message": "Đến:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Hiển thị trạng thái Mở/Đóng"
-    },
-    "blockersLabel": {
-        "message": "Điều gì đang cản trở bạn?"
-    },
-    "blockersPlaceholder": {
-        "message": "Nhập lý do của bạn"
-    },
-    "scrumReportLabel": {
-        "message": "Báo cáo Scrum"
-    },
-    "generateReportButton": {
-        "message": "Tạo"
-    },
-    "copyReportButton": {
-        "message": "Sao chép"
-    },
-    "insertInEmailButton": {
-        "message": "Chèn vào email"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Tên tổ chức"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Nhập tên tổ chức"
-    },
-    "setButton": {
-        "message": "Đặt"
-    },
-    "githubTokenLabel": {
-        "message": "Mã token GitHub của bạn"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Bắt buộc cho các yêu cầu đã xác thực"
-    },
-    "githubTokenTooltip": {
-        "message": "Tại sao nên thêm mã token GitHub? Scrum Helper hoạt động mà không cần mã token GitHub, nhưng việc thêm mã thông báo truy cập cá nhân được khuyến nghị để có trải nghiệm tốt hơn."
-    },
-    "gitlabTokenLabel": {
-        "message": "Mã token GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Bắt buộc cho repo riêng tư"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Tại sao nên thêm mã token GitLab? Scrum Helper hoạt động mà không cần mã token GitLab cho các dự án công khai, nhưng việc thêm mã thông báo truy cập cá nhân được khuyến nghị để có trải nghiệm tốt hơn."
-    },
-    "showCommitsLabel": {
-        "message": "Hiển thị các commit trên PR đang mở/ PR nháp"
-    },
-    "showCommitsTooltip": {
-        "message": "Yêu cầu mã thông báo Github, hãy thêm nó trong cài đặt."
-    },
-    "onlyIssuesLabel": {
-        "message": "Chỉ bao gồm các vấn đề trong báo cáo"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Nếu được chọn, báo cáo sẽ chỉ bao gồm các vấn đề do người dùng tạo hoặc được giao."
-    },
-    "onlyPRsLabel": {
-        "message": "Chỉ bao gồm PR trong báo cáo"
-    },
-    "onlyPRsTooltip": {
-        "message": "Nếu được chọn, báo cáo chỉ bao gồm các pull request do người dùng tạo; các PR đã được xem xét sẽ bị loại trừ."
-    },
-    "cacheTTLLabel": {
-        "message": "Nhập TTL bộ nhớ cache",
-        "description": "Nhãn cho đầu vào thời gian tồn tại của bộ nhớ cache."
-    },
-    "cacheTTLUnit": {
-        "message": "(tính bằng phút)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Nhập TTL bộ nhớ đệm bằng phút (Mặc định: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Làm mới dữ liệu (bỏ qua bộ nhớ đệm)"
-    },
-    "refreshDataInfo": {
-        "message": "Sử dụng nút này để lấy dữ liệu mới ngay lập tức."
-    },
-    "noteTitle": {
-        "message": "Lưu ý:"
-    },
-    "viewCodeButton": {
-        "message": "Xem mã"
-    },
-    "reportIssueButton": {
-        "message": "Báo cáo sự cố"
-    },
-    "repoFilterLabel": {
-        "message": "Lọc theo kho lưu trữ"
-    },
-    "enableFilteringLabel": {
-        "message": "Bật bộ lọc"
-    },
-    "tokenRequiredWarning": {
-        "message": "Cần có mã token GitHub để lọc kho lưu trữ. Vui lòng thêm một mã trong cài đặt."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Tìm kiếm kho lưu trữ để thêm..."
-    },
-    "repoPlaceholder": {
-        "message": "Chưa chọn kho lưu trữ nào (tất cả sẽ được bao gồm)"
-    },
-    "repoCountNone": {
-        "message": "0 kho lưu trữ đã chọn"
-    },
-    "repoCount": {
-        "message": "$1 kho lưu trữ đã chọn"
-    },
-    "repoLoading": {
-        "message": "Đang tải kho lưu trữ..."
-    },
-    "repoLoaded": {
-        "message": "Đã tải $1 kho lưu trữ."
-    },
-    "repoNotFound": {
-        "message": "Không tìm thấy kho lưu trữ nào"
-    },
-    "repoRefetching": {
-        "message": "Đang tải lại kho lưu trữ..."
-    },
-    "repoLoadFailed": {
-        "message": "Không thể tải kho lưu trữ."
-    },
-    "repoTokenPrivate": {
-        "message": "Mã token không hợp lệ hoặc không có quyền đối với kho lưu trữ riêng tư."
-    },
-    "repoRefetchFailed": {
-        "message": "Không thể tải lại kho lưu trữ."
-    },
-    "orgSetMessage": {
-        "message": "Tổ chức đã được đặt thành công."
-    },
-    "orgClearedMessage": {
-        "message": "Đã xóa tổ chức. Nhấp vào 'Tạo báo cáo' để lấy tất cả hoạt động."
-    },
-    "orgNotFoundMessage": {
-        "message": "Không tìm thấy tổ chức trên GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Lỗi khi xác thực tổ chức."
-    },
-    "refreshingButton": {
-        "message": "Đang làm mới..."
-    },
-    "cacheClearFailed": {
-        "message": "Xóa bộ nhớ đệm thất bại."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Đang tạo..."
-    },
-    "copiedButton": {
-        "message": "Đã sao chép!"
-    },
-    "orgChangedMessage": {
-        "message": "Tổ chức đã thay đổi. Nhấp vào 'Tạo báo cáo' để lấy các hoạt động trên GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Bộ nhớ đệm đã được xóa thành công. Nhấp vào 'Tạo báo cáo' để lấy dữ liệu mới."
-    },
-    "cacheExpiredMessage": {
-        "message": "Bộ nhớ đệm đã hết hạn. Nhấp vào \"Tạo\" để lấy dữ liệu mới.",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "Đã xóa bộ nhớ đệm!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Tiện ích mở rộng đã bị tắt. Bật nó từ cài đặt để tạo báo cáo scrum."
-    },
-    "notePoint1": {
-        "message": "Pull request được lấy dựa trên hoạt động đánh giá gần đây nhất của bất kỳ người đóng góp nào, không chỉ của riêng bạn. Vui lòng xem xét và điều chỉnh báo cáo SCRUM được tạo để đảm bảo nó phản ánh chính xác công việc của bạn trước khi chia sẻ."
-    },
-    "noteSeeIssue": {
-        "message": "Xem vấn đề này"
-    },
-    "platformLabel": {
-        "message": "Nền tảng"
-    },
-    "usernameLabel": {
-        "message": "Tên người dùng của bạn"
-    },
-    "usernameRequiredError": {
-        "message": "Vui lòng nhập tên người dùng để tạo báo cáo."
-    },
-    "unknownPlatformError": {
-        "message": "Đã chọn nền tảng không xác định."
-    },
-    "gitlabFetchingError": {
-        "message": "Đã xảy ra lỗi khi lấy dữ liệu GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Đã xảy ra lỗi khi tạo báo cáo."
-    },
-    "githubUserNotFoundError": {
-        "message": "Không tìm thấy người dùng GitHub \"$1\" (404). Vui lòng kiểm tra tên người dùng và thử lại."
-    },
-    "githubUserValidationError": {
-        "message": "Lỗi khi xác thực người dùng GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Truy vấn tìm kiếm hoặc khoảng ngày không hợp lệ. Vui lòng kiểm tra định dạng và thử lại."
-    },
-    "githubIssuesFetchError": {
-        "message": "Lỗi khi lấy các vấn đề từ GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Lỗi khi lấy dữ liệu đánh giá PR từ GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Lỗi khi lấy dữ liệu người dùng GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Mã token GitHub không hợp lệ hoặc đã hết hạn. Vui lòng kiểm tra mã token trong cài đặt Scrum Helper và thử lại."
-    },
-    "displayModeNotice": {
-        "message": "Tiện ích sẽ mở ở chế độ $1 trong lần khởi động tiếp theo."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Chỉ có thể lọc kho lưu trữ trên GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Chỉ có thể tải kho lưu trữ trên GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Chỉ có thể lấy kho lưu trữ trên GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Đang tự động tải kho lưu trữ..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Lỗi khi lấy người dùng GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Không tìm thấy người dùng GitLab '$1'"
-    },
-    "gitlabMembershipError": {
-        "message": "Lỗi khi lấy dự án thành viên GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Lỗi khi lấy dự án đóng góp GitLab: $1 $2"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Chỉ bao gồm các PR bạn đã xem xét trong báo cáo"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Nếu được chọn, báo cáo sẽ chỉ bao gồm các PR bạn đã xem xét."
-    },
-    "usernameMissingError": {
-        "message": "Yêu cầu tên người dùng."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Đang tạo báo cáo..."
-    },
-    "copyingReportNotification": {
-        "message": "Đang sao chép báo cáo..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Đang chèn báo cáo vào email..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Đã chèn báo cáo vào email!"
-    }
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "Báo cáo tiến độ phát triển của bạn bằng cách tự động lấy hoạt động Git trong một khoảng thời gian đã chọn."
+	},
+	"disableLabel": {
+		"message": "Tắt"
+	},
+	"enableLabel": {
+		"message": "Bật"
+	},
+	"projectNameLabel": {
+		"message": "Tên dự án (sử dụng trong chủ đề email)"
+	},
+	"projectNamePlaceholder": {
+		"message": "Nhập tên dự án của bạn"
+	},
+	"githubUsernameLabel": {
+		"message": "Tên người dùng GitHub của bạn"
+	},
+	"gitlabUsernameLabel": {
+		"message": "Tên người dùng GitLab của bạn"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "Bắt buộc để lấy các đóng góp của bạn"
+	},
+	"contributionsLabel": {
+		"message": "Lấy đóng góp của bạn trong:"
+	},
+	"last1DayLabel": {
+		"message": "Ngày trước"
+	},
+	"startDateLabel": {
+		"message": "Từ:"
+	},
+	"endDateLabel": {
+		"message": "Đến:"
+	},
+	"showOpenClosedLabel": {
+		"message": "Hiển thị trạng thái Mở/Đóng"
+	},
+	"blockersLabel": {
+		"message": "Điều gì đang cản trở bạn?"
+	},
+	"blockersPlaceholder": {
+		"message": "Nhập lý do của bạn"
+	},
+	"scrumReportLabel": {
+		"message": "Báo cáo Scrum"
+	},
+	"generateReportButton": {
+		"message": "Tạo"
+	},
+	"copyReportButton": {
+		"message": "Sao chép"
+	},
+	"insertInEmailButton": {
+		"message": "Chèn vào email"
+	},
+	"settingsOrgNameLabel": {
+		"message": "Tên tổ chức"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "Nhập tên tổ chức"
+	},
+	"setButton": {
+		"message": "Đặt"
+	},
+	"githubTokenLabel": {
+		"message": "Mã token GitHub của bạn"
+	},
+	"githubTokenPlaceholder": {
+		"message": "Bắt buộc cho các yêu cầu đã xác thực"
+	},
+	"githubTokenTooltip": {
+		"message": "Tại sao nên thêm mã token GitHub? Scrum Helper hoạt động mà không cần mã token GitHub, nhưng việc thêm mã thông báo truy cập cá nhân được khuyến nghị để có trải nghiệm tốt hơn."
+	},
+	"gitlabTokenLabel": {
+		"message": "Mã token GitLab"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "Bắt buộc cho repo riêng tư"
+	},
+	"gitlabTokenTooltip": {
+		"message": "Tại sao nên thêm mã token GitLab? Scrum Helper hoạt động mà không cần mã token GitLab cho các dự án công khai, nhưng việc thêm mã thông báo truy cập cá nhân được khuyến nghị để có trải nghiệm tốt hơn."
+	},
+	"showCommitsLabel": {
+		"message": "Hiển thị các commit trên PR đang mở/ PR nháp"
+	},
+	"showCommitsTooltip": {
+		"message": "Yêu cầu mã thông báo Github, hãy thêm nó trong cài đặt."
+	},
+	"onlyIssuesLabel": {
+		"message": "Chỉ bao gồm các vấn đề trong báo cáo"
+	},
+	"onlyIssuesTooltip": {
+		"message": "Nếu được chọn, báo cáo sẽ chỉ bao gồm các vấn đề do người dùng tạo hoặc được giao."
+	},
+	"onlyPRsLabel": {
+		"message": "Chỉ bao gồm PR trong báo cáo"
+	},
+	"onlyPRsTooltip": {
+		"message": "Nếu được chọn, báo cáo chỉ bao gồm các pull request do người dùng tạo; các PR đã được xem xét sẽ bị loại trừ."
+	},
+	"cacheTTLLabel": {
+		"message": "Nhập TTL bộ nhớ cache",
+		"description": "Nhãn cho đầu vào thời gian tồn tại của bộ nhớ cache."
+	},
+	"cacheTTLUnit": {
+		"message": "(tính bằng phút)"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "Nhập TTL bộ nhớ đệm bằng phút (Mặc định: 10)"
+	},
+	"refreshDataButton": {
+		"message": "Làm mới dữ liệu (bỏ qua bộ nhớ đệm)"
+	},
+	"refreshDataInfo": {
+		"message": "Sử dụng nút này để lấy dữ liệu mới ngay lập tức."
+	},
+	"noteTitle": {
+		"message": "Lưu ý:"
+	},
+	"viewCodeButton": {
+		"message": "Xem mã"
+	},
+	"reportIssueButton": {
+		"message": "Báo cáo sự cố"
+	},
+	"repoFilterLabel": {
+		"message": "Lọc theo kho lưu trữ"
+	},
+	"enableFilteringLabel": {
+		"message": "Bật bộ lọc"
+	},
+	"tokenRequiredWarning": {
+		"message": "Cần có mã token GitHub để lọc kho lưu trữ. Vui lòng thêm một mã trong cài đặt."
+	},
+	"repoSearchPlaceholder": {
+		"message": "Tìm kiếm kho lưu trữ để thêm..."
+	},
+	"repoPlaceholder": {
+		"message": "Chưa chọn kho lưu trữ nào (tất cả sẽ được bao gồm)"
+	},
+	"repoCountNone": {
+		"message": "0 kho lưu trữ đã chọn"
+	},
+	"repoCount": {
+		"message": "$1 kho lưu trữ đã chọn"
+	},
+	"repoLoading": {
+		"message": "Đang tải kho lưu trữ..."
+	},
+	"repoLoaded": {
+		"message": "Đã tải $1 kho lưu trữ."
+	},
+	"repoNotFound": {
+		"message": "Không tìm thấy kho lưu trữ nào"
+	},
+	"repoRefetching": {
+		"message": "Đang tải lại kho lưu trữ..."
+	},
+	"repoLoadFailed": {
+		"message": "Không thể tải kho lưu trữ."
+	},
+	"repoTokenPrivate": {
+		"message": "Mã token không hợp lệ hoặc không có quyền đối với kho lưu trữ riêng tư."
+	},
+	"repoRefetchFailed": {
+		"message": "Không thể tải lại kho lưu trữ."
+	},
+	"orgSetMessage": {
+		"message": "Tổ chức đã được đặt thành công."
+	},
+	"orgClearedMessage": {
+		"message": "Đã xóa tổ chức. Nhấp vào 'Tạo báo cáo' để lấy tất cả hoạt động."
+	},
+	"orgNotFoundMessage": {
+		"message": "Không tìm thấy tổ chức trên GitHub."
+	},
+	"orgValidationErrorMessage": {
+		"message": "Lỗi khi xác thực tổ chức."
+	},
+	"refreshingButton": {
+		"message": "Đang làm mới..."
+	},
+	"cacheClearFailed": {
+		"message": "Xóa bộ nhớ đệm thất bại."
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "Đang tạo..."
+	},
+	"copiedButton": {
+		"message": "Đã sao chép!"
+	},
+	"orgChangedMessage": {
+		"message": "Tổ chức đã thay đổi. Nhấp vào 'Tạo báo cáo' để lấy các hoạt động trên GitHub."
+	},
+	"cacheClearedMessage": {
+		"message": "Bộ nhớ đệm đã được xóa thành công. Nhấp vào 'Tạo báo cáo' để lấy dữ liệu mới."
+	},
+	"cacheExpiredMessage": {
+		"message": "Bộ nhớ đệm đã hết hạn. Nhấp vào \"Tạo\" để lấy dữ liệu mới.",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "Đã xóa bộ nhớ đệm!"
+	},
+	"extensionDisabledMessage": {
+		"message": "Tiện ích mở rộng đã bị tắt. Bật nó từ cài đặt để tạo báo cáo scrum."
+	},
+	"notePoint1": {
+		"message": "Pull request được lấy dựa trên hoạt động đánh giá gần đây nhất của bất kỳ người đóng góp nào, không chỉ của riêng bạn. Vui lòng xem xét và điều chỉnh báo cáo SCRUM được tạo để đảm bảo nó phản ánh chính xác công việc của bạn trước khi chia sẻ."
+	},
+	"noteSeeIssue": {
+		"message": "Xem vấn đề này"
+	},
+	"platformLabel": {
+		"message": "Nền tảng"
+	},
+	"usernameLabel": {
+		"message": "Tên người dùng của bạn"
+	},
+	"usernameRequiredError": {
+		"message": "Vui lòng nhập tên người dùng để tạo báo cáo."
+	},
+	"unknownPlatformError": {
+		"message": "Đã chọn nền tảng không xác định."
+	},
+	"gitlabFetchingError": {
+		"message": "Đã xảy ra lỗi khi lấy dữ liệu GitLab."
+	},
+	"reportGenerationError": {
+		"message": "Đã xảy ra lỗi khi tạo báo cáo."
+	},
+	"githubUserNotFoundError": {
+		"message": "Không tìm thấy người dùng GitHub \"$1\" (404). Vui lòng kiểm tra tên người dùng và thử lại."
+	},
+	"githubUserValidationError": {
+		"message": "Lỗi khi xác thực người dùng GitHub: $1 $2"
+	},
+	"invalidSearchQueryError": {
+		"message": "Truy vấn tìm kiếm hoặc khoảng ngày không hợp lệ. Vui lòng kiểm tra định dạng và thử lại."
+	},
+	"githubIssuesFetchError": {
+		"message": "Lỗi khi lấy các vấn đề từ GitHub: $1 $2"
+	},
+	"githubPRReviewFetchError": {
+		"message": "Lỗi khi lấy dữ liệu đánh giá PR từ GitHub: $1 $2"
+	},
+	"githubUserFetchError": {
+		"message": "Lỗi khi lấy dữ liệu người dùng GitHub: $1 $2"
+	},
+	"invalidTokenError": {
+		"message": "Mã token GitHub không hợp lệ hoặc đã hết hạn. Vui lòng kiểm tra mã token trong cài đặt Scrum Helper và thử lại."
+	},
+	"displayModeNotice": {
+		"message": "Tiện ích sẽ mở ở chế độ $1 trong lần khởi động tiếp theo."
+	},
+	"repoFilteringGithubOnly": {
+		"message": "Chỉ có thể lọc kho lưu trữ trên GitHub."
+	},
+	"repoLoadingGithubOnly": {
+		"message": "Chỉ có thể tải kho lưu trữ trên GitHub."
+	},
+	"repoFetchingGithubOnly": {
+		"message": "Chỉ có thể lấy kho lưu trữ trên GitHub."
+	},
+	"loadingReposAutomatically": {
+		"message": "Đang tự động tải kho lưu trữ..."
+	},
+	"gitlabUserFetchError": {
+		"message": "Lỗi khi lấy người dùng GitLab: $1 $2"
+	},
+	"gitlabUserNotFoundError": {
+		"message": "Không tìm thấy người dùng GitLab '$1'"
+	},
+	"gitlabMembershipError": {
+		"message": "Lỗi khi lấy dự án thành viên GitLab: $1 $2"
+	},
+	"gitlabContributedError": {
+		"message": "Lỗi khi lấy dự án đóng góp GitLab: $1 $2"
+	},
+	"onlyRevPRsLabel": {
+		"message": "Chỉ bao gồm các PR bạn đã xem xét trong báo cáo"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "Nếu được chọn, báo cáo sẽ chỉ bao gồm các PR bạn đã xem xét."
+	},
+	"usernameMissingError": {
+		"message": "Yêu cầu tên người dùng."
+	},
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"generatingReportNotification": {
+		"message": "Đang tạo báo cáo..."
+	},
+	"copyingReportNotification": {
+		"message": "Đang sao chép báo cáo..."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "Đang chèn báo cáo vào email..."
+	},
+	"insertedInEmailNotification": {
+		"message": "Đã chèn báo cáo vào email!"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -1,319 +1,343 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "通过自动获取选定时间段内的 Git 活动来报告您的开发进度。"
-    },
-    "disableLabel": {
-        "message": "禁用"
-    },
-    "enableLabel": {
-        "message": "启用"
-    },
-    "projectNameLabel": {
-        "message": "项目名称（用于电子邮件主题）"
-    },
-    "projectNamePlaceholder": {
-        "message": "输入您的项目名称"
-    },
-    "githubUsernameLabel": {
-        "message": "您的 GitHub 用户名"
-    },
-    "gitlabUsernameLabel": {
-        "message": "您的 GitLab 用户名"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "获取您的贡献所必需"
-    },
-    "contributionsLabel": {
-        "message": "获取您在此期间的贡献："
-    },
-    "last1DayLabel": {
-        "message": "前一天"
-    },
-    "startDateLabel": {
-        "message": "从:"
-    },
-    "endDateLabel": {
-        "message": "到:"
-    },
-    "showOpenClosedLabel": {
-        "message": "显示“打开/关闭”状态"
-    },
-    "blockersLabel": {
-        "message": "什么阻碍了您的进展？"
-    },
-    "blockersPlaceholder": {
-        "message": "输入您的原因"
-    },
-    "scrumReportLabel": {
-        "message": "Scrum 报告"
-    },
-    "generateReportButton": {
-        "message": "生成"
-    },
-    "copyReportButton": {
-        "message": "复制"
-    },
-    "insertInEmailButton": {
-        "message": "插入到邮件"
-    },
-    "settingsOrgNameLabel": {
-        "message": "组织名称"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "输入组织名称"
-    },
-    "setButton": {
-        "message": "设置"
-    },
-    "githubTokenLabel": {
-        "message": "您的 GitHub 令牌"
-    },
-    "githubTokenPlaceholder": {
-        "message": "进行身份验证请求所必需"
-    },
-    "githubTokenTooltip": {
-        "message": "为什么建议添加 GitHub 令牌？Scrum Helper 无需 GitHub 令牌也能工作，但添加个人访问令牌可以提供更好的体验。"
-    },
-    "gitlabTokenLabel": {
-        "message": "您的 GitLab 令牌"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "私有仓库需要"
-    },
-    "gitlabTokenTooltip": {
-        "message": "为什么建议添加 GitLab 令牌？Scrum Helper 对于公开项目无需 GitLab 令牌也能工作，但添加个人访问令牌可以提供更好的体验。"
-    },
-    "showCommitsLabel": {
-        "message": "在打开的 PR/草稿 PR 上显示提交"
-    },
-    "showCommitsTooltip": {
-        "message": "需要 Github 令牌，请在设置中添加。"
-    },
-    "onlyIssuesLabel": {
-        "message": "报告中仅包含问题"
-    },
-    "onlyIssuesTooltip": {
-        "message": "如果选中，报告将仅包含由用户创建或分配给用户的问题。"
-    },
-    "onlyPRsLabel": {
-        "message": "报告中仅包含PR"
-    },
-    "onlyPRsTooltip": {
-        "message": "勾选后，报告将只包含用户创建的拉取请求；已审核的PR将被排除。"
-    },
-    "cacheTTLLabel": {
-        "message": "输入缓存 TTL",
-        "description": "缓存生存时间输入的标签。"
-    },
-    "cacheTTLUnit": {
-        "message": "（分钟）"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "以分钟为单位输入缓存 TTL（默认为 10）"
-    },
-    "refreshDataButton": {
-        "message": "刷新数据（绕过缓存）"
-    },
-    "refreshDataInfo": {
-        "message": "使用此按钮立即获取新数据。"
-    },
-    "noteTitle": {
-        "message": "注意："
-    },
-    "viewCodeButton": {
-        "message": "查看代码"
-    },
-    "reportIssueButton": {
-        "message": "报告问题"
-    },
-    "repoFilterLabel": {
-        "message": "按仓库筛选"
-    },
-    "enableFilteringLabel": {
-        "message": "启用筛选"
-    },
-    "tokenRequiredWarning": {
-        "message": "仓库筛选需要GitHub令牌。请在设置中添加一个。"
-    },
-    "repoSearchPlaceholder": {
-        "message": "搜索要添加的仓库..."
-    },
-    "repoPlaceholder": {
-        "message": "未选择任何仓库（将包含所有仓库）"
-    },
-    "repoCountNone": {
-        "message": "已选择 0 个仓库"
-    },
-    "repoCount": {
-        "message": "已选择 $1 个仓库"
-    },
-    "repoLoading": {
-        "message": "正在加载仓库..."
-    },
-    "repoLoaded": {
-        "message": "已加载 $1 个仓库。"
-    },
-    "repoNotFound": {
-        "message": "未找到仓库"
-    },
-    "repoRefetching": {
-        "message": "正在重新加载仓库..."
-    },
-    "repoLoadFailed": {
-        "message": "加载仓库失败。"
-    },
-    "repoTokenPrivate": {
-        "message": "令牌无效或没有私有仓库的权限。"
-    },
-    "repoRefetchFailed": {
-        "message": "重新加载仓库失败。"
-    },
-    "orgSetMessage": {
-        "message": "组织设置成功。"
-    },
-    "orgClearedMessage": {
-        "message": "组织已清除。点击“生成报告”以获取所有活动。"
-    },
-    "orgNotFoundMessage": {
-        "message": "在GitHub上找不到组织。"
-    },
-    "orgValidationErrorMessage": {
-        "message": "验证组织时出错。"
-    },
-    "refreshingButton": {
-        "message": "正在刷新..."
-    },
-    "cacheClearFailed": {
-        "message": "清除缓存失败。"
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "正在生成..."
-    },
-    "copiedButton": {
-        "message": "已复制！"
-    },
-    "orgChangedMessage": {
-        "message": "组织已更改。单击“生成报告”按钮以获取 GitHub 活动。"
-    },
-    "cacheClearedMessage": {
-        "message": "缓存已成功清除。单击“生成报告”以获取新数据。"
-    },
-    "cacheExpiredMessage": {
-        "message": "缓存已过期。点击\"生成\"以获取最新数据。",
-        "description": "Message shown when the cached data has expired and user needs to regenerate."
-    },
-    "cacheClearedButton": {
-        "message": "缓存已清除！"
-    },
-    "extensionDisabledMessage": {
-        "message": "扩展已禁用。请在设置中启用它以生成 Scrum 报告。"
-    },
-    "notePoint1": {
-        "message": "拉取请求是根据任何贡献者最近的审查活动来获取的，而不仅仅是您自己的。在分享之前，请审查并调整生成的SCRUM报告，以确保它准确地反映您的工作。"
-    },
-    "noteSeeIssue": {
-        "message": "查看此 issue"
-    },
-    "platformLabel": {
-        "message": "平台"
-    },
-    "usernameLabel": {
-        "message": "您的用户名"
-    },
-    "onlyRevPRsLabel": {
-        "message": "报告中仅包含已审核的 PR"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "如果选中，报告将仅包含由您审核的 PR。"
-    },
-    "usernameRequiredError": {
-        "message": "请填写用户名以生成报告。"
-    },
-    "unknownPlatformError": {
-        "message": "选择了未知的平台。"
-    },
-    "gitlabFetchingError": {
-        "message": "获取 GitLab 数据时发生错误。"
-    },
-    "reportGenerationError": {
-        "message": "生成报告时发生错误。"
-    },
-    "githubUserNotFoundError": {
-        "message": "未找到 GitHub 用户 \"$1\"（404）。请检查用户名后重试。"
-    },
-    "githubUserValidationError": {
-        "message": "验证 GitHub 用户时出错：$1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "无效的搜索查询或日期范围。请检查格式后重试。"
-    },
-    "githubIssuesFetchError": {
-        "message": "获取 GitHub 问题时出错：$1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "获取 GitHub PR 审查数据时出错：$1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "获取 GitHub 用户数据时出错：$1 $2"
-    },
-    "invalidTokenError": {
-        "message": "GitHub 令牌无效或已过期。请在 Scrum Helper 设置中检查您的令牌并重试。"
-    },
-    "displayModeNotice": {
-        "message": "扩展将在下次启动时以 $1 模式打开。"
-    },
-    "repoFilteringGithubOnly": {
-        "message": "仓库筛选仅适用于 GitHub。"
-    },
-    "repoLoadingGithubOnly": {
-        "message": "仓库加载仅适用于 GitHub。"
-    },
-    "repoFetchingGithubOnly": {
-        "message": "仓库获取仅适用于 GitHub。"
-    },
-    "loadingReposAutomatically": {
-        "message": "正在自动加载仓库..."
-    },
-    "gitlabUserFetchError": {
-        "message": "获取 GitLab 用户时出错：$1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "未找到 GitLab 用户 '$1'"
-    },
-    "gitlabMembershipError": {
-        "message": "获取 GitLab 成员项目时出错：$1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "获取 GitLab 贡献项目时出错：$1 $2"
-    },
-    "usernameMissingError": {
-        "message": "需要用户名。"
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "正在生成报告..."
-    },
-    "copyingReportNotification": {
-        "message": "正在复制报告..."
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "正在将报告插入邮件..."
-    },
-    "insertedInEmailNotification": {
-        "message": "报告已插入邮件！"
-    }
+	"appName": {
+		"message": "Scrum Helper"
+	},
+	"appDescription": {
+		"message": "通过自动获取选定时间段内的 Git 活动来报告您的开发进度。"
+	},
+	"disableLabel": {
+		"message": "禁用"
+	},
+	"enableLabel": {
+		"message": "启用"
+	},
+	"projectNameLabel": {
+		"message": "项目名称（用于电子邮件主题）"
+	},
+	"projectNamePlaceholder": {
+		"message": "输入您的项目名称"
+	},
+	"githubUsernameLabel": {
+		"message": "您的 GitHub 用户名"
+	},
+	"gitlabUsernameLabel": {
+		"message": "您的 GitLab 用户名"
+	},
+	"githubUsernamePlaceholder": {
+		"message": "获取您的贡献所必需"
+	},
+	"contributionsLabel": {
+		"message": "获取您在此期间的贡献："
+	},
+	"last1DayLabel": {
+		"message": "前一天"
+	},
+	"startDateLabel": {
+		"message": "从:"
+	},
+	"endDateLabel": {
+		"message": "到:"
+	},
+	"showOpenClosedLabel": {
+		"message": "显示“打开/关闭”状态"
+	},
+	"blockersLabel": {
+		"message": "什么阻碍了您的进展？"
+	},
+	"blockersPlaceholder": {
+		"message": "输入您的原因"
+	},
+	"scrumReportLabel": {
+		"message": "Scrum 报告"
+	},
+	"generateReportButton": {
+		"message": "生成"
+	},
+	"copyReportButton": {
+		"message": "复制"
+	},
+	"insertInEmailButton": {
+		"message": "插入到邮件"
+	},
+	"settingsOrgNameLabel": {
+		"message": "组织名称"
+	},
+	"settingsOrgNamePlaceholder": {
+		"message": "输入组织名称"
+	},
+	"setButton": {
+		"message": "设置"
+	},
+	"githubTokenLabel": {
+		"message": "您的 GitHub 令牌"
+	},
+	"githubTokenPlaceholder": {
+		"message": "进行身份验证请求所必需"
+	},
+	"githubTokenTooltip": {
+		"message": "为什么建议添加 GitHub 令牌？Scrum Helper 无需 GitHub 令牌也能工作，但添加个人访问令牌可以提供更好的体验。"
+	},
+	"gitlabTokenLabel": {
+		"message": "您的 GitLab 令牌"
+	},
+	"gitlabTokenPlaceholder": {
+		"message": "私有仓库需要"
+	},
+	"gitlabTokenTooltip": {
+		"message": "为什么建议添加 GitLab 令牌？Scrum Helper 对于公开项目无需 GitLab 令牌也能工作，但添加个人访问令牌可以提供更好的体验。"
+	},
+	"showCommitsLabel": {
+		"message": "在打开的 PR/草稿 PR 上显示提交"
+	},
+	"showCommitsTooltip": {
+		"message": "需要 Github 令牌，请在设置中添加。"
+	},
+	"onlyIssuesLabel": {
+		"message": "报告中仅包含问题"
+	},
+	"onlyIssuesTooltip": {
+		"message": "如果选中，报告将仅包含由用户创建或分配给用户的问题。"
+	},
+	"onlyPRsLabel": {
+		"message": "报告中仅包含PR"
+	},
+	"onlyPRsTooltip": {
+		"message": "勾选后，报告将只包含用户创建的拉取请求；已审核的PR将被排除。"
+	},
+	"cacheTTLLabel": {
+		"message": "输入缓存 TTL",
+		"description": "缓存生存时间输入的标签。"
+	},
+	"cacheTTLUnit": {
+		"message": "（分钟）"
+	},
+	"cacheTTLPlaceholder": {
+		"message": "以分钟为单位输入缓存 TTL（默认为 10）"
+	},
+	"refreshDataButton": {
+		"message": "刷新数据（绕过缓存）"
+	},
+	"refreshDataInfo": {
+		"message": "使用此按钮立即获取新数据。"
+	},
+	"noteTitle": {
+		"message": "注意："
+	},
+	"viewCodeButton": {
+		"message": "查看代码"
+	},
+	"reportIssueButton": {
+		"message": "报告问题"
+	},
+	"repoFilterLabel": {
+		"message": "按仓库筛选"
+	},
+	"enableFilteringLabel": {
+		"message": "启用筛选"
+	},
+	"tokenRequiredWarning": {
+		"message": "仓库筛选需要GitHub令牌。请在设置中添加一个。"
+	},
+	"repoSearchPlaceholder": {
+		"message": "搜索要添加的仓库..."
+	},
+	"repoPlaceholder": {
+		"message": "未选择任何仓库（将包含所有仓库）"
+	},
+	"repoCountNone": {
+		"message": "已选择 0 个仓库"
+	},
+	"repoCount": {
+		"message": "已选择 $1 个仓库"
+	},
+	"repoLoading": {
+		"message": "正在加载仓库..."
+	},
+	"repoLoaded": {
+		"message": "已加载 $1 个仓库。"
+	},
+	"repoNotFound": {
+		"message": "未找到仓库"
+	},
+	"repoRefetching": {
+		"message": "正在重新加载仓库..."
+	},
+	"repoLoadFailed": {
+		"message": "加载仓库失败。"
+	},
+	"repoTokenPrivate": {
+		"message": "令牌无效或没有私有仓库的权限。"
+	},
+	"repoRefetchFailed": {
+		"message": "重新加载仓库失败。"
+	},
+	"orgSetMessage": {
+		"message": "组织设置成功。"
+	},
+	"orgClearedMessage": {
+		"message": "组织已清除。点击“生成报告”以获取所有活动。"
+	},
+	"orgNotFoundMessage": {
+		"message": "在GitHub上找不到组织。"
+	},
+	"orgValidationErrorMessage": {
+		"message": "验证组织时出错。"
+	},
+	"refreshingButton": {
+		"message": "正在刷新..."
+	},
+	"cacheClearFailed": {
+		"message": "清除缓存失败。"
+	},
+	"madeWithLoveBy": {
+		"message": "Made with ❤️ by"
+	},
+	"generatingButton": {
+		"message": "正在生成..."
+	},
+	"copiedButton": {
+		"message": "已复制！"
+	},
+	"orgChangedMessage": {
+		"message": "组织已更改。单击“生成报告”按钮以获取 GitHub 活动。"
+	},
+	"cacheClearedMessage": {
+		"message": "缓存已成功清除。单击“生成报告”以获取新数据。"
+	},
+	"cacheExpiredMessage": {
+		"message": "缓存已过期。点击\"生成\"以获取最新数据。",
+		"description": "Message shown when the cached data has expired and user needs to regenerate."
+	},
+	"cacheClearedButton": {
+		"message": "缓存已清除！"
+	},
+	"extensionDisabledMessage": {
+		"message": "扩展已禁用。请在设置中启用它以生成 Scrum 报告。"
+	},
+	"notePoint1": {
+		"message": "拉取请求是根据任何贡献者最近的审查活动来获取的，而不仅仅是您自己的。在分享之前，请审查并调整生成的SCRUM报告，以确保它准确地反映您的工作。"
+	},
+	"noteSeeIssue": {
+		"message": "查看此 issue"
+	},
+	"platformLabel": {
+		"message": "平台"
+	},
+	"usernameLabel": {
+		"message": "您的用户名"
+	},
+	"onlyRevPRsLabel": {
+		"message": "报告中仅包含已审核的 PR"
+	},
+	"onlyRevPRsTooltip": {
+		"message": "如果选中，报告将仅包含由您审核的 PR。"
+	},
+	"usernameRequiredError": {
+		"message": "请填写用户名以生成报告。"
+	},
+	"unknownPlatformError": {
+		"message": "选择了未知的平台。"
+	},
+	"gitlabFetchingError": {
+		"message": "获取 GitLab 数据时发生错误。"
+	},
+	"reportGenerationError": {
+		"message": "生成报告时发生错误。"
+	},
+	"githubUserNotFoundError": {
+		"message": "未找到 GitHub 用户 \"$1\"（404）。请检查用户名后重试。"
+	},
+	"githubUserValidationError": {
+		"message": "验证 GitHub 用户时出错：$1 $2"
+	},
+	"invalidSearchQueryError": {
+		"message": "无效的搜索查询或日期范围。请检查格式后重试。"
+	},
+	"githubIssuesFetchError": {
+		"message": "获取 GitHub 问题时出错：$1 $2"
+	},
+	"githubPRReviewFetchError": {
+		"message": "获取 GitHub PR 审查数据时出错：$1 $2"
+	},
+	"githubUserFetchError": {
+		"message": "获取 GitHub 用户数据时出错：$1 $2"
+	},
+	"invalidTokenError": {
+		"message": "GitHub 令牌无效或已过期。请在 Scrum Helper 设置中检查您的令牌并重试。"
+	},
+	"displayModeNotice": {
+		"message": "扩展将在下次启动时以 $1 模式打开。"
+	},
+	"repoFilteringGithubOnly": {
+		"message": "仓库筛选仅适用于 GitHub。"
+	},
+	"repoLoadingGithubOnly": {
+		"message": "仓库加载仅适用于 GitHub。"
+	},
+	"repoFetchingGithubOnly": {
+		"message": "仓库获取仅适用于 GitHub。"
+	},
+	"loadingReposAutomatically": {
+		"message": "正在自动加载仓库..."
+	},
+	"gitlabUserFetchError": {
+		"message": "获取 GitLab 用户时出错：$1 $2"
+	},
+	"gitlabUserNotFoundError": {
+		"message": "未找到 GitLab 用户 '$1'"
+	},
+	"gitlabMembershipError": {
+		"message": "获取 GitLab 成员项目时出错：$1 $2"
+	},
+	"gitlabContributedError": {
+		"message": "获取 GitLab 贡献项目时出错：$1 $2"
+	},
+	"usernameMissingError": {
+		"message": "需要用户名。"
+	},
+	"generateReportTooltip": {
+		"message": "Ctrl+G"
+	},
+	"copyReportTooltip": {
+		"message": "Ctrl+Shift+Y"
+	},
+	"generatingReportNotification": {
+		"message": "正在生成报告..."
+	},
+	"copyingReportNotification": {
+		"message": "正在复制报告..."
+	},
+	"insertInEmailTooltip": {
+		"message": "Ctrl+Shift+M"
+	},
+	"insertingInEmailNotification": {
+		"message": "正在将报告插入邮件..."
+	},
+	"insertedInEmailNotification": {
+		"message": "报告已插入邮件！"
+	},
+	"bitbucketTokenLabel": {
+		"message": "Your Bitbucket App Password",
+		"description": "Label for the Bitbucket app password input field."
+	},
+	"bitbucketTokenPlaceholder": {
+		"message": "username:app_password",
+		"description": "Placeholder for the Bitbucket app password input."
+	},
+	"bitbucketTokenTooltip": {
+		"message": "Required to access your pull requests and issues. Enter as username:app_password.",
+		"description": "Tooltip for Bitbucket app password."
+	},
+	"bitbucketUserFetchError": {
+		"message": "Error fetching Bitbucket user: $1 $2",
+		"description": "Error when fetching Bitbucket user fails. $1=status, $2=statusText"
+	},
+	"bitbucketUserNotFoundError": {
+		"message": "Bitbucket user '$1' not found.",
+		"description": "Error when Bitbucket user is not found. $1=username"
+	},
+	"bitbucketFetchingError": {
+		"message": "An error occurred while fetching Bitbucket data.",
+		"description": "Error shown when Bitbucket data fetch fails."
+	}
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -144,6 +144,10 @@
 									class="hover:bg-gray-100" data-value="gitlab">
 									<i class="fab fa-gitlab" style="margin-right: 12px; font-size: 18px;"></i> GitLab
 								</li>
+								<li style="padding-left: 8px; padding-right: 16px; padding-top: 8px; padding-bottom: 8px; display: flex; align-items: center; cursor: pointer;"
+									class="hover:bg-gray-100" data-value="bitbucket">
+									<i class="fab fa-bitbucket" style="margin-right: 12px; font-size: 18px;"></i> Bitbucket
+								</li>
 							</ul>
 						</div>
 					</div>
@@ -526,6 +530,36 @@
 							data-i18n-placeholder="gitlabTokenPlaceholder">
 					</div>
 
+					<div class="bitbucketOnlySection hidden mt-3">
+						<div class="flex items-center justify-between">
+							<div class="flex">
+								<p class="text-sm font-medium" data-i18n="bitbucketTokenLabel">Your Bitbucket App Password</p>
+								<span class="tooltip-container">
+									<i class="fa fa-question-circle question-icon"></i>
+									<span class="tooltip-bubble" data-i18n="bitbucketTokenTooltip">
+										<b>Why add a Bitbucket app password?</b><br>
+										Required to access your pull requests and issues. Use format
+										<b>username:app_password</b>.<br><br>
+										<b>How to get one:</b><br>
+										1. Go to <a href="https://bitbucket.org/account/settings/app-passwords/"
+											target="_blank" rel="noopener noreferrer"
+											style="color:#2563eb;text-decoration:underline;">Bitbucket App Passwords</a><br>
+										2. Click "Create app password"<br>
+										3. Select "Repositories: Read" and "Issues: Read" scopes<br>
+										4. Enter here as <b>username:app_password</b><br>
+										<i>Keep it secret!</i>
+									</span>
+								</span>
+							</div>
+							<button id="toggleBitbucketTokenVisibility" type="button" class="focus:outline-none">
+								<i id="bitbucketTokenEyeIcon" class="fa fa-eye text-gray-600"></i>
+							</button>
+						</div>
+						<input id="bitbucketToken" type="password"
+							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2 pr-10"
+							data-i18n-placeholder="bitbucketTokenPlaceholder">
+					</div>
+
 					<div class="cacheSection mt-3">
 						<div class="flex items-center justify-between mb-2">
 							<div class="flex items-center">
@@ -619,6 +653,7 @@
 	<script src="scripts/emailClientAdapter.js"></script>
 	<script src="scripts/main.js"></script>
 	<script src="scripts/gitlabHelper.js"></script>
+	<script src="scripts/bitbucketHelper.js"></script>
 	<script src="scripts/scrumHelper.js"></script>
 	<script src="scripts/popup.js"></script>
 </body>

--- a/src/scripts/bitbucketHelper.js
+++ b/src/scripts/bitbucketHelper.js
@@ -1,0 +1,211 @@
+class BitbucketHelper {
+	constructor() {
+		this.baseUrl = 'https://api.bitbucket.org/2.0';
+		this.cache = {
+			data: null,
+			cacheKey: null,
+			timestamp: 0,
+			ttl: 10 * 60 * 1000,
+			fetching: false,
+			queue: [],
+		};
+	}
+
+	async getCacheTTL() {
+		try {
+			const items = await browser.storage.local.get(['cacheInput']);
+			return items.cacheInput ? Number.parseInt(items.cacheInput, 10) * 60 * 1000 : 10 * 60 * 1000;
+		} catch (error) {
+			console.error('Error getting cache TTL:', error);
+			return 10 * 60 * 1000;
+		}
+	}
+
+	async saveToStorage(data) {
+		try {
+			await browser.storage.local.set({
+				bitbucketCache: {
+					data: data,
+					cacheKey: this.cache.cacheKey,
+					timestamp: this.cache.timestamp,
+				},
+			});
+		} catch (error) {
+			console.error('Error saving to storage:', error);
+		}
+	}
+
+	async loadFromStorage() {
+		try {
+			const items = await browser.storage.local.get(['bitbucketCache']);
+			if (items.bitbucketCache) {
+				this.cache.data = items.bitbucketCache.data;
+				this.cache.cacheKey = items.bitbucketCache.cacheKey;
+				this.cache.timestamp = items.bitbucketCache.timestamp;
+			}
+		} catch (error) {
+			console.error('Error loading from storage:', error);
+		}
+	}
+
+	buildHeaders(token) {
+		const headers = {};
+		if (token) {
+			headers['Authorization'] = `Basic ${btoa(token)}`;
+		}
+		return headers;
+	}
+
+	async fetchAllPages(url, headers) {
+		const results = [];
+		let nextUrl = url;
+		while (nextUrl) {
+			const res = await fetch(nextUrl, { headers });
+			if (!res.ok) {
+				throw new Error(`Bitbucket API error: ${res.status} ${res.statusText}`);
+			}
+			const data = await res.json();
+			results.push(...(data.values || []));
+			nextUrl = data.next || null;
+			if (nextUrl) {
+				await new Promise((r) => setTimeout(r, 100));
+			}
+		}
+		return results;
+	}
+
+	async fetchBitbucketData(username, startDate, endDate, token = null) {
+		const tokenMarker = token ? 'auth' : 'noauth';
+		const cacheKey = `${username}-${startDate}-${endDate}-${tokenMarker}`;
+
+		if (!this.cache.data && !this.cache.fetching) {
+			await this.loadFromStorage();
+		}
+
+		const currentTTL = await this.getCacheTTL();
+		this.cache.ttl = currentTTL;
+
+		const now = Date.now();
+		const isCacheFresh = now - this.cache.timestamp < this.cache.ttl;
+		const isCacheKeyMatch = this.cache.cacheKey === cacheKey;
+
+		if (this.cache.data && isCacheFresh && isCacheKeyMatch) {
+			return this.cache.data;
+		}
+
+		if (!isCacheKeyMatch) {
+			this.cache.data = null;
+		}
+
+		if (this.cache.fetching) {
+			return new Promise((resolve, reject) => {
+				this.cache.queue.push({ resolve, reject });
+			});
+		}
+
+		this.cache.fetching = true;
+		this.cache.cacheKey = cacheKey;
+
+		const headers = this.buildHeaders(token);
+
+		try {
+			await new Promise((r) => setTimeout(r, 500));
+
+			const userRes = await fetch(`${this.baseUrl}/users/${username}`, { headers });
+			if (!userRes.ok) {
+				if (userRes.status === 404) {
+					throw new Error(
+						chrome?.i18n.getMessage('bitbucketUserNotFoundError', [username]) ||
+							`Bitbucket user '${username}' not found`,
+					);
+				}
+				throw new Error(
+					chrome?.i18n.getMessage('bitbucketUserFetchError', [userRes.status, userRes.statusText]) ||
+						`Error fetching Bitbucket user: ${userRes.status} ${userRes.statusText}`,
+				);
+			}
+			const user = await userRes.json();
+
+			const reposUrl = `${this.baseUrl}/repositories?role=member&pagelen=50`;
+			let repos = [];
+			try {
+				repos = await this.fetchAllPages(reposUrl, headers);
+			} catch (e) {
+				console.error('Bitbucket: error fetching repos:', e);
+			}
+
+			const afterDate = `${startDate}T00:00:00+00:00`;
+			const beforeDate = `${endDate}T23:59:59+00:00`;
+
+			let allPullRequests = [];
+			let allIssues = [];
+
+			for (const repo of repos) {
+				const workspace = repo.workspace?.slug || repo.full_name.split('/')[0];
+				const repoSlug = repo.slug;
+
+				try {
+					const prsUrl = `${this.baseUrl}/repositories/${workspace}/${repoSlug}/pullrequests?q=author.username="${username}" AND created_on>="${afterDate}" AND created_on<="${beforeDate}"&pagelen=50`;
+					const prs = await this.fetchAllPages(prsUrl, headers);
+					for (const pr of prs) {
+						pr._repoName = repo.name;
+						pr._repoFullName = repo.full_name;
+					}
+					allPullRequests = allPullRequests.concat(prs);
+				} catch (e) {
+					console.error(`Bitbucket: error fetching PRs for ${repo.full_name}:`, e);
+				}
+
+				try {
+					const issuesUrl = `${this.baseUrl}/repositories/${workspace}/${repoSlug}/issues?q=reporter.username="${username}" AND created_on>="${afterDate}" AND created_on<="${beforeDate}"&pagelen=50`;
+					const issues = await this.fetchAllPages(issuesUrl, headers);
+					for (const issue of issues) {
+						issue._repoName = repo.name;
+						issue._repoFullName = repo.full_name;
+					}
+					allIssues = allIssues.concat(issues);
+				} catch (e) {
+					console.error(`Bitbucket: error fetching issues for ${repo.full_name}:`, e);
+				}
+
+				await new Promise((r) => setTimeout(r, 100));
+			}
+
+			const bitbucketData = {
+				user: user,
+				repos: repos,
+				pullRequests: allPullRequests,
+				issues: allIssues,
+			};
+
+			this.cache.data = bitbucketData;
+			this.cache.timestamp = Date.now();
+
+			await this.saveToStorage(bitbucketData);
+
+			this.cache.queue.forEach(({ resolve }) => resolve(bitbucketData));
+			this.cache.queue = [];
+
+			return bitbucketData;
+		} catch (err) {
+			console.error('Bitbucket Fetch Failed:', err);
+			this.cache.queue.forEach(({ reject }) => reject(err));
+			this.cache.queue = [];
+			throw err;
+		} finally {
+			this.cache.fetching = false;
+		}
+	}
+
+	formatDate(dateString) {
+		const date = new Date(dateString);
+		const options = { day: '2-digit', month: 'short', year: 'numeric' };
+		return date.toLocaleDateString('en-US', options);
+	}
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = BitbucketHelper;
+} else {
+	window.BitbucketHelper = BitbucketHelper;
+}

--- a/src/scripts/bitbucketHelper.js
+++ b/src/scripts/bitbucketHelper.js
@@ -75,8 +75,8 @@ class BitbucketHelper {
 	}
 
 	async fetchBitbucketData(username, startDate, endDate, token = null) {
-		const tokenMarker = token ? 'auth' : 'noauth';
-		const cacheKey = `${username}-${startDate}-${endDate}-${tokenMarker}`;
+		const tokenId = token ? token.slice(-8) : 'noauth';
+		const cacheKey = `${username}-${startDate}-${endDate}-${tokenId}`;
 
 		if (!this.cache.data && !this.cache.fetching) {
 			await this.loadFromStorage();
@@ -197,11 +197,6 @@ class BitbucketHelper {
 		}
 	}
 
-	formatDate(dateString) {
-		const date = new Date(dateString);
-		const options = { day: '2-digit', month: 'short', year: 'numeric' };
-		return date.toLocaleDateString('en-US', options);
-	}
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -149,6 +149,12 @@ document.addEventListener('DOMContentLoaded', () => {
 	const gitlabTokenEyeIcon = document.getElementById('gitlabTokenEyeIcon');
 	let gitlabTokenVisible = false;
 
+	// Bitbucket token elements
+	const bitbucketTokenInput = document.getElementById('bitbucketToken');
+	const toggleBitbucketTokenBtn = document.getElementById('toggleBitbucketTokenVisibility');
+	const bitbucketTokenEyeIcon = document.getElementById('bitbucketTokenEyeIcon');
+	let bitbucketTokenVisible = false;
+
 	const orgInput = document.getElementById('orgInput');
 
 	const platformSelect = document.getElementById('platformSelect');
@@ -340,6 +346,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			gitlabTokenInput.classList.add('token-animating');
 			setTimeout(() => gitlabTokenInput.classList.remove('token-animating'), 300);
+		});
+	}
+
+	if (toggleBitbucketTokenBtn && bitbucketTokenInput) {
+		toggleBitbucketTokenBtn.addEventListener('click', () => {
+			bitbucketTokenVisible = !bitbucketTokenVisible;
+			bitbucketTokenInput.type = bitbucketTokenVisible ? 'text' : 'password';
+
+			bitbucketTokenEyeIcon.classList.add('eye-animating');
+			setTimeout(() => bitbucketTokenEyeIcon.classList.remove('eye-animating'), 400);
+			bitbucketTokenEyeIcon.className = bitbucketTokenVisible ? 'fa fa-eye-slash text-gray-600' : 'fa fa-eye text-gray-600';
+
+			bitbucketTokenInput.classList.add('token-animating');
+			setTimeout(() => bitbucketTokenInput.classList.remove('token-animating'), 300);
 		});
 	}
 
@@ -650,6 +670,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				'platform',
 				'githubUsername',
 				'gitlabUsername',
+				'bitbucketUsername',
 			])
 			.then((result) => {
 				if (result.projectName) projectNameInput.value = result.projectName;
@@ -695,6 +716,7 @@ document.addEventListener('DOMContentLoaded', () => {
 					browser?.storage.local.set({ onlyPRs: false });
 				}
 				if (result.githubToken) githubTokenInput.value = result.githubToken;
+				if (result.bitbucketToken && bitbucketTokenInput) bitbucketTokenInput.value = result.bitbucketToken;
 				if (result.cacheInput) cacheInput.value = result.cacheInput;
 				if (typeof result.yesterdayContribution !== 'undefined') yesterdayRadio.checked = result.yesterdayContribution;
 				if (result.startingDate) startingDateInput.value = result.startingDate;
@@ -1008,6 +1030,11 @@ document.addEventListener('DOMContentLoaded', () => {
 		githubTokenInput.addEventListener('input', () => {
 			browser.storage.local.set({ githubToken: githubTokenInput.value });
 		});
+		if (bitbucketTokenInput) {
+			bitbucketTokenInput.addEventListener('input', () => {
+				browser.storage.local.set({ bitbucketToken: bitbucketTokenInput.value });
+			});
+		}
 		cacheInput.addEventListener('input', () => {
 			browser.storage.local.set({ cacheInput: cacheInput.value });
 		});
@@ -1738,7 +1765,7 @@ function updatePlatformUI(platform) {
 
 	const orgSection = document.querySelector('.orgSection');
 	if (orgSection) {
-		if (platform === 'gitlab') {
+		if (platform === 'gitlab' || platform === 'bitbucket') {
 			orgSection.classList.add('hidden');
 		} else {
 			orgSection.classList.remove('hidden');
@@ -1746,7 +1773,7 @@ function updatePlatformUI(platform) {
 	}
 	const githubOnlySections = document.querySelectorAll('.githubOnlySection');
 	githubOnlySections.forEach((el) => {
-		if (platform === 'gitlab') {
+		if (platform === 'gitlab' || platform === 'bitbucket') {
 			el.classList.add('hidden');
 		} else {
 			el.classList.remove('hidden');
@@ -1754,10 +1781,18 @@ function updatePlatformUI(platform) {
 	});
 	const gitlabOnlySections = document.querySelectorAll('.gitlabOnlySection');
 	gitlabOnlySections.forEach((el) => {
-		if (platform === 'github') {
-			el.classList.add('hidden');
-		} else {
+		if (platform === 'gitlab') {
 			el.classList.remove('hidden');
+		} else {
+			el.classList.add('hidden');
+		}
+	});
+	const bitbucketOnlySections = document.querySelectorAll('.bitbucketOnlySection');
+	bitbucketOnlySections.forEach((el) => {
+		if (platform === 'bitbucket') {
+			el.classList.remove('hidden');
+		} else {
+			el.classList.add('hidden');
 		}
 	});
 }
@@ -1811,6 +1846,8 @@ function buildScrumSubjectFromPopup() {
 function setPlatformDropdown(value) {
 	if (value === 'gitlab') {
 		dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
+	} else if (value === 'bitbucket') {
+		dropdownSelected.innerHTML = '<i class="fab fa-bitbucket mr-2"></i> Bitbucket';
 	} else {
 		dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
 	}
@@ -1932,6 +1969,8 @@ browser.storage.local.get(['platform']).then((result) => {
 	// Just update the UI without clearing username when restoring from storage
 	if (platform === 'gitlab') {
 		dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
+	} else if (platform === 'bitbucket') {
+		dropdownSelected.innerHTML = '<i class="fab fa-bitbucket mr-2"></i> Bitbucket';
 	} else {
 		dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
 	}

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -21,6 +21,8 @@ let platform = 'github';
 let platformUsername = '';
 let gitlabToken = '';
 let gitlabHelper = null;
+let bitbucketToken = '';
+let bitbucketHelper = null;
 let usernameValidationListenerAttached = false;
 
 const scrumReportEl = document.getElementById('scrumReport');
@@ -64,6 +66,9 @@ function allIncluded(outputTarget = 'email') {
 	// Always re-instantiate gitlabHelper for gitlab platform to ensure fresh cache after refresh
 	if (platform === 'gitlab' || (typeof platform === 'undefined' && window.GitLabHelper)) {
 		gitlabHelper = new window.GitLabHelper();
+	}
+	if (platform === 'bitbucket' || (typeof platform === 'undefined' && window.BitbucketHelper)) {
+		bitbucketHelper = new window.BitbucketHelper();
 	}
 	if (scrumGenerationInProgress) {
 		return;
@@ -122,8 +127,10 @@ function allIncluded(outputTarget = 'email') {
 				'platform',
 				'githubUsername',
 				'gitlabUsername',
+				'bitbucketUsername',
 				'githubToken',
 				'gitlabToken',
+				'bitbucketToken',
 				'projectName',
 				'startingDate',
 				'endingDate',
@@ -156,6 +163,7 @@ function allIncluded(outputTarget = 'email') {
 					const projectFromDOM = document.getElementById('projectName')?.value;
 					const tokenFromDOM = document.getElementById('githubToken')?.value;
 					const gitlabTokenFromDOM = document.getElementById('gitlabToken')?.value;
+					const bitbucketTokenFromDOM = document.getElementById('bitbucketToken')?.value;
 
 					// Save to platform-specific storage
 					if (usernameFromDOM) {
@@ -167,10 +175,12 @@ function allIncluded(outputTarget = 'email') {
 					items.projectName = projectFromDOM || items.projectName;
 					items.githubToken = tokenFromDOM || items.githubToken;
 					items.gitlabToken = gitlabTokenFromDOM || items.gitlabToken;
+					items.bitbucketToken = bitbucketTokenFromDOM || items.bitbucketToken;
 					chrome.storage.local.set({
 						projectName: items.projectName,
 						githubToken: items.githubToken,
 						gitlabToken: items.gitlabToken,
+						bitbucketToken: items.bitbucketToken,
 					});
 				}
 				projectName = items.projectName;
@@ -179,6 +189,7 @@ function allIncluded(outputTarget = 'email') {
 				chrome.storage.local.remove(['userReason']);
 				githubToken = items.githubToken;
 				gitlabToken = items.gitlabToken || '';
+				bitbucketToken = items.bitbucketToken || '';
 				yesterdayContribution = items.yesterdayContribution;
 
 				onlyIssues = items.onlyIssues === true;
@@ -358,6 +369,92 @@ function allIncluded(outputTarget = 'email') {
 								});
 						}
 						// --- FIX END ---
+					} else {
+						if (outputTarget === 'popup') {
+							const generateBtn = document.getElementById('generateReport');
+							const ErrMessage = chrome.i18n.getMessage('usernameRequiredError') || 'Please enter your username to generate a report.';
+							handleUsernameValidationError(ErrMessage);
+							if (generateBtn) {
+								generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
+								generateBtn.disabled = false;
+							}
+						}
+						scrumGenerationInProgress = false;
+					}
+				} else if (platform === 'bitbucket') {
+					if (!bitbucketHelper) bitbucketHelper = new window.BitbucketHelper();
+					if (platformUsernameLocal) {
+						const generateBtn = document.getElementById('generateReport');
+						if (generateBtn && outputTarget === 'popup') {
+							generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
+							generateBtn.disabled = true;
+						}
+						const doFetch = async () => {
+							try {
+								const data = await bitbucketHelper.fetchBitbucketData(
+									platformUsernameLocal,
+									startingDate,
+									endingDate,
+									bitbucketToken,
+								);
+								function mapBitbucketItem(item, type) {
+									const repoName = item._repoName || 'unknown';
+									const repoFullName = item._repoFullName || '';
+									return {
+										...item,
+										repository_url: `https://api.bitbucket.org/2.0/repositories/${repoFullName}`,
+										html_url: item.links?.html?.href || '',
+										number: item.id,
+										title: item.title,
+										state: item.state === 'OPEN' ? 'open' : (item.state?.toLowerCase() || item.state),
+										project: repoName,
+										pull_request: type === 'pr',
+										updated_at: item.updated_on,
+										created_at: item.created_on,
+									};
+								}
+								const mappedIssues = (data.issues || []).map((issue) => mapBitbucketItem(issue, 'issue'));
+								const mappedPRs = (data.pullRequests || []).map((pr) => mapBitbucketItem(pr, 'pr'));
+								const mappedData = {
+									githubIssuesData: { items: mappedIssues },
+									githubPrsReviewData: { items: mappedPRs },
+									githubUserData: data.user || {},
+								};
+								githubUserData = mappedData.githubUserData;
+								if (outputTarget === 'email') {
+									const curDate = new Date();
+									const year = curDate.getFullYear().toString();
+									let date = curDate.getDate();
+									let month = curDate.getMonth() + 1;
+									if (month < 10) month = '0' + month;
+									if (date < 10) date = '0' + date;
+									const dateCode = year + month + date;
+									const subject = `[Scrum]${projectName ? ' - ' + projectName : ''} - ${dateCode}`;
+									subjectForEmail = subject;
+									await processGithubData(mappedData, true, subjectForEmail);
+								} else {
+									processGithubData(mappedData);
+								}
+								scrumGenerationInProgress = false;
+							} catch (err) {
+								console.error('Bitbucket fetch failed:', err);
+								if (outputTarget === 'popup') {
+									const generateBtn = document.getElementById('generateReport');
+									if (generateBtn) {
+										generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
+										generateBtn.disabled = false;
+									}
+									const ErrMessage = `${err.message || 'Error fetching Bitbucket data.'}`;
+									if (typeof ErrMessage === 'string' && ErrMessage.toLowerCase().includes('not found')) {
+										handleUsernameValidationError(ErrMessage);
+									} else {
+										showReportMessage(ErrMessage);
+									}
+								}
+								scrumGenerationInProgress = false;
+							}
+						};
+						doFetch();
 					} else {
 						if (outputTarget === 'popup') {
 							const generateBtn = document.getElementById('generateReport');
@@ -1039,7 +1136,7 @@ function allIncluded(outputTarget = 'email') {
 		log('[SCRUM-DEBUG] Processing issues for main activity:', githubIssuesData?.items);
 		if (platform === 'github') {
 			await writeGithubIssuesPrs(githubIssuesData?.items || []);
-		} else if (platform === 'gitlab') {
+		} else if (platform === 'gitlab' || platform === 'bitbucket') {
 			await writeGithubIssuesPrs(githubIssuesData?.items || []);
 			await writeGithubIssuesPrs(githubPrsReviewData?.items || []);
 		}
@@ -1162,7 +1259,7 @@ ${blockerText}`;
 				scrumReport.innerHTML = content;
 				try {
 					const cacheKey =
-						platform === 'gitlab' ? (gitlabHelper?.cache?.cacheKey ?? null) : (githubCache?.cacheKey ?? null);
+						platform === 'gitlab' ? (gitlabHelper?.cache?.cacheKey ?? null) : platform === 'bitbucket' ? (bitbucketHelper?.cache?.cacheKey ?? null) : (githubCache?.cacheKey ?? null);
 
 					chrome.storage.local.set({
 						lastScrumReportHtml: content,
@@ -1314,6 +1411,8 @@ ${blockerText}`;
 				isAuthoredByUser = item.user && item.user.login === platformUsernameLocal;
 			} else if (platform === 'gitlab') {
 				isAuthoredByUser = item.author && item.author.username === platformUsername;
+			} else if (platform === 'bitbucket') {
+				isAuthoredByUser = item.author && item.author.nickname === platformUsername;
 			}
 
 			if (isAuthoredByUser || !item.pull_request) continue;
@@ -1661,7 +1760,7 @@ ${blockerText}`;
 			const repository_url = item.repository_url;
 			// Use project name for GitLab, repo extraction for GitHub
 			const project =
-				platform === 'gitlab' && item.project
+				(platform === 'gitlab' || platform === 'bitbucket') && item.project
 					? item.project
 					: repository_url
 						? repository_url.substr(repository_url.lastIndexOf('/') + 1)
@@ -1740,6 +1839,8 @@ ${blockerText}`;
 					} else {
 						prAction = 'Updated Merge Request';
 					}
+				} else if (platform === 'bitbucket') {
+					prAction = isNewPR ? 'Made Pull Request' : 'Updated Pull Request';
 				}
 
 				if (isDraft) {
@@ -1766,7 +1867,7 @@ ${blockerText}`;
 						li += '</ul>';
 					}
 					li += `</li>`;
-				} else if (platform === 'gitlab' && item.state === 'closed') {
+				} else if ((platform === 'gitlab' || platform === 'bitbucket') && item.state === 'closed') {
 					li = `<li><i>(${project})</i> - ${prAction} <a href='${html_url}' target='_blank' rel='noopener noreferrer' contenteditable='false'>(#${number})</a> - <a href='${html_url}' target='_blank' rel='noopener noreferrer' contenteditable='false'>${title}</a>${showOpenLabel ? ' ' + pr_closed_button : ''}</li>`;
 				} else {
 					let merged = null;
@@ -1845,7 +1946,7 @@ ${blockerText}`;
 	}, 500);
 
 	const intervalSubject = setInterval(() => {
-		const userData = platform === 'gitlab' ? githubUserData || platformUsername : githubUserData;
+		const userData = (platform === 'gitlab' || platform === 'bitbucket') ? githubUserData || platformUsername : githubUserData;
 		if (!userData || !window.emailClientAdapter) return;
 
 		const elements = window.emailClientAdapter.getEditorElements();
@@ -1870,7 +1971,7 @@ ${blockerText}`;
 		if (outputTarget === 'popup') {
 			return;
 		}
-		const username = platform === 'gitlab' ? platformUsername : platformUsernameLocal;
+		const username = (platform === 'gitlab' || platform === 'bitbucket') ? platformUsername : platformUsernameLocal;
 		if (scrumBody && username && githubIssuesData && githubPrsReviewData) {
 			clearInterval(intervalWriteGithubIssues);
 			clearInterval(intervalWriteGithubPrs);
@@ -1882,7 +1983,7 @@ ${blockerText}`;
 			return;
 		}
 
-		const username = platform === 'gitlab' ? platformUsername : platformUsernameLocal;
+		const username = (platform === 'gitlab' || platform === 'bitbucket') ? platformUsername : platformUsernameLocal;
 		if (scrumBody && username && githubPrsReviewData && githubIssuesData) {
 			clearInterval(intervalWriteGithubPrs);
 			clearInterval(intervalWriteGithubIssues);
@@ -1993,6 +2094,12 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 						console.error('Force refresh failed:', err);
 						sendResponse({ success: false, error: err.message });
 					});
+			} else if (platform === 'bitbucket') {
+				if (bitbucketHelper) {
+					bitbucketHelper.cache.data = null;
+					bitbucketHelper.cache.timestamp = 0;
+				}
+				sendResponse({ success: true });
 			} else {
 				forceGithubDataRefresh()
 					.then((result) => sendResponse(result))

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1867,7 +1867,7 @@ ${blockerText}`;
 						li += '</ul>';
 					}
 					li += `</li>`;
-				} else if ((platform === 'gitlab' || platform === 'bitbucket') && item.state === 'closed') {
+				} else if ((platform === 'gitlab' && item.state === 'closed') || (platform === 'bitbucket' && (item.state === 'merged' || item.state === 'declined'))) {
 					li = `<li><i>(${project})</i> - ${prAction} <a href='${html_url}' target='_blank' rel='noopener noreferrer' contenteditable='false'>(#${number})</a> - <a href='${html_url}' target='_blank' rel='noopener noreferrer' contenteditable='false'>${title}</a>${showOpenLabel ? ' ' + pr_closed_button : ''}</li>`;
 				} else {
 					let merged = null;


### PR DESCRIPTION
- Add BitbucketHelper class for fetching pull requests and issues via Bitbucket REST API
- Add Bitbucket option to platform dropdown in popup UI
- Add Bitbucket app password token input with visibility toggle
- Handle Bitbucket data fetching and mapping in scrumHelper
- Add i18n keys for Bitbucket in all supported locales
- Wire up storage load/save for bitbucketToken and bitbucketUsername

Closes #185

## Summary by Sourcery

Add Bitbucket as a supported platform alongside GitHub and GitLab for scrum report generation.

New Features:
- Introduce BitbucketHelper to fetch Bitbucket pull requests, issues, repositories, and user data via the Bitbucket REST API with client-side caching.
- Add Bitbucket as a selectable platform in the popup UI, including a Bitbucket-specific section with app password input and visibility toggle.
- Persist Bitbucket credentials (username and app password token) in extension storage and load them into the popup and scrum helper flows.
- Integrate Bitbucket data into the existing scrum report generation pipeline by mapping Bitbucket issues and pull requests into the GitHub-style processing model.

Enhancements:
- Extend scrum report rendering, activity classification, and caching logic to handle Bitbucket-specific fields, authorship checks, and PR states consistently with other platforms.

Documentation:
- Add localized i18n strings and tooltip guidance for Bitbucket configuration and app password usage across all supported locales.