### PR TITLE
fix: merged PRs filter related problems

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -138,7 +138,6 @@ if (!window.clearScrumHelperToast) {
 	};
 }
 
-
 // Backwards-compatible wrapper used across the codebase
 if (!window.showPopupMessage) {
 	window.showPopupMessage = function showPopupMessage(message, options = {}) {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -224,7 +224,8 @@ function allIncluded(outputTarget = 'email') {
 				onlyIssues = items.onlyIssues === true;
 				onlyPRs = items.onlyPRs === true;
 				onlyRevPRs = items.onlyRevPRs === true;
-				console.log('[SCRUM-DEBUG] loaded flags:', { onlyIssues, onlyPRs, onlyRevPRs });
+				onlyMergedPRs = items.onlyMergedPRs === true;
+				console.log('[SCRUM-DEBUG] loaded flags:', { onlyIssues, onlyPRs, onlyRevPRs,onlyMergedPRs });
 				// Enforce mutual exclusivity between onlyIssues and onlyPRs to avoid filtering out everything
 				if (onlyIssues && onlyPRs) {
 					console.warn('[SCRUM-HELPER]: Detected both onlyIssues and onlyPRs enabled; normalizing to onlyIssues.');
@@ -1246,7 +1247,7 @@ ${blockerText}`;
 	}
 
 	function writeGithubPrsReviews() {
-		const isAnyFilterActive = onlyIssues || onlyPRs || onlyRevPRs;
+		const isAnyFilterActive = onlyIssues || onlyPRs || onlyRevPRs || onlyMergedPRs;
 		if (isAnyFilterActive && !onlyRevPRs) {
 			log('Filters active but onlyRevPRs not checked, skipping PR reviews.');
 			reviewedPrsArray = [];

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -225,7 +225,7 @@ function allIncluded(outputTarget = 'email') {
 				onlyPRs = items.onlyPRs === true;
 				onlyRevPRs = items.onlyRevPRs === true;
 				onlyMergedPRs = items.onlyMergedPRs === true;
-				console.log('[SCRUM-DEBUG] loaded flags:', { onlyIssues, onlyPRs, onlyRevPRs,onlyMergedPRs });
+				console.log('[SCRUM-DEBUG] loaded flags:', { onlyIssues, onlyPRs, onlyRevPRs, onlyMergedPRs });
 				// Enforce mutual exclusivity between onlyIssues and onlyPRs to avoid filtering out everything
 				if (onlyIssues && onlyPRs) {
 					console.warn('[SCRUM-HELPER]: Detected both onlyIssues and onlyPRs enabled; normalizing to onlyIssues.');


### PR DESCRIPTION
### 📌 Fixes

Fixes #606 

---

### 📝 Summary of Changes

- fix filter for merge PRs
- fix the checkbox state and show only merged PRs when merge box checked

---

### 📸 Screenshots / Demo (if UI-related)

Before:

[Demo 1.webm](https://github.com/user-attachments/assets/5e9646df-044e-4a84-8ba6-e138b5a79fe9)


After:

[Deme.webm](https://github.com/user-attachments/assets/206cedf4-f9f1-4e50-bbf5-7f717b954976)



---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests
- [ ] I’ve updated documentation
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_

## Summary by Sourcery

Fix filtering logic for GitHub PR reviews when the merged PRs option is used.

Bug Fixes:
- Load and track the onlyMergedPRs filter flag alongside existing issue and PR filters.
- Ensure merged PRs filtering participates correctly in the active-filter detection for PR reviews.