### PR TITLE
Add GitLab API base URL setting (Self-hosted)

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -130,6 +130,22 @@
     "message": "Leave blank to use GitLab.com. For self-managed GitLab, enter the API v4 base URL.",
     "description": "Tooltip for the GitLab API base URL input."
   },
+  "gitlabBaseUrlInvalid": {
+    "message": "Enter a valid GitLab API v4 base URL, for example https://gitlab.example.com/api/v4.",
+    "description": "Validation message shown when the GitLab API base URL is invalid."
+  },
+  "gitlabHostPermissionGranted": {
+    "message": "GitLab host access granted.",
+    "description": "Toast shown when custom GitLab host permission is granted."
+  },
+  "gitlabHostPermissionDenied": {
+    "message": "GitLab host access was not granted.",
+    "description": "Toast shown when custom GitLab host permission is denied."
+  },
+  "gitlabHostPermissionFailed": {
+    "message": "Could not request GitLab host access.",
+    "description": "Toast shown when requesting custom GitLab host permission fails."
+  },
   "showCommitsLabel": {
     "message": "Show commits on open PRs/ draft PRs",
     "description": "Label for the checkbox to show commits in open PRs."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -118,6 +118,18 @@
     "message": "Why is it recommended to add a GitLab token? Scrum Helper works without a GitLab token for public projects, but adding a personal access token is recommended for a better experience.",
     "description": "Tooltip for GitLab token explaining why it's needed."
   },
+  "gitlabBaseUrlLabel": {
+    "message": "GitLab API Base URL",
+    "description": "Label for the GitLab API base URL input."
+  },
+  "gitlabBaseUrlPlaceholder": {
+    "message": "https://gitlab.com/api/v4",
+    "description": "Placeholder for the GitLab API base URL input."
+  },
+  "gitlabBaseUrlTooltip": {
+    "message": "Leave blank to use GitLab.com. For self-managed GitLab, enter the API v4 base URL.",
+    "description": "Tooltip for the GitLab API base URL input."
+  },
   "showCommitsLabel": {
     "message": "Show commits on open PRs/ draft PRs",
     "description": "Label for the checkbox to show commits in open PRs."

--- a/src/index.css
+++ b/src/index.css
@@ -161,6 +161,7 @@ hr,
 }
 
 .dark-mode input[type="text"],
+.dark-mode input[type="url"],
 .dark-mode input[type="date"],
 .dark-mode #scrumReport {
     background-color: #404040 !important;

--- a/src/manifests/chrome.json
+++ b/src/manifests/chrome.json
@@ -68,7 +68,8 @@
     "https://gitlab.com/*"
   ],
   "optional_host_permissions": [
-    "*://*/*"
+    "http://*/*",
+    "https://*/*"
   ],
   "default_locale": "en"
 }

--- a/src/manifests/chrome.json
+++ b/src/manifests/chrome.json
@@ -67,5 +67,8 @@
     "https://api.github.com/*",
     "https://gitlab.com/*"
   ],
+  "optional_host_permissions": [
+    "*://*/*"
+  ],
   "default_locale": "en"
 }

--- a/src/manifests/firefox.json
+++ b/src/manifests/firefox.json
@@ -67,7 +67,8 @@
     "https://gitlab.com/*"
   ],
   "optional_host_permissions": [
-    "*://*/*"
+    "http://*/*",
+    "https://*/*"
   ],
   "default_locale": "en",
   "sidebar_action": {

--- a/src/manifests/firefox.json
+++ b/src/manifests/firefox.json
@@ -66,6 +66,9 @@
     "https://api.github.com/*",
     "https://gitlab.com/*"
   ],
+  "optional_host_permissions": [
+    "*://*/*"
+  ],
   "default_locale": "en",
   "sidebar_action": {
     "default_panel": "popup.html?view=sidebar",

--- a/src/popup.html
+++ b/src/popup.html
@@ -497,6 +497,19 @@
 					</div>
 
 					<div class="gitlabOnlySection hidden mt-3">
+						<div class="flex items-center">
+							<p class="text-sm font-medium" data-i18n="gitlabBaseUrlLabel">GitLab API Base URL</p>
+							<span class="tooltip-container ml-2">
+								<i class="fa fa-question-circle question-icon"></i>
+								<span class="tooltip-bubble" data-i18n="gitlabBaseUrlTooltip">
+									Leave blank to use GitLab.com. For self-managed GitLab, enter the API v4 base URL.
+								</span>
+							</span>
+						</div>
+						<input id="gitlabBaseUrl" type="url"
+							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2"
+							data-i18n-placeholder="gitlabBaseUrlPlaceholder">
+
 						<div class="flex items-center justify-between">
 							<div class="flex">
 								<p class="text-sm font-medium" data-i18n="gitlabTokenLabel">Your GitLab Token</p>

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -143,7 +143,6 @@ if (!window.clearScrumHelperToast) {
 	};
 }
 
