### PR TITLE
Add abstraction layer

### DIFF
--- a/src/manifests/chrome.json
+++ b/src/manifests/chrome.json
@@ -32,6 +32,8 @@
         "scripts/browser-polyfill.min.js",
         "scripts/jquery-3.2.1.min.js",
         "scripts/emailClientAdapter.js",
+        "scripts/platformRegistry.js",
+        "scirpts/githubProvider.js",
         "scripts/gitlabHelper.js",
         "scripts/scrumHelper.js"
       ]

--- a/src/manifests/chrome.json
+++ b/src/manifests/chrome.json
@@ -33,7 +33,7 @@
         "scripts/jquery-3.2.1.min.js",
         "scripts/emailClientAdapter.js",
         "scripts/platformRegistry.js",
-        "scirpts/githubProvider.js",
+        "scripts/githubProvider.js",
         "scripts/gitlabHelper.js",
         "scripts/scrumHelper.js"
       ]

--- a/src/manifests/firefox.json
+++ b/src/manifests/firefox.json
@@ -32,6 +32,8 @@
         "scripts/browser-polyfill.min.js",
         "scripts/jquery-3.2.1.min.js",
         "scripts/emailClientAdapter.js",
+        "scripts/platformRegistry.js",
+        "scirpts/githubProvider.js",
         "scripts/gitlabHelper.js",
         "scripts/scrumHelper.js"
       ]

--- a/src/manifests/firefox.json
+++ b/src/manifests/firefox.json
@@ -33,7 +33,7 @@
         "scripts/jquery-3.2.1.min.js",
         "scripts/emailClientAdapter.js",
         "scripts/platformRegistry.js",
-        "scirpts/githubProvider.js",
+        "scripts/githubProvider.js",
         "scripts/gitlabHelper.js",
         "scripts/scrumHelper.js"
       ]

--- a/src/popup.html
+++ b/src/popup.html
@@ -617,6 +617,8 @@
 	<script type="text/javascript" src="materialize/js/materialize.min.js"></script>
 	<script src="scripts/emailClientAdapter.js"></script>
 	<script src="scripts/main.js"></script>
+	<script src="scripts/platformRegistry.js"></script>
+	<script src="scripts/githubProvider.js"></script>
 	<script src="scripts/gitlabHelper.js"></script>
 	<script src="scripts/scrumHelper.js"></script>
 	<script src="scripts/popup.js"></script>

--- a/src/scripts/githubProvider.js
+++ b/src/scripts/githubProvider.js
@@ -1,0 +1,58 @@
+// GitHub platform provider for Scrum_Helper
+class GitHubProvider {
+    constructor(){
+        this.baseUrl = 'https://api.github.com';
+        this.graphqlUrl = 'https://api.github.com/graphql';
+    }
+
+    buildHeaders(token){
+         const headers = {
+            Accept: 'application/vnd.github.v3+json',
+         };
+         if (token){
+            headers.Authorization = `token ${token}`;
+         } 
+         return headers;
+    }
+
+    buildGraphQLHeaders(token){
+        return{
+            ...this.buildHeaders(token),
+            'Content-Type': 'application/json',
+        }
+    }
+
+    buildUserUrl(username){
+        return `${this.baseUrl}/users/${username}`;
+    }
+
+    buidlSearchUrl(query){
+        return `${this.baseUrl}/search/issues?q=${query}&per_page=100`;
+    }
+
+    buildOrgQuery(orgName){
+        return orgName && orgName !== 'all' ? `+org:${orgName}` : '';
+    }
+
+    buildRepoQuery(repo){
+        if(!repo) return '';
+
+        if(typeof repo === 'object' && repo.fullName){
+            const cleanName = repo.fullName.startsWith('/') ? repo.fullName.substring(1) : repo;
+            return `repo:${cleanName}`
+        }
+
+        return `repo:${repo}`;
+    }
+
+    
+}
+if(typeof module !== undefined && module.exports){
+    module.exports = GitHubProvider;
+}else {
+    window.GitHubProvider = GitHubProvider;
+
+    if(window.platformRegistry){
+        window.platformRegistry.registerProvider('github',new GitHubProvider());
+    }
+}

