### PR TITLE
fix: remove redundant date filter dropping pr reviews

### DIFF
--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1343,18 +1343,7 @@ ${blockerText}`;
 				}
 			}
 
-			// Additional conservative check: For PRs that were created before the date range,
-			// only include them if they were updated very recently (within the last day of the range)
 			const createdDate = new Date(item.created_at);
-			if (createdDate < startDateTime) {
-				// If PR was created before the date range, only include if it was updated in the last day
-				const lastDayOfRange = new Date(endDateTime);
-				lastDayOfRange.setDate(lastDayOfRange.getDate() - 1);
-				if (itemDate < lastDayOfRange) {
-					log(`Skipping PR #${item.number} - created before date range and not updated recently enough`);
-					continue;
-				}
-			}
 
 			// Extra conservative check: For "yesterday" filter, be very strict
 			if (yesterdayContribution) {


### PR DESCRIPTION
### 📌 Fixes

Fixes #618

---

### 📝 Summary of Changes

* removed an extra date check that was causing some valid pr reviews to be skipped
* cleaned up redundant filtering logic since the selected date range was already being handled correctly

---

### 📸 Screenshots / Demo (if UI-related)

n/a

---

### ✅ Checklist

* [x] i’ve tested my changes locally
* [ ] i’ve added tests (if applicable)
* [ ] i’ve updated documentation (if applicable)
* [x] my code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

n/a