### PR TITLE
Feat: adding redaction for exposing PAT on log

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -138,7 +138,6 @@ if (!window.clearScrumHelperToast) {
 	};
 }
 
-
 // Backwards-compatible wrapper used across the codebase
 if (!window.showPopupMessage) {
 	window.showPopupMessage = function showPopupMessage(message, options = {}) {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -39,6 +39,17 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 });
 
+function logRedaction(items) {
+	const spreadItems = { ...items };
+	const sensitiveKeys = ['githubToken', 'gitlabToken'];
+	sensitiveKeys.forEach((key) => {
+		if (key in spreadItems) {
+			spreadItems[key] = '[REDACTED]';
+		}
+	});
+	return spreadItems;
+}
+
 function showReportMessage(message) {
 	if (!message) return;
 	if (scrumReportEl) {
@@ -178,7 +189,7 @@ function allIncluded(outputTarget = 'email') {
 				'onlyMergedPRs',
 			])
 			.then((items) => {
-				console.log('[DEBUG] Storage items received:', items);
+				console.log('[DEBUG] Storage items received:', logRedaction(items));
 				platform = items.platform || 'github';
 
 				// Load platform-specific username


### PR DESCRIPTION
### 📌 Fixes

Fixes #564 

---

### 📝 Summary of Changes

- Add helper function call logRedaction
- Use it to redact user PAT in log

---

### 📸 Screenshots / Demo (if UI-related)

<img width="328" height="45" alt="Screenshot 2026-05-13 111855" src="https://github.com/user-attachments/assets/38b711dc-4bca-461f-95f0-724ac68d27ca" />


---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

Instead of inline redaction inside the log session , use writing helper function .
This function can use in centralized redaction when we extend our extension .

## Summary by Sourcery

Enhancements:
- Clean up whitespace in the main script for consistent formatting.