--- a/src/scripts/githubProvider.js
+++ b/src/scripts/githubProvider.js
@@ -26,12 +26,13 @@ class GitHubProvider {
         return `${this.baseUrl}/users/${username}`;
     }
 
-    buidlSearchUrl(query){
+    buildSearchUrl(query){
         return `${this.baseUrl}/search/issues?q=${query}&per_page=100`;
     }
 
     buildOrgQuery(orgName){
-        return orgName && orgName !== 'all' ? `+org:${orgName}` : '';
+       return orgName && orgName.trim() ? `+org%3A${orgName}` : '';
+      
     }
 
     buildRepoQuery(repo){
@@ -44,10 +45,40 @@ class GitHubProvider {
 
         return `repo:${repo}`;
     }
+    buildRepoQueries(selectedRepos, repoData){
+        return selectedRepos.filter((repo)=> repo!== null).map((repo)=>{
+            if(typeof repo === 'object' && repo.fullName){
+                return this.buildRepoQuery(repo);
+            }
+            if(repo.includes('/')){
+                return this.buildRepoQuery(repo);
+            }
+            const fullRepoInfo = repoData?.find((r)=>r.name === repo);
+            if(fullRepoInfo && fullRepoInfo.fullName) {
+                return `repo:${fullRepoInfo.fullName}`;
+            }
+
+            return this.buildRepoQuery(repo);
+        }).join('+');
+    }
+
+    buildActivityUrls(options){
+        const orgQuery = this.buildOrgQuery(options.orgName);
+        const repoQueries= options.useRepoFilter ? this.buildRepoQueries(options.selectedRepos || [] , options.repoData) : '';
+        const repoQuery= repoQueries ? `+${repoQueries}` : '';
+        const dataQuery= `updated%3A${options.startDate}..${options.endDate}`;
+
+        return{
+            issueUrl:this.buildSearchUrl(`author%3A${options.username}${repoQuery}${orgQuery}+${dataQuery}`),
+            prUrl:this.buildSearchUrl(`commenter%3A${options.username}${repoQuery}${orgQuery}+${dataQuery}`),
+            userUrl:this.buildUserUrl(options.username),
+            repoQueries
+        }
+    }
 
     
 }
-if(typeof module !== undefined && module.exports){
+if(typeof module !== 'undefined' && module.exports){
     module.exports = GitHubProvider;
 }else {
     window.GitHubProvider = GitHubProvider;

--- a/src/scripts/platformRegistry.js
+++ b/src/scripts/platformRegistry.js
@@ -1,0 +1,20 @@
+// Function for saving and calling SCM providers
+(function () {
+  const providers = {};
+
+  // For saving platform and its related provider
+  function registerProvider(platform, provider) {
+    if (!platform || !provider) return;
+    providers[platform] = provider;
+  }
+
+  // For finding the provider to work by using these save platform
+  function getProvider(platform) {
+    return providers[platform] || null;
+  }
+
+  window.platformRegistry = {
+    registerProvider,
+    getProvider,
+  };
+})();

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -596,63 +596,42 @@ function allIncluded(outputTarget = 'email') {
 		console.log('[SCRUM-HELPER] orgName before API query:', orgName);
 		console.log('[SCRUM-HELPER] orgName type:', typeof orgName);
 		console.log('[SCRUM-HELPER] orgName length:', orgName ? orgName.length : 0);
-		const orgPart = orgName && orgName.trim() ? `+org%3A${orgName}` : '';
-		console.log('[SCRUM-HELPER] orgPart for API:', orgPart);
-		console.log('[SCRUM-HELPER] orgPart length:', orgPart.length);
 
-		let issueUrl;
-		let prUrl;
-		let userUrl;
+		const githubProvider = window.platformRegistry?.getProvider('github');
+		if(!githubProvider){
+			throw new Error ('GitHub provider is not available');
+		}
+		if(useRepoFilter && selectedRepos && selectedRepos.length > 0 ){
+			log('Using repo filter for api calls', selectedRepos);
+		
+		try{
+			await fetchReposIfNeeded();
+		} catch(err){
+			logError('Failed to fetch repo data for filtering',err);
+		} 
+	    }else{
+			log ('Using org wide search');
+		}
 
-		if (useRepoFilter && selectedRepos && selectedRepos.length > 0) {
-			log('Using repo filter for api calls:', selectedRepos);
+		const activityUrls = githubProvider.buildActivityUrls({
+			username:platformUsernameLocal,
+			orgName: orgName,
+			startDate: startDateForCache,
+			endDate: endDateForCache,
+			useRepoFilter: useRepoFilter && selectedRepos && selectedRepos.length > 0,
+			selectedRepos:selectedRepos,
+			repoData: githubCache.repoData,
+		});
 
-			try {
-				await fetchReposIfNeeded();
-			} catch (err) {
-				logError('Failed to fetch repo data for filtering:', err);
-			}
-
-			const repoQueries = selectedRepos
-				.filter((repo) => repo !== null)
-				.map((repo) => {
-					if (typeof repo === 'object' && repo.fullName) {
-						const cleanName = repo.fullName.startsWith('/') ? repo.fullName.substring(1) : repo.fullName;
-						return `repo:${cleanName}`;
-					}
-
-					if (repo.includes('/')) {
-						const cleanName = repo.startsWith('/') ? repo.substring(1) : repo;
-						return `repo:${cleanName}`;
-					}
-
-					const fullRepoInfo = githubCache.repoData?.find((r) => r.name === repo);
-					if (fullRepoInfo && fullRepoInfo.fullName) {
-						return `repo:${fullRepoInfo.fullName}`;
-					}
-					logError(`Missing owner for repo ${repo} - search may fail`);
-					return `repo:${repo}`;
-				})
-				.join('+');
-
-			const orgQuery = orgPart ? `+${orgPart}` : '';
-			if (!repoQueries) {
-				loadFromStorage('Repo filter empty, using org wide search');
-				issueUrl = `https://api.github.com/search/issues?q=author%3A${platformUsernameLocal}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
-				prUrl = `https://api.github.com/search/issues?q=commenter%3A${platformUsernameLocal}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
-				userUrl = `https://api.github.com/users/${platformUsernameLocal}`;
-			} else {
-				issueUrl = `https://api.github.com/search/issues?q=author%3A${platformUsernameLocal}+${repoQueries}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
-				prUrl = `https://api.github.com/search/issues?q=commenter%3A${platformUsernameLocal}+${repoQueries}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
-				userUrl = `https://api.github.com/users/${platformUsernameLocal}`;
-				log('Repository-filtered URLs:', { issueUrl, prUrl });
-			}
-		} else {
-			loadFromStorage('Using org wide search');
-			const orgQuery = orgPart ? `+${orgPart}` : '';
-			issueUrl = `https://api.github.com/search/issues?q=author%3A${platformUsernameLocal}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
-			prUrl = `https://api.github.com/search/issues?q=commenter%3A${platformUsernameLocal}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
-			userUrl = `https://api.github.com/users/${platformUsernameLocal}`;
+		const issueUrl = activityUrls.issueUrl;
+		const prUrl = activityUrls.prUrl;
+		const userUrl=activityUrls.userUrl;
+		
+		if(useRepoFilter && selectedRepos && selectedRepos.length > 0 && !activityUrls.repoQueries){
+			log('Repo filter empty, using org wide search');
+		}
+		if(activityUrls.repoQueries){
+			log('Repository-filtered URLs:',{issueUrl,prUrl})
 		}
 
 		try {


### PR DESCRIPTION
### 📌 Fixes

Fixes #637 

---

### 📝 Summary of Changes

- Add platform Registry layer where will decide which platform user want and find its related provider
- Build githubprovider.js and relocate URL composing from scrumHelper.js to here as testing step

---

### 📸 Screenshots / Demo (if UI-related)

There will be no screen shot for this PR.
Since it is code refactoring without affecting current working logic.

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

- I will commit and  fix some code formatting error in next. So, contributors can review code changes more comfortably.

## Summary by Sourcery

Introduce a platform registry and GitHub provider abstraction and migrate Scrum helper GitHub activity URL construction to this new layer.

New Features:
- Add a platform registry for registering and retrieving SCM providers by platform key.
- Add a GitHub provider module that encapsulates GitHub API URL and header construction.

Enhancements:
- Refactor scrumHelper to delegate GitHub activity URL building to the shared GitHub provider abstraction.
- Wire the new platform registry and GitHub provider into the popup script loading pipeline.