### PR TITLE
fix: Issues without activity incorrectly shown as "Updated Issue"

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -138,7 +138,6 @@ if (!window.clearScrumHelperToast) {
 	};
 }
 
-
 // Backwards-compatible wrapper used across the codebase
 if (!window.showPopupMessage) {
 	window.showPopupMessage = function showPopupMessage(message, options = {}) {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1791,13 +1791,37 @@ ${blockerText}`;
 						'&nbsp;&nbsp;</li>';
 					nextWeekArray.push(li2);
 				}
+                // Compute date range for filtering
+				let issueStartDateFilter;
+				let issueEndDateFilter;
+				if (yesterdayContribution) {
+					const todayDate = new Date();
+					const yesterdayDate = new Date(todayDate.getTime() - 24 * 60 * 60 * 1000);
+					issueStartDateFilter = new Date(yesterdayDate.toISOString().split('T')[0] + 'T00:00:00Z');
+					issueEndDateFilter = new Date(todayDate.toISOString().split('T')[0] + 'T23:59:59Z');
+				} else if (startingDate && endingDate) {
+					issueStartDateFilter = new Date(startingDate + 'T00:00:00Z');
+					issueEndDateFilter = new Date(endingDate + 'T23:59:59Z');
+				} else {
+					const todayDate = new Date();
+					const lastWeek = new Date(todayDate.getFullYear(), todayDate.getMonth(), todayDate.getDate() - 7);
+					issueStartDateFilter = new Date(lastWeek.toISOString().split('T')[0] + 'T00:00:00Z');
+					issueEndDateFilter = new Date(todayDate.toISOString().split('T')[0] + 'T23:59:59Z');
+				}
 
-				const today = new Date();
-				today.setHours(0, 0, 0, 0);
-				const itemCreatedDate = new Date(item.created_at);
-				itemCreatedDate.setHours(0, 0, 0, 0);
-				const isCreatedToday = today.getTime() === itemCreatedDate.getTime();
-				const issueActionText = isCreatedToday ? 'Opened Issue' : 'Updated Issue';
+				const issueCreatedDate = new Date(item.created_at);
+				const issueUpdatedDate = new Date(item.updated_at);
+				const isNewIssue = issueCreatedDate >= issueStartDateFilter && issueCreatedDate <= issueEndDateFilter;
+				const isUpdatedInRange = issueUpdatedDate >= issueStartDateFilter && issueUpdatedDate <= issueEndDateFilter;
+
+				// Skip issues that were neither created nor updated within the selected date range
+				if (!isNewIssue && !isUpdatedInRange) {
+					log(`[ISSUE DEBUG] Skipping Issue #${number} - not created or updated in date range`);
+					continue;
+				}
+
+				const issueActionText = isNewIssue ? 'Opened Issue' : 'Updated Issue';
+			
 				if (item.state === 'open') {
 					li = `<li><i>(${project})</i> - ${issueActionText}(#${number}) - <a href='${html_url}'>${title}</a>${showOpenLabel ? ' ' + issue_opened_button : ''}</li>`;
 				} else if (item.state === 'closed') {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1798,7 +1798,7 @@ ${blockerText}`;
 					const todayDate = new Date();
 					const yesterdayDate = new Date(todayDate.getTime() - 24 * 60 * 60 * 1000);
 					issueStartDateFilter = new Date(yesterdayDate.toISOString().split('T')[0] + 'T00:00:00Z');
-					issueEndDateFilter = new Date(todayDate.toISOString().split('T')[0] + 'T23:59:59Z');
+					issueEndDateFilter = new Date(yesterdayDate.toISOString().split('T')[0] + 'T23:59:59Z');
 				} else if (startingDate && endingDate) {
 					issueStartDateFilter = new Date(startingDate + 'T00:00:00Z');
 					issueEndDateFilter = new Date(endingDate + 'T23:59:59Z');

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1791,7 +1791,7 @@ ${blockerText}`;
 						'&nbsp;&nbsp;</li>';
 					nextWeekArray.push(li2);
 				}
-                // Compute date range for filtering
+				// Compute date range for filtering
 				let issueStartDateFilter;
 				let issueEndDateFilter;
 				if (yesterdayContribution) {
@@ -1821,7 +1821,7 @@ ${blockerText}`;
 				}
 
 				const issueActionText = isNewIssue ? 'Opened Issue' : 'Updated Issue';
-			
+
 				if (item.state === 'open') {
 					li = `<li><i>(${project})</i> - ${issueActionText}(#${number}) - <a href='${html_url}'>${title}</a>${showOpenLabel ? ' ' + issue_opened_button : ''}</li>`;
 				} else if (item.state === 'closed') {


### PR DESCRIPTION
### 📌 Fixes

Fixes #598 

---

### 📝 Summary of Changes

- Checks whether each issue was actually created or updated within that range
- Skips issues that fall outside the range entirely
- Labels correctly: "Opened Issue" if created within the range, "Updated Issue" if only updated


### 📸 Screenshots / Demo (if UI-related)

### Before 
<img width="588" height="783" alt="Issues Before" src="https://github.com/user-attachments/assets/38239ac7-6445-43b6-a131-8aaf73a1e624" />


### After
<img width="588" height="783" alt="Issues After" src="https://github.com/user-attachments/assets/9618d60d-957a-4f7a-950e-75b588f020b8" />

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

Now the issues are fileter properly with in date range and have appropriate label as expacted

## Summary by Sourcery

Adjust issue filtering and labeling to respect a configurable date range for created and updated issues.

Bug Fixes:
- Ensure issues are only included when their creation or last update falls within the selected or default date range.
- Correctly label issues as "Opened Issue" when created in range and "Updated Issue" when only updated in range.

Enhancements:
- Introduce reusable date range calculation for issue activity based on explicit dates, yesterday-only, or the last week by default.