-
 // Backwards-compatible wrapper used across the codebase
 if (!window.showPopupMessage) {
 	window.showPopupMessage = function showPopupMessage(message, options = {}) {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,6 +1,7 @@
 const platformUsernameElement = document.getElementById('platformUsername');
 const githubTokenElement = document.getElementById('githubToken');
 const gitlabTokenElement = document.getElementById('gitlabToken');
+const gitlabBaseUrlElement = document.getElementById('gitlabBaseUrl');
 const cacheInputElement = document.getElementById('cacheInput');
 const projectNameElement = document.getElementById('projectName');
 const yesterdayContributionElement = document.getElementById('yesterdayContribution');
@@ -174,6 +175,7 @@ function handleBodyOnLoad() {
 			'cacheInput',
 			'githubToken',
 			'gitlabToken',
+			'gitlabBaseUrl',
 			'showCommits',
 		])
 		.then((items) => {
@@ -189,6 +191,9 @@ function handleBodyOnLoad() {
 			}
 			if (items.gitlabToken && gitlabTokenElement) {
 				gitlabTokenElement.value = items.gitlabToken;
+			}
+			if (items.gitlabBaseUrl && gitlabBaseUrlElement) {
+				gitlabBaseUrlElement.value = items.gitlabBaseUrl;
 			}
 			if (items.projectName) {
 				projectNameElement.value = items.projectName;
@@ -296,6 +301,10 @@ function handleGitlabTokenChange() {
 	const value = gitlabTokenElement.value;
 	browser.storage.local.set({ gitlabToken: value });
 }
+function handleGitlabBaseUrlChange() {
+	const value = gitlabBaseUrlElement.value.trim();
+	browser.storage.local.set({ gitlabBaseUrl: value });
+}
 function handleProjectNameChange() {
 	const value = projectNameElement.value;
 	browser.storage.local.set({ projectName: value });
@@ -330,6 +339,9 @@ if (githubTokenElement) {
 }
 if (gitlabTokenElement) {
 	gitlabTokenElement.addEventListener('keyup', handleGitlabTokenChange);
+}
+if (gitlabBaseUrlElement) {
+	gitlabBaseUrlElement.addEventListener('input', handleGitlabBaseUrlChange);
 }
 cacheInputElement.addEventListener('keyup', handleCacheInputChange);
 projectNameElement.addEventListener('keyup', handleProjectNameChange);

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -13,6 +13,10 @@ const userReasonElement = null;
 
 const showCommitsElement = document.getElementById('showCommits');
 
+function normalizeGitLabBaseUrl(baseUrl) {
+	return baseUrl.trim().replace(/\/+$/, '');
+}
+
 if (!window.scrumDateRangeUtils) {
 	window.scrumDateRangeUtils = {
 		formatLocalDate(date) {
@@ -302,7 +306,7 @@ function handleGitlabTokenChange() {
 	browser.storage.local.set({ gitlabToken: value });
 }
 function handleGitlabBaseUrlChange() {
-	const value = gitlabBaseUrlElement.value.trim();
+	const value = normalizeGitLabBaseUrl(gitlabBaseUrlElement.value);
 	browser.storage.local.set({ gitlabBaseUrl: value });
 }
 function handleProjectNameChange() {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -306,6 +306,7 @@ function handleGitlabTokenChange() {
 }
 function handleGitlabBaseUrlChange() {
 	const value = normalizeGitLabBaseUrl(gitlabBaseUrlElement.value);
+	gitlabBaseUrlElement.value = value;
 	browser.storage.local.set({ gitlabBaseUrl: value });
 }
 function handleProjectNameChange() {
@@ -344,7 +345,7 @@ if (gitlabTokenElement) {
 	gitlabTokenElement.addEventListener('keyup', handleGitlabTokenChange);
 }
 if (gitlabBaseUrlElement) {
-	gitlabBaseUrlElement.addEventListener('input', handleGitlabBaseUrlChange);
+	gitlabBaseUrlElement.addEventListener('change', handleGitlabBaseUrlChange);
 }
 cacheInputElement.addEventListener('keyup', handleCacheInputChange);
 projectNameElement.addEventListener('keyup', handleProjectNameChange);

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -480,9 +480,6 @@ document.addEventListener('DOMContentLoaded', () => {
 		if (!origin || !browser.permissions?.request) return true;
 
 		try {
-			const hasPermission = await browser.permissions.contains({ origins: [origin] });
-			if (hasPermission) return true;
-
 			const granted = await browser.permissions.request({ origins: [origin] });
 			if (granted) {
 				window.showPopupMessage?.(browser.i18n.getMessage('gitlabHostPermissionGranted'));
@@ -773,45 +770,43 @@ document.addEventListener('DOMContentLoaded', () => {
 			});
 		}
 
-		generateBtn.addEventListener('click', () => {
-			browser.storage.local.get(['platform']).then(async (result) => {
-				platformUsername.classList.remove('input-error');
-				usernameError.classList.remove('errorMessage');
-				usernameError.textContent = '';
-				const platform = result.platform || 'github';
-				const platformUsernameKey = `${platform}Username`;
-				const gitlabBaseUrl = normalizeGitLabBaseUrl(gitlabBaseUrlInput?.value || '');
-				if (gitlabBaseUrlInput) {
-					gitlabBaseUrlInput.value = gitlabBaseUrl;
-				}
+		generateBtn.addEventListener('click', async () => {
+			platformUsername.classList.remove('input-error');
+			usernameError.classList.remove('errorMessage');
+			usernameError.textContent = '';
+			const platform = platformSelect.value || 'github';
+			const platformUsernameKey = `${platform}Username`;
+			const gitlabBaseUrl = normalizeGitLabBaseUrl(gitlabBaseUrlInput?.value || '');
+			if (gitlabBaseUrlInput) {
+				gitlabBaseUrlInput.value = gitlabBaseUrl;
+			}
 
-				if (platformSelect.value === 'gitlab' && !isValidGitLabApiBaseUrl(gitlabBaseUrl)) {
-					window.showPopupMessage?.(browser.i18n.getMessage('gitlabBaseUrlInvalid'));
-					return;
-				}
+			if (platform === 'gitlab' && !isValidGitLabApiBaseUrl(gitlabBaseUrl)) {
+				window.showPopupMessage?.(browser.i18n.getMessage('gitlabBaseUrlInvalid'));
+				return;
+			}
 
-				if (platformSelect.value === 'gitlab') {
-					const hasGitLabHostPermission = await requestGitLabHostPermission(gitlabBaseUrl);
-					if (!hasGitLabHostPermission) return;
-				}
+			if (platform === 'gitlab') {
+				const hasGitLabHostPermission = await requestGitLabHostPermission(gitlabBaseUrl);
+				if (!hasGitLabHostPermission) return;
+			}
 
-				browser.storage.local
-					.set({
-						platform: platformSelect.value,
-						[platformUsernameKey]: platformUsername.value,
-						gitlabBaseUrl: gitlabBaseUrl,
-					})
-					.then(() => {
-						// Reload platform from storage before generating report
-						browser.storage.local.get(['platform']).then((res) => {
-							platformSelect.value = res.platform || 'github';
-							updatePlatformUI(platformSelect.value);
-							generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
-							generateBtn.disabled = true;
-							window.generateScrumReport && window.generateScrumReport();
-						});
+			browser.storage.local
+				.set({
+					platform: platform,
+					[platformUsernameKey]: platformUsername.value,
+					gitlabBaseUrl: gitlabBaseUrl,
+				})
+				.then(() => {
+					// Reload platform from storage before generating report
+					browser.storage.local.get(['platform']).then((res) => {
+						platformSelect.value = res.platform || 'github';
+						updatePlatformUI(platformSelect.value);
+						generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
+						generateBtn.disabled = true;
+						window.generateScrumReport && window.generateScrumReport();
 					});
-			});
+				});
 		});
 
 		copyBtn.addEventListener('click', function () {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -482,14 +482,14 @@ document.addEventListener('DOMContentLoaded', () => {
 		try {
 			const granted = await browser.permissions.request({ origins: [origin] });
 			if (granted) {
-				window.showPopupMessage?.(browser.i18n.getMessage('gitlabHostPermissionGranted'));
+				window.scrumHelperToast?.(browser.i18n.getMessage('gitlabHostPermissionGranted'));
 				return true;
 			}
 
-			window.showPopupMessage?.(browser.i18n.getMessage('gitlabHostPermissionDenied'));
+			window.scrumHelperToast?.(browser.i18n.getMessage('gitlabHostPermissionDenied'), { variant: 'error' });
 		} catch (error) {
 			console.error('GitLab host permission request failed:', error);
-			window.showPopupMessage?.(browser.i18n.getMessage('gitlabHostPermissionFailed'));
+			window.scrumHelperToast?.(browser.i18n.getMessage('gitlabHostPermissionFailed'), { variant: 'error' });
 		}
 
 		return false;
@@ -782,7 +782,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 
 			if (platform === 'gitlab' && !isValidGitLabApiBaseUrl(gitlabBaseUrl)) {
-				window.showPopupMessage?.(browser.i18n.getMessage('gitlabBaseUrlInvalid'));
+				window.scrumHelperToast?.(browser.i18n.getMessage('gitlabBaseUrlInvalid'), { variant: 'error' });
 				return;
 			}
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -457,7 +457,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			const url = new URL(baseUrl);
 			return (
 				(url.protocol === 'http:' || url.protocol === 'https:') &&
-				url.pathname === '/api/v4' &&
+				url.pathname.endsWith('/api/v4') &&
 				url.search === '' &&
 				url.hash === ''
 			);
@@ -1018,11 +1018,6 @@ document.addEventListener('DOMContentLoaded', () => {
 		githubTokenInput.addEventListener('input', () => {
 			browser.storage.local.set({ githubToken: githubTokenInput.value });
 		});
-		if (gitlabBaseUrlInput) {
-			gitlabBaseUrlInput.addEventListener('input', () => {
-				browser.storage.local.set({ gitlabBaseUrl: normalizeGitLabBaseUrl(gitlabBaseUrlInput.value) });
-			});
-		}
 		cacheInput.addEventListener('input', () => {
 			browser.storage.local.set({ cacheInput: cacheInput.value });
 		});

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -446,6 +446,58 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	window.updateGenerateButtonState = updateGenerateButtonState;
 
+	function normalizeGitLabBaseUrl(baseUrl) {
+		return baseUrl.trim().replace(/\/+$/, '');
+	}
+
+	function isValidGitLabApiBaseUrl(baseUrl) {
+		if (!baseUrl) return true;
+
+		try {
+			const url = new URL(baseUrl);
+			return (
+				(url.protocol === 'http:' || url.protocol === 'https:') &&
+				url.pathname === '/api/v4' &&
+				url.search === '' &&
+				url.hash === ''
+			);
+		} catch (_error) {
+			return false;
+		}
+	}
+
+	function getGitLabHostPermissionOrigin(baseUrl) {
+		if (!baseUrl) return null;
+
+		const url = new URL(baseUrl);
+		if (url.origin === 'https://gitlab.com') return null;
+
+		return `${url.protocol}//${url.host}/*`;
+	}
+
+	async function requestGitLabHostPermission(baseUrl) {
+		const origin = getGitLabHostPermissionOrigin(baseUrl);
+		if (!origin || !browser.permissions?.request) return true;
+
+		try {
+			const hasPermission = await browser.permissions.contains({ origins: [origin] });
+			if (hasPermission) return true;
+
+			const granted = await browser.permissions.request({ origins: [origin] });
+			if (granted) {
+				window.showPopupMessage?.(browser.i18n.getMessage('gitlabHostPermissionGranted'));
+				return true;
+			}
+
+			window.showPopupMessage?.(browser.i18n.getMessage('gitlabHostPermissionDenied'));
+		} catch (error) {
+			console.error('GitLab host permission request failed:', error);
+			window.showPopupMessage?.(browser.i18n.getMessage('gitlabHostPermissionFailed'));
+		}
+
+		return false;
+	}
+
 	async function bootstrapScrumReportOnPopupLoad(generateBtn) {
 		console.log('[BOOTSTRAP] bootstrapScrumReportOnPopupLoad called');
 
@@ -722,17 +774,32 @@ document.addEventListener('DOMContentLoaded', () => {
 		}
 
 		generateBtn.addEventListener('click', () => {
-			browser.storage.local.get(['platform']).then((result) => {
+			browser.storage.local.get(['platform']).then(async (result) => {
 				platformUsername.classList.remove('input-error');
 				usernameError.classList.remove('errorMessage');
 				usernameError.textContent = '';
 				const platform = result.platform || 'github';
 				const platformUsernameKey = `${platform}Username`;
+				const gitlabBaseUrl = normalizeGitLabBaseUrl(gitlabBaseUrlInput?.value || '');
+				if (gitlabBaseUrlInput) {
+					gitlabBaseUrlInput.value = gitlabBaseUrl;
+				}
+
+				if (platformSelect.value === 'gitlab' && !isValidGitLabApiBaseUrl(gitlabBaseUrl)) {
+					window.showPopupMessage?.(browser.i18n.getMessage('gitlabBaseUrlInvalid'));
+					return;
+				}
+
+				if (platformSelect.value === 'gitlab') {
+					const hasGitLabHostPermission = await requestGitLabHostPermission(gitlabBaseUrl);
+					if (!hasGitLabHostPermission) return;
+				}
 
 				browser.storage.local
 					.set({
 						platform: platformSelect.value,
 						[platformUsernameKey]: platformUsername.value,
+						gitlabBaseUrl: gitlabBaseUrl,
 					})
 					.then(() => {
 						// Reload platform from storage before generating report
@@ -958,7 +1025,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		});
 		if (gitlabBaseUrlInput) {
 			gitlabBaseUrlInput.addEventListener('input', () => {
-				browser.storage.local.set({ gitlabBaseUrl: gitlabBaseUrlInput.value.trim() });
+				browser.storage.local.set({ gitlabBaseUrl: normalizeGitLabBaseUrl(gitlabBaseUrlInput.value) });
 			});
 		}
 		cacheInput.addEventListener('input', () => {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -128,6 +128,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	// GitLab token elements
 	const gitlabTokenInput = document.getElementById('gitlabToken');
+	const gitlabBaseUrlInput = document.getElementById('gitlabBaseUrl');
 	const toggleGitlabTokenBtn = document.getElementById('toggleGitlabTokenVisibility');
 	const gitlabTokenEyeIcon = document.getElementById('gitlabTokenEyeIcon');
 	let gitlabTokenVisible = false;
@@ -585,6 +586,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				'showOpenLabel',
 				'showCommits',
 				'githubToken',
+				'gitlabBaseUrl',
 				'cacheInput',
 				'onlyIssues',
 				'onlyPRs',
@@ -642,6 +644,7 @@ document.addEventListener('DOMContentLoaded', () => {
 					browser?.storage.local.set({ onlyPRs: false });
 				}
 				if (result.githubToken) githubTokenInput.value = result.githubToken;
+				if (result.gitlabBaseUrl && gitlabBaseUrlInput) gitlabBaseUrlInput.value = result.gitlabBaseUrl;
 				if (result.cacheInput) cacheInput.value = result.cacheInput;
 				if (typeof result.yesterdayContribution !== 'undefined') yesterdayRadio.checked = result.yesterdayContribution;
 				if (result.startingDate) startingDateInput.value = result.startingDate;
@@ -953,6 +956,11 @@ document.addEventListener('DOMContentLoaded', () => {
 		githubTokenInput.addEventListener('input', () => {
 			browser.storage.local.set({ githubToken: githubTokenInput.value });
 		});
+		if (gitlabBaseUrlInput) {
+			gitlabBaseUrlInput.addEventListener('input', () => {
+				browser.storage.local.set({ gitlabBaseUrl: gitlabBaseUrlInput.value.trim() });
+			});
+		}
 		cacheInput.addEventListener('input', () => {
 			browser.storage.local.set({ cacheInput: cacheInput.value });
 		});

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -60,7 +60,7 @@ function handleUsernameValidationError(errMessage) {
 }
 
 function mapGitLabReportItem(item, projectById, type, gitlabApiBaseUrl) {
-	const project = projectById.get(item.project_id);
+	const project = projectById?.get(item.project_id);
 	const repoName = project ? project.name : 'unknown';
 
 	return {
@@ -1951,6 +1951,8 @@ async function forceGitlabDataRefresh() {
 	hasInjectedContent = false;
 	// Re-instantiate gitlabHelper to ensure a fresh instance for next API call
 	if (window.GitLabHelper) {
+		const items = await chrome.storage.local.get(['gitlabBaseUrl']);
+		gitlabBaseUrl = items.gitlabBaseUrl || '';
 		gitlabHelper = new window.GitLabHelper(gitlabBaseUrl);
 	}
 	return { success: true };


### PR DESCRIPTION
### 📌 Fixes

Part of #627

---

### 📝 Summary of Changes

- Added a GitLab-only `GitLab API Base URL` field in the popup/settings UI.
- Persisted `gitlabBaseUrl` in browser storage and restored it when the popup initializes.
- Normalized the saved value by trimming whitespace and removing trailing slashes.
- Required custom GitLab URLs to be explicit API v4 URLs, including subpath installs such as `https://gitlab.example.com/gitlab/api/v4`.
- Added optional host permission handling for custom GitLab hosts.
- Requested custom host permission only when generating a GitLab report.
- Updated dark mode styling for the new URL input.
- Addressed review feedback around duplicate storage writes, refresh behavior, and GitLab project mapping safety.

---

### 📸 Screenshots / Demo (if UI-related)

Both default & self-hosted gitlab flow:

<img width="576" height="946" alt="OC7TaTYD6G" src="https://github.com/user-attachments/assets/61a7e8b3-64c3-476d-b4e1-26b8a06e27cf" />

Permission request:

<img width="1920" height="1080" alt="Screenshot (198)" src="https://github.com/user-attachments/assets/79584aac-aae2-4af0-888e-ea9d79c2af62" />

Access granted:

<img width="1920" height="1080" alt="Screenshot (199)" src="https://github.com/user-attachments/assets/fe91c48b-71a8-4331-9488-68ea6330dd0d" />

Report generation:

<img width="1920" height="1080" alt="Screenshot (200)" src="https://github.com/user-attachments/assets/8f9a674e-cc7f-4831-8825-81fe306b828a" />

Invalid base URL validation:

<img width="1920" height="1080" alt="Screenshot (201)" src="https://github.com/user-attachments/assets/ad0edbbd-2ad6-44f2-aa9f-d87e6c216fc8" />

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

This PR intentionally keeps the scope limited to GitLab API base URL configuration and custom host permission handling.

## Summary by Sourcery

Add support for configuring a GitLab API base URL, including self-hosted instances, and wire it through the popup UI, storage, and GitLab data fetching.

New Features:
- Introduce a GitLab API base URL setting in the popup UI for GitLab users, including support for self-hosted instances.
- Persist the GitLab API base URL in browser storage and apply it when generating GitLab-based scrum reports.
- Request optional host permissions dynamically for custom GitLab hosts when generating GitLab reports.

Enhancements:
- Refactor GitLab report data mapping to share logic and derive repository URLs from the configured API base URL.
- Include the GitLab API base URL in the GitLabHelper cache key and allow GitLabHelper to be initialized with a custom base URL.
- Update dark mode styling to support the new GitLab API base URL input field.

Build:
- Adjust browser extension manifests to support optional permissions for custom GitLab host origins.

## Summary by Sourcery

Add configurable GitLab API base URL support, including self-hosted instances, and wire it through the popup UI, storage, permissions, and GitLab data fetching.

New Features:
- Introduce a GitLab API base URL input in the popup for GitLab users with self-hosted support.
- Persist the GitLab API base URL in browser storage and apply it when generating GitLab-based scrum reports.
- Dynamically request optional host permissions for custom GitLab hosts when generating GitLab reports.

Enhancements:
- Normalize and validate GitLab API base URLs and surface user-facing validation feedback.
- Ensure GitLab report generation and helper instances respect the configured API base URL and refresh behavior.
- Improve dark mode styling to cover the new GitLab API base URL input field.

Build:
- Update browser extension manifests to support optional permissions for configurable GitLab host origins.