### PR TITLE
fix: copy empty report

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -346,7 +346,7 @@
 							</div>
 
 							<div class="tooltip-container">
-								<button id="copyReport"
+								<button id="copyReport" disabled
 									class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded">
 									<i class="fa fa-copy"></i> <span data-i18n="copyReportButton">Copy</span>
 								</button>

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -138,7 +138,6 @@ if (!window.clearScrumHelperToast) {
 	};
 }
 
-
 // Backwards-compatible wrapper used across the codebase
 if (!window.showPopupMessage) {
 	window.showPopupMessage = function showPopupMessage(message, options = {}) {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -746,8 +746,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		copyBtn.addEventListener('click', function () {
 			const scrumReport = document.getElementById('scrumReport');
+			const reportHtml = scrumReport ? sanitizeHtml(scrumReport.innerHTML) : '';
 			const tempDiv = document.createElement('div');
-			tempDiv.innerHTML = sanitizeHtml(scrumReport.innerHTML);
+			tempDiv.innerHTML = reportHtml;
+
+			if (!tempDiv.textContent.trim()) {
+				this._triggeredByShortcut = false;
+				return;
+			}
+
 			document.body.appendChild(tempDiv);
 			tempDiv.style.position = 'absolute';
 			tempDiv.style.left = '-9999px';

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -452,7 +452,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			return;
 		}
 
-		copyBtn.disabled = !scrumReport.textContent.trim();
+		copyBtn.disabled = scrumReport.dataset.copyPlaceholder === 'true' || !scrumReport.textContent.trim();
 	}
 
 	async function bootstrapScrumReportOnPopupLoad(generateBtn) {
@@ -536,6 +536,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 				if (reportEmpty && lastScrumReportHtml && matches) {
 					scrumReport.innerHTML = sanitizeHtml(lastScrumReportHtml);
+					delete scrumReport.dataset.copyPlaceholder;
 					if (generateBtn) generateBtn.disabled = false;
 					return;
 				}
@@ -548,6 +549,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			// If cache is expired, still only show the old HTML if it was for the current username
 			if ((!scrumReport.innerHTML || !scrumReport.innerHTML.trim()) && lastScrumReportHtml && isUsernameMatch) {
 				scrumReport.innerHTML = sanitizeHtml(lastScrumReportHtml);
+				delete scrumReport.dataset.copyPlaceholder;
 			}
 
 			if (generateBtn) generateBtn.disabled = false;
@@ -682,6 +684,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		const scrumReportEl = document.getElementById('scrumReport');
 		if (scrumReportEl) {
+			scrumReportEl.addEventListener('input', () => {
+				if (scrumReportEl.dataset.copyPlaceholder === 'true') {
+					delete scrumReportEl.dataset.copyPlaceholder;
+				}
+				updateCopyButtonState();
+			});
+
 			const copyBtnObserver = new MutationObserver(updateCopyButtonState);
 			copyBtnObserver.observe(scrumReportEl, {
 				childList: true,
@@ -768,6 +777,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		copyBtn.addEventListener('click', function () {
 			const scrumReport = document.getElementById('scrumReport');
+			if (scrumReport?.dataset.copyPlaceholder === 'true') {
+				this._triggeredByShortcut = false;
+				return;
+			}
+
 			const reportHtml = scrumReport ? sanitizeHtml(scrumReport.innerHTML) : '';
 			const tempDiv = document.createElement('div');
 			tempDiv.innerHTML = reportHtml;
@@ -2032,6 +2046,7 @@ document.getElementById('refreshCache').addEventListener('click', async function
 		// Clear the scrum report
 		const scrumReport = document.getElementById('scrumReport');
 		if (scrumReport) {
+			scrumReport.dataset.copyPlaceholder = 'true';
 			scrumReport.innerHTML = `<p style="text-align: center; color: #666; padding: 20px;">${browser.i18n.getMessage('cacheClearedMessage')}</p>`;
 		}
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -680,12 +680,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		updateCopyButtonState();
 
-		const copyBtnObserver = new MutationObserver(updateCopyButtonState);
-		copyBtnObserver.observe(document.getElementById('scrumReport'), {
-			childList: true,
-			subtree: true,
-			characterData: true,
-		});
+		const scrumReportEl = document.getElementById('scrumReport');
+		if (scrumReportEl) {
+			const copyBtnObserver = new MutationObserver(updateCopyButtonState);
+			copyBtnObserver.observe(scrumReportEl, {
+				childList: true,
+				subtree: true,
+				characterData: true,
+			});
+		}
 
 		if (insertBtn) {
 			insertBtn.addEventListener('click', () => {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -445,6 +445,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	window.updateGenerateButtonState = updateGenerateButtonState;
 
+	function updateCopyButtonState() {
+		const copyBtn = document.getElementById('copyReport');
+		const scrumReport = document.getElementById('scrumReport');
+		if (!copyBtn || !scrumReport) {
+			return;
+		}
+
+		copyBtn.disabled = !scrumReport.textContent.trim();
+	}
+
 	async function bootstrapScrumReportOnPopupLoad(generateBtn) {
 		console.log('[BOOTSTRAP] bootstrapScrumReportOnPopupLoad called');
 
@@ -667,6 +677,15 @@ document.addEventListener('DOMContentLoaded', () => {
 		const generateBtn = document.getElementById('generateReport');
 		const copyBtn = document.getElementById('copyReport');
 		const insertBtn = document.getElementById('insertInEmail');
+
+		updateCopyButtonState();
+
+		const copyBtnObserver = new MutationObserver(updateCopyButtonState);
+		copyBtnObserver.observe(document.getElementById('scrumReport'), {
+			childList: true,
+			subtree: true,
+			characterData: true,
+		});
 
 		if (insertBtn) {
 			insertBtn.addEventListener('click', () => {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1150,6 +1150,7 @@ ${blockerText}`;
 			if (scrumReport) {
 				log('Found popup div, updating content');
 				scrumReport.innerHTML = sanitizeHtml(content);
+				delete scrumReport.dataset.copyPlaceholder;
 				try {
 					const cacheKey =
 						platform === 'gitlab' ? (gitlabHelper?.cache?.cacheKey ?? null) : (githubCache?.cacheKey ?? null);


### PR DESCRIPTION
### 📌 Fixes

Fixes #497

---

### 📝 Summary of Changes

- Disabled the Copy button by default when no Scrum report content is available.
- Added Copy button state updates based on the Scrum report content.
- Prevented empty report content from being copied and falsely showing the copied state.

---

### 📸 Screenshots / Demo (if UI-related)

<table>
  <tr>
    <td align="center"><strong>Before</strong></td>
    <td align="center"><strong>After</strong></td>
  </tr>
  <tr>
    <td width="50%">
      <img src="https://github.com/user-attachments/assets/18fd4a42-d786-46f3-8892-a2e7e2ef3839" width="100%" />
    </td>
    <td width="50%">
      <img src="https://github.com/user-attachments/assets/00b5514f-8ccd-43fb-9a2d-6e702a263d74" width="100%" />
    </td>
  </tr>
</table>

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

This is a UI behavior fix only.

## Summary by Sourcery

Fix Scrum report copy behavior so the Copy button and copy action correctly reflect the presence of actual report content.

Bug Fixes:
- Disable the Scrum report Copy button when no report content is available and update its enabled state as the report changes.
- Prevent copying and indicating success when the Scrum report content is empty or only whitespace.