### PR TITLE
fix: remove background color when we copy and paste report

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -761,11 +761,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
 				el.style.backgroundColor = 'transparent';
 
-				const commitMessage = el.classList.contains('commitMessageHeadline');
+				const inlineColor = (el.style.color || '').replace(/\s+/g, '').toLowerCase();
+				const isCommitHeadline =
+					el.classList.contains('commitMessageHeadline') ||
+					inlineColor === '#2563eb' ||
+					inlineColor === 'rgb(37,99,235)';
 				const isLink = el.tagName === 'A';
 
-				// Change color only if it is darkmode and not commit message and not PR link and this el is white
-				if (darkMode && !commitMessage && !isLink) {
+				// Change color only if it is darkmode and not a commit headline and not a PR link
+				if (darkMode && !isCommitHeadline && !isLink) {
 					el.style.color = '#000';
 				}
 			});

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -755,7 +755,8 @@ document.addEventListener('DOMContentLoaded', () => {
 			tempDiv.querySelectorAll('*').forEach((el) => {
 				const text = el.textContent?.trim().toLowerCase();
 
-				if (text === 'open' || text === 'closed' || text === 'merged') {
+				const isStatusBadge = el.classList.contains('State') || el.classList.contains('state');
+				if (isStatusBadge || text === 'open' || text === 'closed' || text === 'merged' || text === 'draft') {
 					return;
 				}
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -748,6 +748,27 @@ document.addEventListener('DOMContentLoaded', () => {
 			const scrumReport = document.getElementById('scrumReport');
 			const tempDiv = document.createElement('div');
 			tempDiv.innerHTML = sanitizeHtml(scrumReport.innerHTML);
+
+			const darkMode = document.body.classList.contains('dark-mode');
+
+			//remove background styles
+			tempDiv.querySelectorAll('*').forEach((el) => {
+				const text = el.textContent?.trim().toLowerCase();
+
+				if (text === 'open' || text === 'closed' || text === 'merged') {
+					return;
+				}
+
+				el.style.backgroundColor = 'transparent';
+
+				const commitMessage = el.classList.contains('commitMessageHeadline');
+				const isLink = el.tagName === 'A';
+
+				// Change color only if it is darkmode and not commit message and not PR link and this el is white
+				if (darkMode && !commitMessage && !isLink) {
+					el.style.color = '#000';
+				}
+			});
 			document.body.appendChild(tempDiv);
 			tempDiv.style.position = 'absolute';
 			tempDiv.style.left = '-9999px';

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -760,6 +760,8 @@ document.addEventListener('DOMContentLoaded', () => {
 				}
 
 				el.style.backgroundColor = 'transparent';
+				el.style.background = 'transparent';
+				el.style.backgroundImage = 'none';
 
 				const inlineColor = (el.style.color || '').replace(/\s+/g, '').toLowerCase();
 				const isCommitHeadline =


### PR DESCRIPTION
### 📌 Fixes

Fixes #605 

---

### 📝 Summary of Changes

- Updated copy-to-clipboard preprocessing for scrum report HTML in dark mode.
- Strips non-essential background colors before copy so pasted output doesn’t carry dark background artifacts.
- Keeps status labels (Open, Closed, Merged) untouched.
- In dark mode, sets copied text color to black for readability, excluding commit headline text and links.

Related issue: #605

---

### 📸 Screenshots / Demo (if UI-related)

<img width="1289" height="595" alt="image" src="https://github.com/user-attachments/assets/998850e5-4e93-4f0a-a0eb-e5beff672ceb" />

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

Change is intentionally minimal and scoped to copy/paste formatting logic in popup script.

## Summary by Sourcery

Bug Fixes:
- Prevent copied scrum report content from including unwanted dark-mode background styling when pasted into external editors.