### PR TITLE
fix: background of extension for firefox sidepanel

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -87,7 +87,7 @@
 	</style>
 </head>
 
-<body class="mode-sidepanel text-gray-800 bg-gray-100 flex flex-col font-sans">
+<body class="mode-sidepanel text-gray-800 bg-gray-50 flex flex-col font-sans">
 	<div id="popupRoot" class="pl-1 py-2 rounded-2xl">
 		<div class="bg-white px-4 py-4 mx-2 mb-2 rounded-3xl">
 			<div class="flex justify-between py-2">

--- a/src/popup.html
+++ b/src/popup.html
@@ -79,7 +79,6 @@
 		/* Firefox Sidebar Fixes ONLY */
 		html.firefox-sidebar, 
 		body.firefox-sidebar {
-			background: transparent !important;
 			min-width: 100% !important;
 		}
 		body.firefox-sidebar #popupRoot {
@@ -88,7 +87,7 @@
 	</style>
 </head>
 
-<body class="mode-sidepanel text-gray-800 bg-gray-50 flex flex-col font-sans">
+<body class="mode-sidepanel text-gray-800 bg-gray-100 flex flex-col font-sans">
 	<div id="popupRoot" class="pl-1 py-2 rounded-2xl">
 		<div class="bg-white px-4 py-4 mx-2 mb-2 rounded-3xl">
 			<div class="flex justify-between py-2">


### PR DESCRIPTION
### 📌 Fixes

Fixes #624 

---

### 📝 Summary of Changes

- Fix the class for firefox side panel bg 


---

### 📸 Screenshots / Demo (if UI-related)

Before

Bg in dark mode shown white   and mad with love by fossasia text not visible in dark mode

<img width="603" height="857" alt="image" src="https://github.com/user-attachments/assets/de73877b-cb79-4a3d-a119-a869408b471d" />

After

<img width="603" height="857" alt="image" src="https://github.com/user-attachments/assets/78ca0c21-3712-4111-b902-4aa0a69fb44e" />

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

## Summary by Sourcery

Bug Fixes:
- Resolve incorrect transparent background in the Firefox sidebar popup that caused visual issues in dark mode.