### PR TITLE
feat: display cache age and staleness badge in popup UI

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -404,7 +404,7 @@
   "usernameMissingError": {
     "message": "Username required.",
     "description": "Error shown when username is missing."
-   },
+  },
   "generateReportTooltip": {
     "message": "Ctrl+G",
     "description": "Tooltip shortcut for the Generate button. Dynamically replaced with Cmd+G on macOS."
@@ -436,5 +436,47 @@
   "insertedInEmailNotification": {
     "message": "Report inserted into email!",
     "description": "Notification shown when report is successfully inserted into email."
+  },
+  "cacheStatusNoCache": {
+    "message": "No cache",
+    "description": "Badge text when no cached report exists yet."
+  },
+  "cacheStatusFresh": {
+    "message": "Cached · $1",
+    "description": "Badge text when the cached report is still within the TTL. $1 is the age string e.g. '3 min ago'.",
+    "placeholders": {
+      "1": {
+        "content": "$1",
+        "example": "3 min ago"
+      }
+    }
+  },
+  "cacheStatusStale": {
+    "message": "Stale · $1",
+    "description": "Badge text when the cached report has exceeded the TTL. $1 is the age string e.g. '12 min ago'.",
+    "placeholders": {
+      "1": {
+        "content": "$1",
+        "example": "12 min ago"
+      }
+    }
+  },
+  "cacheStatusTooltip": {
+    "message": "Report cached $1. Refreshes after $2 min.",
+    "description": "Tooltip on the cache badge. $1 is the age string, $2 is the TTL in minutes.",
+    "placeholders": {
+      "1": {
+        "content": "$1",
+        "example": "5 min ago"
+      },
+      "2": {
+        "content": "$2",
+        "example": "10"
+      }
+    }
+  },
+  "cacheStaleWarning": {
+    "message": "Data may be outdated. Click Generate to refresh.",
+    "description": "Warning shown below the badge when the cache is stale."
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -443,37 +443,15 @@
   },
   "cacheStatusFresh": {
     "message": "Cached · $1",
-    "description": "Badge text when the cached report is still within the TTL. $1 is the age string e.g. '3 min ago'.",
-    "placeholders": {
-      "1": {
-        "content": "$1",
-        "example": "3 min ago"
-      }
-    }
+    "description": "Badge text when the cached report is still within the TTL. $1 is the age string e.g. '3 min ago'."
   },
   "cacheStatusStale": {
     "message": "Stale · $1",
-    "description": "Badge text when the cached report has exceeded the TTL. $1 is the age string e.g. '12 min ago'.",
-    "placeholders": {
-      "1": {
-        "content": "$1",
-        "example": "12 min ago"
-      }
-    }
+    "description": "Badge text when the cached report has exceeded the TTL. $1 is the age string e.g. '12 min ago'."
   },
   "cacheStatusTooltip": {
     "message": "Report cached $1. Refreshes after $2 min.",
-    "description": "Tooltip on the cache badge. $1 is the age string, $2 is the TTL in minutes.",
-    "placeholders": {
-      "1": {
-        "content": "$1",
-        "example": "5 min ago"
-      },
-      "2": {
-        "content": "$2",
-        "example": "10"
-      }
-    }
+    "description": "Tooltip on the cache badge. $1 is the age string, $2 is the TTL in minutes."
   },
   "cacheStaleWarning": {
     "message": "Data may be outdated. Click Generate to refresh.",

--- a/src/popup.html
+++ b/src/popup.html
@@ -2,629 +2,626 @@
 <html lang="en" class="mode-sidepanel">
 
 <head>
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
-	<link rel="stylesheet" href="tailwindcss.css">
-	<link rel="stylesheet" type="text/css" href="index.css">
-	<link rel="stylesheet" href="fontawesome/css/all.min.css">
-	<style type="text/css">
-		html,
-		body {
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <link rel="stylesheet" href="tailwindcss.css">
+  <link rel="stylesheet" type="text/css" href="index.css">
+  <link rel="stylesheet" href="fontawesome/css/all.min.css">
+  <style type="text/css">
+    html,
+    body {
 
-			margin: 0;
-			background: #eae4e4;
-			width: 100%;
-			height: 100%;
-			overflow: hidden;
-		}
+      margin: 0;
+      background: #eae4e4;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
 
-		body {
-			display: flex;
-		}
+    body {
+      display: flex;
+    }
 
-		html.mode-sidepanel,
-		body.mode-sidepanel {
-			width: 100% !important;
-			height: 100% !important;
-			max-width: 100% !important;
-			max-height: 100% !important;
-			min-width: 360px;
-			min-height: 100% !important;
-		}
+    html.mode-sidepanel,
+    body.mode-sidepanel {
+      width: 100% !important;
+      height: 100% !important;
+      max-width: 100% !important;
+      max-height: 100% !important;
+      min-width: 360px;
+      min-height: 100% !important;
+    }
 
-		html.mode-popup,
-		body.mode-popup {
-			width: 360px !important;
-			height: 600px !important;
-			min-width: 360px;
-			max-width: 420px;
-			min-height: 600px !important;
-			max-height: 600px !important;
-			overflow: hidden !important;
-		}
+    html.mode-popup,
+    body.mode-popup {
+      width: 360px !important;
+      height: 600px !important;
+      min-width: 360px;
+      max-width: 420px;
+      min-height: 600px !important;
+      max-height: 600px !important;
+      overflow: hidden !important;
+    }
 
-		#popupRoot {
-			flex: 1;
-			min-width: 360px;
-			flex-shrink: 0;
+    #popupRoot {
+      flex: 1;
+      min-width: 360px;
+      flex-shrink: 0;
 
-			height: 100%;
-			overflow-y: auto;
-			overflow-x: hidden;
-			scrollbar-width: auto;
-			-ms-overflow-style: auto;
-		}
+      height: 100%;
+      overflow-y: auto;
+      overflow-x: hidden;
+      scrollbar-width: auto;
+      -ms-overflow-style: auto;
+    }
 
-		#platformSelect option {
-			font-family: 'FontAwesome', 'Arial', sans-serif;
-		}
+    #platformSelect option {
+      font-family: 'FontAwesome', 'Arial', sans-serif;
+    }
 
-		#customPlatformDropdown {
-			position: relative;
-		}
+    #customPlatformDropdown {
+      position: relative;
+    }
 
-		#platformDropdownList {
-			display: none;
-		}
+    #platformDropdownList {
+      display: none;
+    }
 
-		#customPlatformDropdown.open #platformDropdownList {
-			display: block;
-		}
+    #customPlatformDropdown.open #platformDropdownList {
+      display: block;
+    }
 
-		#platformDropdownBtn:focus {
-			outline: 2px solid #2563eb;
-		}
+    #platformDropdownBtn:focus {
+      outline: 2px solid #2563eb;
+    }
 
-		/* Firefox Sidebar Fixes ONLY */
-		html.firefox-sidebar, 
-		body.firefox-sidebar {
-			min-width: 100% !important;
-		}
-		body.firefox-sidebar #popupRoot {
-			min-width: 100% !important;
-		}
-	</style>
+    /* Firefox Sidebar Fixes ONLY */
+    html.firefox-sidebar,
+    body.firefox-sidebar {
+      min-width: 100% !important;
+    }
+
+    body.firefox-sidebar #popupRoot {
+      min-width: 100% !important;
+    }
+
+    .cache-status-bar {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 11px;
+      padding: 3px 10px;
+      border-radius: 4px;
+      margin-top: 4px;
+      width: fit-content;
+      transition: background 0.3s, color 0.3s;
+    }
+
+    .cache-status-bar.fresh {
+      background: #e8f5e9;
+      color: #2e7d32;
+    }
+
+    .cache-status-bar.stale {
+      background: #fff8e1;
+      color: #e65100;
+    }
+
+    .cache-status-bar.no-cache {
+      background: #f5f5f5;
+      color: #757575;
+    }
+
+    .dark-mode .cache-status-bar.fresh {
+      background: #1b3a1f;
+      color: #81c784;
+    }
+
+    .dark-mode .cache-status-bar.stale {
+      background: #3e2200;
+      color: #ffb74d;
+    }
+
+    .dark-mode .cache-status-bar.no-cache {
+      background: #2a2a2a;
+      color: #aaaaaa;
+    }
+
+    .cache-stale-warning {
+      font-size: 11px;
+      color: #e65100;
+      margin-top: 2px;
+      padding: 0 2px;
+    }
+
+    .dark-mode .cache-stale-warning {
+      color: #ffb74d;
+    }
+  </style>
 </head>
 
 <body class="mode-sidepanel text-gray-800 bg-gray-50 flex flex-col font-sans">
 
-	<div id="scrumHelperToastContainer" class="scrum-toast-container"></div>
-	
-	<div id="popupRoot" class="pl-1 py-2 rounded-2xl">
-		<div class="bg-white px-4 py-4 mx-2 mb-2 rounded-3xl">
-			<div class="flex justify-between py-2">
-				<h3 id="scrumHelperHeading" class="text-3xl font-semibold cursor-pointer">Scrum Helper</h3>
-				<img src="icons/night-mode.png" alt="Night Mode" class="w-7 h-7 mx-3 cursor-pointer"
-					id="darkModeToggle">
-			</div>
-			<div>
-				<p class="" data-i18n="appDescription">Report your development progress by auto-fetching your Git
-					activity for a selected period
-				</p>
-			</div>
+  <div id="scrumHelperToastContainer" class="scrum-toast-container"></div>
 
-			<div class="center mt-2 flex justify-end">
-				<div class="flex">
-					<button id="homeButton"
-						class="ml-1 p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition">
-						<i class="fa fa-home text-2xl text-gray-600 dark:text-gray-300"></i>
-					</button>
-					<button id="settingsToggle">
-						<img id="settingsIcon" src="icons/settings-light.png" alt="Settings"
-							class="w-6 h-6 mx-3 cursor-pointer">
-					</button>
-				</div>
-			</div>
-		</div>
+  <div id="popupRoot" class="pl-1 py-2 rounded-2xl">
+    <div class="bg-white px-4 py-4 mx-2 mb-2 rounded-3xl">
+      <div class="flex justify-between py-2">
+        <h3 id="scrumHelperHeading" class="text-3xl font-semibold cursor-pointer">Scrum Helper</h3>
+        <img src="icons/night-mode.png" alt="Night Mode" class="w-7 h-7 mx-3 cursor-pointer" id="darkModeToggle">
+      </div>
+      <div>
+        <p class="" data-i18n="appDescription">Report your development progress by auto-fetching your Git
+          activity for a selected period
+        </p>
+      </div>
 
-		<div class="rounded-2xl">
-			<div class=" border-gray-100 border-2 bg-white rounded-3xl px-4 py-4 mx-2 my-2">
+      <div class="center mt-2 flex justify-end">
+        <div class="flex">
+          <button id="homeButton" class="ml-1 p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition">
+            <i class="fa fa-home text-2xl text-gray-600 dark:text-gray-300"></i>
+          </button>
+          <button id="settingsToggle">
+            <img id="settingsIcon" src="icons/settings-light.png" alt="Settings" class="w-6 h-6 mx-3 cursor-pointer">
+          </button>
+        </div>
+      </div>
+    </div>
 
-				<div id="reportSection" class="tab-content">
-					<div>
+    <div class="rounded-2xl">
+      <div class=" border-gray-100 border-2 bg-white rounded-3xl px-4 py-4 mx-2 my-2">
+
+        <div id="reportSection" class="tab-content">
+          <div>
 
 
-						<p data-i18n="platformLabel" class="font-medium text-sm" style="margin-bottom: 0.3rem;">Platform
-						</p>
-						<div class="relative mb-4" id="customPlatformDropdown" style="margin-bottom: 0.8rem;">
-							<input type="hidden" id="platformSelect" value="github">
-							<button type="button" id="platformDropdownBtn"
-								class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 pr-8 flex items-center justify-between focus:outline-none focus:ring-2 focus:ring-blue-500">
-								<span id="platformDropdownSelected" class="flex items-center gap-2">
-									<i class="fab fa-github" style="margin-right:8px;"></i> GitHub
-								</span>
-								<i class="fa fa-chevron-down text-gray-500"></i>
-							</button>
-							<ul id="platformDropdownList"
-								class="absolute left-0 right-0 bg-white border-2 border-gray-200 rounded-xl mt-1 shadow-lg z-10 hidden">
-								<li style="padding-left: 8px; padding-right: 16px; padding-top: 8px; padding-bottom: 8px; display: flex; align-items: center; cursor: pointer;"
-									class="hover:bg-gray-100" data-value="github">
-									<i class="fab fa-github" style="margin-right: 12px; font-size: 18px;"></i> GitHub
-								</li>
-								<li style="padding-left: 8px; padding-right: 16px; padding-top: 8px; padding-bottom: 8px; display: flex; align-items: center; cursor: pointer;"
-									class="hover:bg-gray-100" data-value="gitlab">
-									<i class="fab fa-gitlab" style="margin-right: 12px; font-size: 18px;"></i> GitLab
-								</li>
-							</ul>
-						</div>
-					</div>
-					<div>
-						<div class="flex">
+            <p data-i18n="platformLabel" class="font-medium text-sm" style="margin-bottom: 0.3rem;">Platform
+            </p>
+            <div class="relative mb-4" id="customPlatformDropdown" style="margin-bottom: 0.8rem;">
+              <input type="hidden" id="platformSelect" value="github">
+              <button type="button" id="platformDropdownBtn" class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 pr-8 flex items-center justify-between focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <span id="platformDropdownSelected" class="flex items-center gap-2">
+                  <i class="fab fa-github" style="margin-right:8px;"></i> GitHub
+                </span>
+                <i class="fa fa-chevron-down text-gray-500"></i>
+              </button>
+              <ul id="platformDropdownList" class="absolute left-0 right-0 bg-white border-2 border-gray-200 rounded-xl mt-1 shadow-lg z-10 hidden">
+                <li style="padding-left: 8px; padding-right: 16px; padding-top: 8px; padding-bottom: 8px; display: flex; align-items: center; cursor: pointer;" class="hover:bg-gray-100" data-value="github">
+                  <i class="fab fa-github" style="margin-right: 12px; font-size: 18px;"></i> GitHub
+                </li>
+                <li style="padding-left: 8px; padding-right: 16px; padding-top: 8px; padding-bottom: 8px; display: flex; align-items: center; cursor: pointer;" class="hover:bg-gray-100" data-value="gitlab">
+                  <i class="fab fa-gitlab" style="margin-right: 12px; font-size: 18px;"></i> GitLab
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div>
+            <div class="flex">
 
-							<p class=" font-medium text-sm" data-i18n="projectNameLabel">Project Name (used in email
-								subject)</p><span class="tooltip-container ml-2">
-								<i class="fa fa-question-circle question-icon"></i>
-								<span class="tooltip-bubble" data-i18n="projectNameTooltip">
-									This project name will appear in the subject line of your email as part of:
-									"[Scrum] Project Name - Date”. Leave blank to skip.
-								</span>
-							</span>
+              <p class=" font-medium text-sm" data-i18n="projectNameLabel">Project Name (used in email
+                subject)</p><span class="tooltip-container ml-2">
+                <i class="fa fa-question-circle question-icon"></i>
+                <span class="tooltip-bubble" data-i18n="projectNameTooltip">
+                  This project name will appear in the subject line of your email as part of:
+                  "[Scrum] Project Name - Date". Leave blank to skip.
+                </span>
+              </span>
 
-						</div>
+            </div>
 
 
-						<input id="projectName" type="text"
-							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2"
-							data-i18n-placeholder="projectNamePlaceholder" style="margin-top: 0.3rem; margin-bottom: 0.8rem;">
-					</div>
-					<div>
+            <input id="projectName" type="text" class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2" data-i18n-placeholder="projectNamePlaceholder" style="margin-top: 0.3rem; margin-bottom: 0.8rem;">
+          </div>
+          <div>
 
-						<p id="usernameLabel" class="font-medium text-sm" data-i18n="usernameLabel">Your Username</p>
-						<input id="platformUsername" type="text" aria-describedby="usernameError"
-							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2"
-							data-i18n-placeholder="githubUsernamePlaceholder"
-							style="margin-top: 0.3rem; margin-bottom: 0.2rem;">
-						<span id="usernameError" class="" role="alert" aria-live="polite"></span>
+            <p id="usernameLabel" class="font-medium text-sm" data-i18n="usernameLabel">Your Username</p>
+            <input id="platformUsername" type="text" aria-describedby="usernameError" class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2" data-i18n-placeholder="githubUsernamePlaceholder" style="margin-top: 0.3rem; margin-bottom: 0.2rem;">
+            <span id="usernameError" class="" role="alert" aria-live="polite"></span>
 
-					</div>
+          </div>
 
-					<div>
-						<p class="text-lg mb-1 font-medium text-sm" data-i18n="contributionsLabel" style="margin-top: 0.6rem;">Fetch your
-							contributions between:</p>
+          <div>
+            <p class="text-lg mb-1 font-medium text-sm" data-i18n="contributionsLabel" style="margin-top: 0.6rem;">Fetch your
+              contributions between:</p>
 
 
-						<div class="flex gap-[3px] justify-between items-center mt-2" style="gap: 8px">
+            <div class="flex gap-[3px] justify-between items-center mt-2" style="gap: 8px">
 
-							<div id="customDateContainer" class="flex gap-2">
+              <div id="customDateContainer" class="flex gap-2">
 
-								<div>
-									<label for="startingDate" class="flex items-center font-medium text-xs"
-										data-i18n="startDateLabel">From:</label>
-									<input type="date" id="startingDate"
-										class="border-2 border-gray-200 bg-gray-200 rounded-xl p-1"
-										style="width: 96px;">
-								</div>
-								<div>
-									<label for="endingDate" class="flex items-center font-medium text-xs"
-										data-i18n="endDateLabel">To:</label>
-									<input type="date" id="endingDate"
-										class="border-2 border-gray-200 bg-gray-200 rounded-xl p-1"
-										style="width: 96px;">
-								</div>
-							</div>
-							<div class="flex items-center gap-1">
-								<input type="radio" id="yesterdayContribution" name="timeframe" class="form-radio"
-									style="margin-right: 4px;">
-								<label for="yesterdayContribution" class="font-medium text-xs"
-									data-i18n="last1DayLabel">Previous Day</label>
-							</div>
-						</div>
-					</div>
+                <div>
+                  <label for="startingDate" class="flex items-center font-medium text-xs" data-i18n="startDateLabel">From:</label>
+                  <input type="date" id="startingDate" class="border-2 border-gray-200 bg-gray-200 rounded-xl p-1" style="width: 96px;">
+                </div>
+                <div>
+                  <label for="endingDate" class="flex items-center font-medium text-xs" data-i18n="endDateLabel">To:</label>
+                  <input type="date" id="endingDate" class="border-2 border-gray-200 bg-gray-200 rounded-xl p-1" style="width: 96px;">
+                </div>
+              </div>
+              <div class="flex items-center gap-1">
+                <input type="radio" id="yesterdayContribution" name="timeframe" class="form-radio" style="margin-right: 4px;">
+                <label for="yesterdayContribution" class="font-medium text-xs" data-i18n="last1DayLabel">Previous Day</label>
+              </div>
+            </div>
+          </div>
 
-					<details class="group mb-4" style="margin-top: 1rem;">
-						<summary class="flex items-center justify-between cursor-pointer list-none font-medium text-sm outline-none select-none pr-1">
-							<span data-i18n="advancedFiltersLabel">Advanced Filters</span>
-							<i class="fa fa-chevron-down text-gray-500 w-4 text-center transition-transform duration-200 group-open:-rotate-180"></i>
-						</summary>
-						<div class="mt-4 border-l-2 border-gray-200" style="margin-left: 0.25rem; padding-left: 1rem;">
-							<div class="my-2 flex items-center">
-								<input type="checkbox" id="showOpenLabel" class="form-checkbox text-blue-600">
-								<label id="checkboxLabel" for="showOpenLabel" class="font-medium text-sm"
-									style="margin-left: 4px;" data-i18n="showOpenClosedLabel">Show
-									PRs Labels</label>
-							</div>
+          <details class="group mb-4" style="margin-top: 1rem;">
+            <summary class="flex items-center justify-between cursor-pointer list-none font-medium text-sm outline-none select-none pr-1">
+              <span data-i18n="advancedFiltersLabel">Advanced Filters</span>
+              <i class="fa fa-chevron-down text-gray-500 w-4 text-center transition-transform duration-200 group-open:-rotate-180"></i>
+            </summary>
+            <div class="mt-4 border-l-2 border-gray-200" style="margin-left: 0.25rem; padding-left: 1rem;">
+              <div class="my-2 flex items-center">
+                <input type="checkbox" id="showOpenLabel" class="form-checkbox text-blue-600">
+                <label id="checkboxLabel" for="showOpenLabel" class="font-medium text-sm" style="margin-left: 4px;" data-i18n="showOpenClosedLabel">Show
+                  PRs Labels</label>
+              </div>
 
-							<div class="my-4">
-								<div class="flex items-center">
-									<input type="checkbox" id="onlyIssues" class="form-checkbox text-blue-600">
-									<label for="onlyIssues" class="font-medium text-sm flex items-center"
-										style="margin-left: 4px;" data-i18n="onlyIssuesLabel">
-										Include only issues in the report
-									</label>
-									<span class="tooltip-container">
-										<i class="fa fa-question-circle question-icon"></i>
-										<span class="tooltip-bubble" data-i18n="onlyIssuesTooltip">
-											If checked, the report will only include issues created or assigned to the user.
-										</span>
-									</span>
-								</div>
-							</div>
+              <div class="my-4">
+                <div class="flex items-center">
+                  <input type="checkbox" id="onlyIssues" class="form-checkbox text-blue-600">
+                  <label for="onlyIssues" class="font-medium text-sm flex items-center" style="margin-left: 4px;" data-i18n="onlyIssuesLabel">
+                    Include only issues in the report
+                  </label>
+                  <span class="tooltip-container">
+                    <i class="fa fa-question-circle question-icon"></i>
+                    <span class="tooltip-bubble" data-i18n="onlyIssuesTooltip">
+                      If checked, the report will only include issues created or assigned to the user.
+                    </span>
+                  </span>
+                </div>
+              </div>
 
-							<div class="my-4">
-								<div class="flex items-center">
-									<input type="checkbox" id="onlyPRs" class="form-checkbox text-blue-600">
-									<label for="onlyPRs" class="font-medium text-sm flex items-center" style="margin-left: 4px;"
-										data-i18n="onlyPRsLabel">
-										Include only PRs in the report
-									</label>
-									<span class="tooltip-container">
-										<i class="fa fa-question-circle question-icon"></i>
-										<span class="tooltip-bubble" data-i18n="onlyPRsTooltip">
-											If checked, the report will only include PRs created by you.
-										</span>
-									</span>
-								</div>
-							</div>
+              <div class="my-4">
+                <div class="flex items-center">
+                  <input type="checkbox" id="onlyPRs" class="form-checkbox text-blue-600">
+                  <label for="onlyPRs" class="font-medium text-sm flex items-center" style="margin-left: 4px;" data-i18n="onlyPRsLabel">
+                    Include only PRs in the report
+                  </label>
+                  <span class="tooltip-container">
+                    <i class="fa fa-question-circle question-icon"></i>
+                    <span class="tooltip-bubble" data-i18n="onlyPRsTooltip">
+                      If checked, the report will only include PRs created by you.
+                    </span>
+                  </span>
+                </div>
+              </div>
 
-							<div class="my-4">
-								<div class="flex items-center">
-									<input type="checkbox" id="onlyRevPRs" class="form-checkbox text-blue-600">
-									<label for="onlyRevPRs" class="font-medium text-sm flex items-center"
-										style="margin-left: 4px;" data-i18n="onlyRevPRsLabel">
-										Include only Reviewed PRs in the report
-									</label>
-									<span class="tooltip-container">
-										<i class="fa fa-question-circle question-icon"></i>
-										<span class="tooltip-bubble" data-i18n="onlyPRsTooltip">
-											If checked, the report will only include PRs reviewed by you.
-										</span>
-									</span>
-								</div>
-							</div>
+              <div class="my-4">
+                <div class="flex items-center">
+                  <input type="checkbox" id="onlyRevPRs" class="form-checkbox text-blue-600">
+                  <label for="onlyRevPRs" class="font-medium text-sm flex items-center" style="margin-left: 4px;" data-i18n="onlyRevPRsLabel">
+                    Include only Reviewed PRs in the report
+                  </label>
+                  <span class="tooltip-container">
+                    <i class="fa fa-question-circle question-icon"></i>
+                    <span class="tooltip-bubble" data-i18n="onlyPRsTooltip">
+                      If checked, the report will only include PRs reviewed by you.
+                    </span>
+                  </span>
+                </div>
+              </div>
 
-							<div class="my-4 githubOnlySection">
-								<div class="flex items-center">
-									<input type="checkbox" id="onlyMergedPRs" class="form-checkbox text-blue-600">
-									<label for="onlyMergedPRs" class="font-medium text-sm flex items-center"
-										style="margin-left: 4px;" data-i18n="onlyMergedPRsLabel">
-										Include only Merged PRs in the report
-									</label>
-									<span class="tooltip-container">
-										<i class="fa fa-question-circle question-icon"></i>
-										<span class="tooltip-bubble" data-i18n="onlyMergedPRsTooltip">
-											If checked, the report will only include merged PRs. A GitHub token is required.
-										</span>
-									</span>
-								</div>
-								<div id="tokenWarningForMergedPRs"
-									class="hidden text-xs text-red-600 p-2 bg-red-50 border border-red-200 rounded-xl mt-2">
-									<span data-i18n="tokenRequiredMergedPRsWarning">A GitHub token is required to filter by merged PRs. Please add one in the settings.</span>
-								</div>
-							</div>
+              <div class="my-4 githubOnlySection">
+                <div class="flex items-center">
+                  <input type="checkbox" id="onlyMergedPRs" class="form-checkbox text-blue-600">
+                  <label for="onlyMergedPRs" class="font-medium text-sm flex items-center" style="margin-left: 4px;" data-i18n="onlyMergedPRsLabel">
+                    Include only Merged PRs in the report
+                  </label>
+                  <span class="tooltip-container">
+                    <i class="fa fa-question-circle question-icon"></i>
+                    <span class="tooltip-bubble" data-i18n="onlyMergedPRsTooltip">
+                      If checked, the report will only include merged PRs. A GitHub token is required.
+                    </span>
+                  </span>
+                </div>
+                <div id="tokenWarningForMergedPRs" class="hidden text-xs text-red-600 p-2 bg-red-50 border border-red-200 rounded-xl mt-2">
+                  <span data-i18n="tokenRequiredMergedPRsWarning">A GitHub token is required to filter by merged PRs. Please add one in the settings.</span>
+                </div>
+              </div>
 
-							<div class="my-4 githubOnlySection">
-								<div class="flex items-center">
-									<input type="checkbox" id="showCommits" checked class="form-checkbox text-blue-600 ">
+              <div class="my-4 githubOnlySection">
+                <div class="flex items-center">
+                  <input type="checkbox" id="showCommits" checked class="form-checkbox text-blue-600 ">
 
-									<label id="showCommitsLabel" for="showCommits"
-										class="font-medium text-sm flex items-center pl-5 ml-4" style="margin-left: 4px;"
-										data-i18n="showCommitsLabel">Show commits on open PRs/ draft PRs</label><span
-										class="tooltip-container">
-										<i class="fa fa-question-circle question-icon"></i>
-										<span class="tooltip-bubble" data-i18n="showCommitsTooltip">
-											Github Token required, add it in the settings.
-										</span>
-									</span>
+                  <label id="showCommitsLabel" for="showCommits" class="font-medium text-sm flex items-center pl-5 ml-4" style="margin-left: 4px;" data-i18n="showCommitsLabel">Show commits on open PRs/ draft PRs</label><span class="tooltip-container">
+                    <i class="fa fa-question-circle question-icon"></i>
+                    <span class="tooltip-bubble" data-i18n="showCommitsTooltip">
+                      Github Token required, add it in the settings.
+                    </span>
+                  </span>
 
-								</div>
-								<div id="tokenWarningForShowCommits"
-									class="hidden text-xs text-red-600 p-2 bg-red-50 border border-red-200 rounded-xl mt-2">
-									<span data-i18n="tokenRequiredShowCommitsWarning">A GitHub token is required to show commits
-										on open or draft PRs. Please add one in the settings.</span>
-								</div>
-							</div>
-						</div>
-					</details>
+                </div>
+                <div id="tokenWarningForShowCommits" class="hidden text-xs text-red-600 p-2 bg-red-50 border border-red-200 rounded-xl mt-2">
+                  <span data-i18n="tokenRequiredShowCommitsWarning">A GitHub token is required to show commits
+                    on open or draft PRs. Please add one in the settings.</span>
+                </div>
+              </div>
+            </div>
+          </details>
 
-					<div>
-						<div>
-							<h6 class="text-base font-semibold mt-2" data-i18n="scrumReportLabel">Scrum Report</h6>
-							<div id="scrumReport" contenteditable="true"
-								class="min-h-[200px] overflow-y-auto whitespace-pre-wrap border-2 border-gray-200 bg-gray-100 rounded-xl text-gray-800 p-2 my-2">
-							</div>
-						</div>
+          <div>
+            <div>
+              <h6 class="text-base font-semibold mt-2" data-i18n="scrumReportLabel">Scrum Report</h6>
+              <div id="scrumReport" contenteditable="true" class="min-h-[200px] overflow-y-auto whitespace-pre-wrap border-2 border-gray-200 bg-gray-100 rounded-xl text-gray-800 p-2 my-2">
+              </div>
 
-						<div class="scrum-actions my-2">
-							<div class="tooltip-container">
-								<button id="generateReport" disabled
-									class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 rounded"
-									style="padding-left: 0.875rem; padding-right: 0.875rem;">
-									<i class="fa fa-refresh"></i> <span data-i18n="generateReportButton">Generate</span>
-								</button>
-								<span class="shortcut-tooltip" id="generateReportTooltipText">Ctrl+G</span>
-							</div>
+              <div id="cacheStatusBar" class="cache-status-bar hidden" role="status" aria-live="polite">
+                <span id="cacheStatusIcon"></span>
+                <span id="cacheStatusText"></span>
+              </div>
+              <div id="cacheStaleWarning" class="cache-stale-warning hidden">
+                <span data-i18n="cacheStaleWarning">Data may be outdated. Click Generate to refresh.</span>
+              </div>
+            </div>
 
-							<div class="tooltip-container">
-								<button id="insertInEmail"
-									class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 rounded"
-									style="padding-left: 0.875rem; padding-right: 0.875rem;">
-									<i class="fa fa-envelope"></i> <span data-i18n="insertInEmailButton">Insert in
-										Email</span>
-								</button>
-								<span class="shortcut-tooltip" id="insertInEmailTooltipText">Ctrl+Shift+M</span>
-							</div>
+            <div class="scrum-actions my-2">
+              <div class="tooltip-container">
+                <button id="generateReport" disabled class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 rounded" style="padding-left: 0.875rem; padding-right: 0.875rem;">
+                  <i class="fa fa-refresh"></i> <span data-i18n="generateReportButton">Generate</span>
+                </button>
+                <span class="shortcut-tooltip" id="generateReportTooltipText">Ctrl+G</span>
+              </div>
 
-							<div class="tooltip-container">
-								<button id="copyReport"
-									class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded">
-									<i class="fa fa-copy"></i> <span data-i18n="copyReportButton">Copy</span>
-								</button>
-								<span class="shortcut-tooltip" id="copyReportTooltipText">Ctrl+Shift+Y</span>
-							</div>
-						</div>
+              <div class="tooltip-container">
+                <button id="insertInEmail" class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 rounded" style="padding-left: 0.875rem; padding-right: 0.875rem;">
+                  <i class="fa fa-envelope"></i> <span data-i18n="insertInEmailButton">Insert in
+                    Email</span>
+                </button>
+                <span class="shortcut-tooltip" id="insertInEmailTooltipText">Ctrl+Shift+M</span>
+              </div>
+
+              <div class="tooltip-container">
+                <button id="copyReport" class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded">
+                  <i class="fa fa-copy"></i> <span data-i18n="copyReportButton">Copy</span>
+                </button>
+                <span class="shortcut-tooltip" id="copyReportTooltipText">Ctrl+Shift+Y</span>
+              </div>
+            </div>
 
 
-					</div>
-					<div class="border-gray-100 border-2 bg-white rounded-3xl px-4 py-2 mx-2 my-2">
-						<div>
-							<h4 class="font-semibold text-xl" data-i18n="noteTitle">Note:</h4>
-							<ul class="text-xs list-disc list-inside">
-								<p data-i18n="notePoint1">Pull requests are fetched based on the most recent review
-									activity by any contributor, not just your own. Please review and adjust the
-									generated SCRUM report to ensure it accurately reflects your work before sharing.
-								</p>
-							</ul>
-						</div>
-					</div>
-				</div>
+          </div>
+          <div class="border-gray-100 border-2 bg-white rounded-3xl px-4 py-2 mx-2 my-2">
+            <div>
+              <h4 class="font-semibold text-xl" data-i18n="noteTitle">Note:</h4>
+              <ul class="text-xs list-disc list-inside">
+                <p data-i18n="notePoint1">Pull requests are fetched based on the most recent review
+                  activity by any contributor, not just your own. Please review and adjust the
+                  generated SCRUM report to ensure it accurately reflects your work before sharing.
+                </p>
+              </ul>
+            </div>
+          </div>
+        </div>
 
-				<div id="settingsSection" class="tab-content hidden">
-					<div class="orgSection">
-						<div>
-							<div class="flex items-center justify-between">
-								<div class="flex">
-									<p class="text-sm font-medium" data-i18n="githubTokenLabel">Your GitHub Token</p>
-									<span class="tooltip-container">
-										<i class="fa fa-question-circle question-icon"></i>
-										<span class="tooltip-bubble" data-i18n="githubTokenTooltip">
-											<b>Why is it recommended to add a GitHub token?</b><br>
-											Scrum Helper works without a GitHub token, but adding a personal access
-											token is recommended for a
-											better experience. It raises your API limits, allows access to private
-											repos
-											(if permitted), and
-											improves accuracy and speed. Tokens are stored locally and never sent to
-											us
-											and used only to fetch
-											your git data. You can add one anytime in the extension
-											settings.<br><br>
-											<b>How to obtain:</b><br>
-											1. Go to <a href="https://github.com/settings/tokens" target="_blank"
-												rel="noopener noreferrer"
-												style="color:#2563eb;text-decoration:underline;">GitHub Developer
-												Settings</a>.<br>
-											3. Click "Generate new token", select classic token<br>
-											4. Paste it here.<br>
-											<i>Keep your token secret!</i>
-										</span>
-									</span>
+        <div id="settingsSection" class="tab-content hidden">
+          <div class="orgSection">
+            <div>
+              <div class="flex items-center justify-between">
+                <div class="flex">
+                  <p class="text-sm font-medium" data-i18n="githubTokenLabel">Your GitHub Token</p>
+                  <span class="tooltip-container">
+                    <i class="fa fa-question-circle question-icon"></i>
+                    <span class="tooltip-bubble" data-i18n="githubTokenTooltip">
+                      <b>Why is it recommended to add a GitHub token?</b><br>
+                      Scrum Helper works without a GitHub token, but adding a personal access
+                      token is recommended for a
+                      better experience. It raises your API limits, allows access to private
+                      repos
+                      (if permitted), and
+                      improves accuracy and speed. Tokens are stored locally and never sent to
+                      us
+                      and used only to fetch
+                      your git data. You can add one anytime in the extension
+                      settings.<br><br>
+                      <b>How to obtain:</b><br>
+                      1. Go to <a href="https://github.com/settings/tokens" target="_blank" rel="noopener noreferrer" style="color:#2563eb;text-decoration:underline;">GitHub Developer
+                        Settings</a>.<br>
+                      3. Click "Generate new token", select classic token<br>
+                      4. Paste it here.<br>
+                      <i>Keep your token secret!</i>
+                    </span>
+                  </span>
 
-								</div>
-								<button id="toggleTokenVisibility" type="button" class="focus:outline-none">
-									<i id="tokenEyeIcon" class="fa fa-eye text-gray-600"></i>
-								</button>
-							</div>
-							<input id="githubToken" type="password"
-								class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2 pr-10"
-								data-i18n-placeholder="githubTokenPlaceholder">
-						</div>
-						<div class="githubOnlySection">
-							<div class="flex items-center mt-4">
-								<p class="text-sm font-semibold" data-i18n="settingsOrgNameLabel">Your Organization Name
-								</p>
-								<span class="tooltip-container ml-2">
-									<i class="fa fa-question-circle question-icon"></i>
-									<span class="tooltip-bubble" data-i18n="orgNameTooltip">
-										<b>Which organization's GitHub activity?</b><br>
-										Enter the GitHub organization name to fetch activities for. Leave empty to fetch
-										all
-										your GitHub
-										activities across all organizations.
-										Organization name is not case-sensitive.
-									</span>
-								</span>
-							</div>
-							<input id="orgInput" type="text"
-								class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2"
-								data-i18n-placeholder="settingsOrgNamePlaceholder"
-								style="margin-top: 0.3rem; margin-bottom: 0.8rem;">
+                </div>
+                <button id="toggleTokenVisibility" type="button" class="focus:outline-none">
+                  <i id="tokenEyeIcon" class="fa fa-eye text-gray-600"></i>
+                </button>
+              </div>
+              <input id="githubToken" type="password" class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2 pr-10" data-i18n-placeholder="githubTokenPlaceholder">
+            </div>
+            <div class="githubOnlySection">
+              <div class="flex items-center mt-4">
+                <p class="text-sm font-semibold" data-i18n="settingsOrgNameLabel">Your Organization Name
+                </p>
+                <span class="tooltip-container ml-2">
+                  <i class="fa fa-question-circle question-icon"></i>
+                  <span class="tooltip-bubble" data-i18n="orgNameTooltip">
+                    <b>Which organization's GitHub activity?</b><br>
+                    Enter the GitHub organization name to fetch activities for. Leave empty to fetch
+                    all
+                    your GitHub
+                    activities across all organizations.
+                    Organization name is not case-sensitive.
+                  </span>
+                </span>
+              </div>
+              <input id="orgInput" type="text" class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2" data-i18n-placeholder="settingsOrgNamePlaceholder" style="margin-top: 0.3rem; margin-bottom: 0.8rem;">
 
-							<!-- Organization validation feedback -->
-							<div id="orgValidationMessage" class="hidden text-xs mt-1 mb-2 px-3 py-2 rounded-lg">
-								<span id="orgValidationText"></span>
-							</div>
-						</div>
+              <!-- Organization validation feedback -->
+              <div id="orgValidationMessage" class="hidden text-xs mt-1 mb-2 px-3 py-2 rounded-lg">
+                <span id="orgValidationText"></span>
+              </div>
+            </div>
 
-						<div class="mb-4">
-							<div class="flex items-center justify-between mb-2">
-								<p class="text-sm font-medium">
-									<span data-i18n="repoFilterLabel">Filter by repositories</span><span
-										class="tooltip-container">
-										<i class="fa fa-question-circle question-icon"></i>
-										<span class="tooltip-bubble" data-i18n="repoFilterTooltip">
-											Github Token required.<br>
-											To force a repo list update, <br>
-											click the Refresh Data button.
-										</span>
-									</span>
-								</p>
-								<div class="flex items-center">
+            <div class="mb-4">
+              <div class="flex items-center justify-between mb-2">
+                <p class="text-sm font-medium">
+                  <span data-i18n="repoFilterLabel">Filter by repositories</span><span class="tooltip-container">
+                    <i class="fa fa-question-circle question-icon"></i>
+                    <span class="tooltip-bubble" data-i18n="repoFilterTooltip">
+                      Github Token required.<br>
+                      To force a repo list update, <br>
+                      click the Refresh Data button.
+                    </span>
+                  </span>
+                </p>
+                <div class="flex items-center">
 
-									<input type="checkbox" id="useRepoFilter" class="mr-2" style="margin-right: 4px;">
-									<label for="useRepoFilter" class="text-xs text-gray-600"><span
-											data-i18n="enableFilteringLabel">Enable
-											filtering</span></label>
-								</div>
-							</div>
-							<div id="tokenWarningForFilter"
-								class="hidden text-xs text-red-600 p-2 bg-red-50 border border-red-200 rounded-xl mt-2">
-								<span data-i18n="tokenRequiredWarning">A GitHub token is required for repository
-									filtering. Please add one in the settings.</span>
-							</div>
+                  <input type="checkbox" id="useRepoFilter" class="mr-2" style="margin-right: 4px;">
+                  <label for="useRepoFilter" class="text-xs text-gray-600"><span data-i18n="enableFilteringLabel">Enable
+                      filtering</span></label>
+                </div>
+              </div>
+              <div id="tokenWarningForFilter" class="hidden text-xs text-red-600 p-2 bg-red-50 border border-red-200 rounded-xl mt-2">
+                <span data-i18n="tokenRequiredWarning">A GitHub token is required for repository
+                  filtering. Please add one in the settings.</span>
+              </div>
 
-							<div id="repoFilterContainer" class="hidden">
-								<input id="repoSearch" type="text" data-i18n-placeholder="repoSearchPlaceholder"
-									class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 pr-10"
-									autocomplete="off">
-								<!-- Typeahead Input -->
-								<div class="relative">
+              <div id="repoFilterContainer" class="hidden">
+                <input id="repoSearch" type="text" data-i18n-placeholder="repoSearchPlaceholder" class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 pr-10" autocomplete="off">
+                <!-- Typeahead Input -->
+                <div class="relative">
 
-									<!-- Dropdown -->
-									<div id="repoDropdown"
-										class="absolute w-full bg-white border border-gray-300 rounded-xl shadow-lg hidden max-h-48 overflow-y-auto"
-										style="z-index: 1000; margin-top: -10px;">
-									</div>
-								</div>
+                  <!-- Dropdown -->
+                  <div id="repoDropdown" class="absolute w-full bg-white border border-gray-300 rounded-xl shadow-lg hidden max-h-48 overflow-y-auto" style="z-index: 1000; margin-top: -10px;">
+                  </div>
+                </div>
 
-								<!-- Selected Tags Container -->
-								<div id="selectedRepos"
-									class="mt-3 min-h-[32px] p-2 border-2 border-gray-200 bg-gray-50 rounded-xl">
-									<div class="flex flex-wrap gap-1" id="repoTags">
-										<span class="text-xs text-gray-500 select-none" id="repoPlaceholder"
-											data-i18n="repoPlaceholder">No
-											repositories selected (all will be included)</span>
-									</div>
-								</div>
+                <!-- Selected Tags Container -->
+                <div id="selectedRepos" class="mt-3 min-h-[32px] p-2 border-2 border-gray-200 bg-gray-50 rounded-xl">
+                  <div class="flex flex-wrap gap-1" id="repoTags">
+                    <span class="text-xs text-gray-500 select-none" id="repoPlaceholder" data-i18n="repoPlaceholder">No
+                      repositories selected (all will be included)</span>
+                  </div>
+                </div>
 
-								<!-- Status/Info -->
-								<div class="mt-2 text-xs text-gray-600 flex justify-between">
-									<span id="repoCount" data-i18n="repoCountNone">0 repositories selected</span>
-									<span id="repoStatus" class="text-blue-600"></span>
-								</div>
-							</div>
-						</div>
-					</div>
+                <!-- Status/Info -->
+                <div class="mt-2 text-xs text-gray-600 flex justify-between">
+                  <span id="repoCount" data-i18n="repoCountNone">0 repositories selected</span>
+                  <span id="repoStatus" class="text-blue-600"></span>
+                </div>
+              </div>
+            </div>
+          </div>
 
-					<div class="gitlabOnlySection hidden mt-3">
-						<div class="flex items-center justify-between">
-							<div class="flex">
-								<p class="text-sm font-medium" data-i18n="gitlabTokenLabel">Your GitLab Token</p>
-								<span class="tooltip-container">
-									<i class="fa fa-question-circle question-icon"></i>
-									<span class="tooltip-bubble" data-i18n="gitlabTokenTooltip">
-										<b>Why add a GitLab token?</b><br>
-										Scrum Helper works without a token for public projects, but a personal access token enables
-										private repos and better rate limits. Your token stays local and is only used to
-										fetch your GitLab data.<br><br>
-										<b>How to get one:</b><br>
-										1. Go to <a href="https://gitlab.com/-/profile/personal_access_tokens"
-											target="_blank" rel="noopener noreferrer"
-											style="color:#2563eb;text-decoration:underline;">GitLab Access
-											Tokens</a><br>
-										2. Click "Add new token"<br>
-										3. Select "read_api" scope<br>
-										4. Paste it here<br>
-										<i>Keep it secret!</i>
-									</span>
-								</span>
-							</div>
-							<button id="toggleGitlabTokenVisibility" type="button" class="focus:outline-none">
-								<i id="gitlabTokenEyeIcon" class="fa fa-eye text-gray-600"></i>
-							</button>
-						</div>
-						<input id="gitlabToken" type="password"
-							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2 pr-10"
-							data-i18n-placeholder="gitlabTokenPlaceholder">
-					</div>
+          <div class="gitlabOnlySection hidden mt-3">
+            <div class="flex items-center justify-between">
+              <div class="flex">
+                <p class="text-sm font-medium" data-i18n="gitlabTokenLabel">Your GitLab Token</p>
+                <span class="tooltip-container">
+                  <i class="fa fa-question-circle question-icon"></i>
+                  <span class="tooltip-bubble" data-i18n="gitlabTokenTooltip">
+                    <b>Why add a GitLab token?</b><br>
+                    Scrum Helper works without a token for public projects, but a personal access token enables
+                    private repos and better rate limits. Your token stays local and is only used to
+                    fetch your GitLab data.<br><br>
+                    <b>How to get one:</b><br>
+                    1. Go to <a href="https://gitlab.com/-/profile/personal_access_tokens" target="_blank" rel="noopener noreferrer" style="color:#2563eb;text-decoration:underline;">GitLab Access
+                      Tokens</a><br>
+                    2. Click "Add new token"<br>
+                    3. Select "read_api" scope<br>
+                    4. Paste it here<br>
+                    <i>Keep it secret!</i>
+                  </span>
+                </span>
+              </div>
+              <button id="toggleGitlabTokenVisibility" type="button" class="focus:outline-none">
+                <i id="gitlabTokenEyeIcon" class="fa fa-eye text-gray-600"></i>
+              </button>
+            </div>
+            <input id="gitlabToken" type="password" class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2 pr-10" data-i18n-placeholder="gitlabTokenPlaceholder">
+          </div>
 
-					<div class="cacheSection mt-3">
-						<div class="flex items-center justify-between mb-2">
-							<div class="flex items-center">
-								<p class="text-sm font-medium" data-i18n="displayModeLabel">Display Mode</p>
-								<span class="tooltip-container ml-2">
-									<i class="fa fa-question-circle question-icon"></i>
-									<span class="tooltip-bubble" data-i18n="displayModeTooltip">
-										Choose how Scrum Helper opens when you click its icon.
-										<b>Side Panel</b> keeps it docked alongside your page.
-										<b>Popup</b> opens a floating window.
-									</span>
-								</span>
-							</div>
-						</div>
-						<select id="displayModeSelect"
-							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 mb-2">
-							<option value="sidePanel">Side Panel</option>
-							<option value="popup">Popup</option>
-						</select>
-						<div id="displayModeNotice"
-							class="hidden text-xs text-blue-700 bg-blue-50 border border-blue-200 rounded-xl p-2 mt-1 mb-2 flex items-center gap-2">
-							<i class="fa fa-info-circle"></i>
-							<span id="displayModeNoticeText"></span>
-						</div>
-					</div>
+          <div class="cacheSection mt-3">
+            <div class="flex items-center justify-between mb-2">
+              <div class="flex items-center">
+                <p class="text-sm font-medium" data-i18n="displayModeLabel">Display Mode</p>
+                <span class="tooltip-container ml-2">
+                  <i class="fa fa-question-circle question-icon"></i>
+                  <span class="tooltip-bubble" data-i18n="displayModeTooltip">
+                    Choose how Scrum Helper opens when you click its icon.
+                    <b>Side Panel</b> keeps it docked alongside your page.
+                    <b>Popup</b> opens a floating window.
+                  </span>
+                </span>
+              </div>
+            </div>
+            <select id="displayModeSelect" class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 mb-2">
+              <option value="sidePanel">Side Panel</option>
+              <option value="popup">Popup</option>
+            </select>
+            <div id="displayModeNotice" class="hidden text-xs text-blue-700 bg-blue-50 border border-blue-200 rounded-xl p-2 mt-1 mb-2 flex items-center gap-2">
+              <i class="fa fa-info-circle"></i>
+              <span id="displayModeNoticeText"></span>
+            </div>
+          </div>
 
-					<div class="cacheSection mt-3">
-						<p class="text-sm font-medium"><span data-i18n="cacheTTLLabel">Enter cache TTL</span> <span
-								class="text-sm font-normal" data-i18n="cacheTTLUnit">(in
-								minutes)</span>
-							<span class="tooltip-container">
-								<i class="fa fa-question-circle question-icon"></i>
-								<span class="tooltip-bubble" data-i18n="cacheTTLTooltip">
-									We are caching the data to avoid redundant calls. By default the cache expires after
-									10 minutes, you
-									can change it here to your desired time. We have given a refresh cache button in
-									case you want to
-									fetch fresh data right now.
-								</span>
-							</span>
-						</p>
-						<input type="text" id="cacheInput"
-							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800  p-2 my-2"
-							data-i18n-placeholder="cacheTTLPlaceholder">
-					</div>
+          <div class="cacheSection mt-3">
+            <p class="text-sm font-medium"><span data-i18n="cacheTTLLabel">Enter cache TTL</span> <span class="text-sm font-normal" data-i18n="cacheTTLUnit">(in
+                minutes)</span>
+              <span class="tooltip-container">
+                <i class="fa fa-question-circle question-icon"></i>
+                <span class="tooltip-bubble" data-i18n="cacheTTLTooltip">
+                  We are caching the data to avoid redundant calls. By default the cache expires after
+                  10 minutes, you
+                  can change it here to your desired time. We have given a refresh cache button in
+                  case you want to
+                  fetch fresh data right now.
+                </span>
+              </span>
+            </p>
+            <input type="text" id="cacheInput" class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800  p-2 my-2" data-i18n-placeholder="cacheTTLPlaceholder">
+          </div>
 
-					<div class="">
-						<button id="refreshCache"
-							class="w-full mt-3 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded flex items-center justify-center gap-2 transition-colors duration-200">
-							<i class="fa fa-refresh"></i>
-							<span data-i18n="refreshDataButton">Refresh Data (bypass cache)</span>
-						</button>
-						<p class="cache-info">
-							<i class="fa fa-info-circle"></i>
-							<span data-i18n="refreshDataInfo">Use this button to fetch fresh data immediately.</span>
-						</p>
-					</div>
+          <div class="">
+            <button id="refreshCache" class="w-full mt-3 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded flex items-center justify-center gap-2 transition-colors duration-200">
+              <i class="fa fa-refresh"></i>
+              <span data-i18n="refreshDataButton">Refresh Data (bypass cache)</span>
+            </button>
+            <p class="cache-info">
+              <i class="fa fa-info-circle"></i>
+              <span data-i18n="refreshDataInfo">Use this button to fetch fresh data immediately.</span>
+            </p>
+          </div>
 
-				</div>
-			</div>
+        </div>
+      </div>
 
-			<div class="mt-6 border-t border-gray-300">
-				<div class="bg-white rounded-3xl mx-2 mt-4 mb-2 p-4 border border-gray-100 shadow-sm">
-					<div class="flex items-center justify-center space-x-3">
-						<a target="_blank" rel="noopener noreferrer" href="https://github.com/fossasia/scrum_helper"
-							class="bg-blue-50 hover:bg-blue-100 text-blue-600 transition-all duration-200 rounded-lg px-4 py-2 flex items-center space-x-2 gap-2">
-							<i class="fa fa-code text-sm pl-1"></i>
-							<span class="text-sm font-medium" data-i18n="viewCodeButton">View Code</span>
-						</a>
-						<a target="_blank" rel="noopener noreferrer"
-							href="https://github.com/fossasia/scrum_helper/issues"
-							class="bg-blue-50 hover:bg-blue-100 text-blue-600 transition-all duration-200 rounded-lg px-4 py-2 flex items-center space-x-2 gap-2">
-							<i class="fa fa-bug text-sm"></i>
-							<span class="text-sm font-medium" data-i18n="reportIssueButton">Report Issue</span>
-						</a>
-					</div>
-				</div>
-				<div class="mt-3 pt-3 border-t border-gray-200 flex justify-center items-center py-">
-					<p class="text-xs text-gray-600 text-center">
-						Made with ❤️ by <strong>FOSSASIA</strong> •
-						<span class="text-gray-500 dark:text-gray-300">v2.1.4</span>
-					</p>
-				</div>
-			</div>
-		</div>
-	</div>
-	<!-- WebExtensions Polyfill for Cross-Browser compatibility (Chrome, Firefox, Edge, etc.) -->
-	 <script src="libs/purify.min.js"></script>
-	 <script src="scripts/domSanitizer.js"></script>
-	<script src="scripts/browser-polyfill.min.js"></script>
-	<script src="scripts/jquery-3.2.1.min.js"></script>
-	<script type="text/javascript" src="materialize/js/materialize.min.js"></script>
-	<script src="scripts/emailClientAdapter.js"></script>
-	<script src="scripts/main.js"></script>
-	<script src="scripts/gitlabHelper.js"></script>
-	<script src="scripts/scrumHelper.js"></script>
-	<script src="scripts/popup.js"></script>
+      <div class="mt-6 border-t border-gray-300">
+        <div class="bg-white rounded-3xl mx-2 mt-4 mb-2 p-4 border border-gray-100 shadow-sm">
+          <div class="flex items-center justify-center space-x-3">
+            <a target="_blank" rel="noopener noreferrer" href="https://github.com/fossasia/scrum_helper" class="bg-blue-50 hover:bg-blue-100 text-blue-600 transition-all duration-200 rounded-lg px-4 py-2 flex items-center space-x-2 gap-2">
+              <i class="fa fa-code text-sm pl-1"></i>
+              <span class="text-sm font-medium" data-i18n="viewCodeButton">View Code</span>
+            </a>
+            <a target="_blank" rel="noopener noreferrer" href="https://github.com/fossasia/scrum_helper/issues" class="bg-blue-50 hover:bg-blue-100 text-blue-600 transition-all duration-200 rounded-lg px-4 py-2 flex items-center space-x-2 gap-2">
+              <i class="fa fa-bug text-sm"></i>
+              <span class="text-sm font-medium" data-i18n="reportIssueButton">Report Issue</span>
+            </a>
+          </div>
+        </div>
+        <div class="mt-3 pt-3 border-t border-gray-200 flex justify-center items-center py-">
+          <p class="text-xs text-gray-600 text-center">
+            Made with ❤️ by <strong>FOSSASIA</strong> •
+            <span class="text-gray-500 dark:text-gray-300">v2.1.4</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- WebExtensions Polyfill for Cross-Browser compatibility (Chrome, Firefox, Edge, etc.) -->
+  <script src="libs/purify.min.js"></script>
+  <script src="scripts/domSanitizer.js"></script>
+  <script src="scripts/browser-polyfill.min.js"></script>
+  <script src="scripts/jquery-3.2.1.min.js"></script>
+  <script type="text/javascript" src="materialize/js/materialize.min.js"></script>
+  <script src="scripts/emailClientAdapter.js"></script>
+  <script src="scripts/main.js"></script>
+  <script src="scripts/gitlabHelper.js"></script>
+  <script src="scripts/scrumHelper.js"></script>
+  <script src="scripts/popup.js"></script>
 </body>
 
 </html>

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -50,11 +50,38 @@ function showShortcutNotification(messageKey) {
 
 let _cacheAgeTicker = null;
 
+function getUILocale() {
+  if (
+    typeof browser !== "undefined" &&
+    browser.i18n &&
+    typeof browser.i18n.getUILanguage === "function"
+  ) {
+    return browser.i18n.getUILanguage();
+  }
+
+  if (
+    typeof chrome !== "undefined" &&
+    chrome.i18n &&
+    typeof chrome.i18n.getUILanguage === "function"
+  ) {
+    return chrome.i18n.getUILanguage();
+  }
+
+  return undefined;
+}
+
 function formatCacheAge(ms) {
-  const totalSeconds = Math.floor(ms / 1000);
-  if (totalSeconds < 60) return `${totalSeconds}s ago`;
+  const safeMs = Math.max(0, ms);
+  const totalSeconds = Math.floor(safeMs / 1000);
+  const rtf = new Intl.RelativeTimeFormat(getUILocale(), {
+    numeric: "auto",
+    style: "short",
+  });
+
+  if (totalSeconds < 60) return rtf.format(-totalSeconds, "second");
+
   const minutes = Math.floor(totalSeconds / 60);
-  return `${minutes} min ago`;
+  return rtf.format(-minutes, "minute");
 }
 
 function updateCacheStatusBadge(timestamp, ttlMs) {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -2321,8 +2321,14 @@ document
       this.innerHTML = `<i class="fa fa-check"></i><span>${browser.i18n.getMessage("cacheClearedButton")}</span>`;
       this.classList.remove("loading");
 
-      // Reset badge to "no cache" since storage was just wiped
-      updateCacheStatusBadge(null, 10 * 60 * 1000);
+      // Reset badge to "no cache" since storage was just wiped, using the configured TTL when available
+      const cacheInput = document.getElementById("cacheInput");
+      const cacheInputMinutes = cacheInput ? Number.parseInt(cacheInput.value, 10) : NaN;
+      const cacheTtlMs =
+        Number.isFinite(cacheInputMinutes) && cacheInputMinutes > 0
+          ? cacheInputMinutes * 60 * 1000
+          : 10 * 60 * 1000;
+      updateCacheStatusBadge(null, cacheTtlMs);
       stopCacheAgeTicker();
 
       // Do NOT trigger report generation automatically

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1,1583 +1,1843 @@
 /* global chrome */
 
 function debounce(func, wait) {
-	let timeout;
-	return function (...args) {
-		clearTimeout(timeout);
-		timeout = setTimeout(() => func.apply(this, args), wait);
-	};
+  let timeout;
+  return function (...args) {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func.apply(this, args), wait);
+  };
 }
 
 // Utility: Detect if the current OS is macOS
 function isMacOS() {
-	if (typeof navigator === 'undefined') {
-		return false;
-	}
+  if (typeof navigator === "undefined") {
+    return false;
+  }
 
-	if (navigator.userAgentData && typeof navigator.userAgentData.platform === 'string') {
-		return navigator.userAgentData.platform.toLowerCase().includes('mac');
-	}
+  if (
+    navigator.userAgentData &&
+    typeof navigator.userAgentData.platform === "string"
+  ) {
+    return navigator.userAgentData.platform.toLowerCase().includes("mac");
+  }
 
-	const platform = navigator.platform || '';
-	if (navigator.maxTouchPoints && navigator.maxTouchPoints > 2 && /MacIntel/.test(platform)) {
-		return true;
-	}
+  const platform = navigator.platform || "";
+  if (
+    navigator.maxTouchPoints &&
+    navigator.maxTouchPoints > 2 &&
+    /MacIntel/.test(platform)
+  ) {
+    return true;
+  }
 
-	return /Mac/.test(platform);
+  return /Mac/.test(platform);
 }
 
 function showShortcutNotification(messageKey) {
-	if (typeof chrome === 'undefined' || !chrome.i18n) {
-		return;
-	}
+  if (typeof chrome === "undefined" || !chrome.i18n) {
+    return;
+  }
 
-	const message = chrome.i18n.getMessage(messageKey);
-	if (!message) {
-		return;
-	}
+  const message = chrome.i18n.getMessage(messageKey);
+  if (!message) {
+    return;
+  }
 
-	window.scrumHelperToast?.(message, { duration: 2200, variant: 'info' });
+  window.scrumHelperToast?.(message, { duration: 2200, variant: "info" });
+}
+
+// --- Cache status badge (Issue #574) ---
+
+let _cacheAgeTicker = null;
+
+function formatCacheAge(ms) {
+  const totalSeconds = Math.floor(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s ago`;
+  const minutes = Math.floor(totalSeconds / 60);
+  return `${minutes} min ago`;
+}
+
+function updateCacheStatusBadge(timestamp, ttlMs) {
+  const bar = document.getElementById("cacheStatusBar");
+  const iconEl = document.getElementById("cacheStatusIcon");
+  const textEl = document.getElementById("cacheStatusText");
+  const warning = document.getElementById("cacheStaleWarning");
+
+  if (!bar || !iconEl || !textEl) return;
+
+  // No cache at all
+  if (!timestamp) {
+    bar.className = "cache-status-bar no-cache";
+    iconEl.textContent = "⟳";
+    textEl.textContent =
+      browser.i18n.getMessage("cacheStatusNoCache") || "No cache";
+    bar.removeAttribute("title");
+    bar.classList.remove("hidden");
+    warning?.classList.add("hidden");
+    return;
+  }
+
+  const age = Date.now() - timestamp;
+  const isStale = age > ttlMs;
+  const ttlMin = Math.round(ttlMs / 60000);
+
+  bar.className = `cache-status-bar ${isStale ? "stale" : "fresh"}`;
+  iconEl.textContent = isStale ? "⚠" : "✓";
+  textEl.textContent = isStale
+    ? browser.i18n.getMessage("cacheStatusStale", [formatCacheAge(age)]) ||
+      `Stale · ${formatCacheAge(age)}`
+    : browser.i18n.getMessage("cacheStatusFresh", [formatCacheAge(age)]) ||
+      `Cached · ${formatCacheAge(age)}`;
+
+  bar.title =
+    browser.i18n.getMessage("cacheStatusTooltip", [
+      formatCacheAge(age),
+      String(ttlMin),
+    ]) ||
+    `Report cached ${formatCacheAge(age)}. Refreshes after ${ttlMin} min.`;
+
+  bar.classList.remove("hidden");
+  warning?.classList.toggle("hidden", !isStale);
+}
+
+function startCacheAgeTicker(timestamp, ttlMs) {
+  stopCacheAgeTicker();
+  if (!timestamp) return;
+  _cacheAgeTicker = setInterval(() => {
+    updateCacheStatusBadge(timestamp, ttlMs);
+  }, 30_000);
+}
+
+function stopCacheAgeTicker() {
+  if (_cacheAgeTicker) {
+    clearInterval(_cacheAgeTicker);
+    _cacheAgeTicker = null;
+  }
+}
+
+function hideCacheStatusBadge() {
+  document.getElementById("cacheStatusBar")?.classList.add("hidden");
+  document.getElementById("cacheStaleWarning")?.classList.add("hidden");
+  stopCacheAgeTicker();
 }
 
 function setupButtonTooltips() {
-	const mac = isMacOS();
+  const mac = isMacOS();
 
-	const generateTooltipEl = document.getElementById('generateReportTooltipText');
-	if (generateTooltipEl) {
-		const text = chrome?.i18n.getMessage('generateReportTooltip') || 'Ctrl+G';
-		generateTooltipEl.textContent = mac ? text.replace('Ctrl', 'Cmd') : text;
-	}
+  const generateTooltipEl = document.getElementById(
+    "generateReportTooltipText",
+  );
+  if (generateTooltipEl) {
+    const text = chrome?.i18n.getMessage("generateReportTooltip") || "Ctrl+G";
+    generateTooltipEl.textContent = mac ? text.replace("Ctrl", "Cmd") : text;
+  }
 
-	const copyTooltipEl = document.getElementById('copyReportTooltipText');
-	if (copyTooltipEl) {
-		const text = chrome?.i18n.getMessage('copyReportTooltip') || 'Ctrl+Shift+Y';
-		copyTooltipEl.textContent = mac ? text.replace('Ctrl', 'Cmd') : text;
-	}
+  const copyTooltipEl = document.getElementById("copyReportTooltipText");
+  if (copyTooltipEl) {
+    const text = chrome?.i18n.getMessage("copyReportTooltip") || "Ctrl+Shift+Y";
+    copyTooltipEl.textContent = mac ? text.replace("Ctrl", "Cmd") : text;
+  }
 
-	const insertEmailTooltipEl = document.getElementById('insertInEmailTooltipText');
-	if (insertEmailTooltipEl) {
-		const text = chrome?.i18n.getMessage('insertInEmailTooltip') || 'Ctrl+Shift+M';
-		insertEmailTooltipEl.textContent = mac ? text.replace('Ctrl', 'Cmd') : text;
-	}
+  const insertEmailTooltipEl = document.getElementById(
+    "insertInEmailTooltipText",
+  );
+  if (insertEmailTooltipEl) {
+    const text =
+      chrome?.i18n.getMessage("insertInEmailTooltip") || "Ctrl+Shift+M";
+    insertEmailTooltipEl.textContent = mac ? text.replace("Ctrl", "Cmd") : text;
+  }
 }
 
 function getToday() {
-	const today = new Date();
-	return today.toISOString().split('T')[0];
+  const today = new Date();
+  return today.toISOString().split("T")[0];
 }
 
 function getYesterday() {
-	const today = new Date();
-	const yesterday = new Date(today);
-	yesterday.setDate(today.getDate() - 1);
-	return yesterday.toISOString().split('T')[0];
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  return yesterday.toISOString().split("T")[0];
 }
 
 function applyI18n() {
-	document.querySelectorAll('[data-i18n]').forEach((el) => {
-		const key = el.getAttribute('data-i18n');
-		const message = browser.i18n.getMessage(key);
-		if (message) {
-			// Use innerHTML to support simple formatting like <b> in tooltips
-			if (el.classList.contains('tooltip-bubble') || el.classList.contains('cache-info')) {
-				el.innerHTML = sanitizeHtml(message);
-			} else {
-				el.textContent = message;
-			}
-		}
-	});
+  document.querySelectorAll("[data-i18n]").forEach((el) => {
+    const key = el.getAttribute("data-i18n");
+    const message = browser.i18n.getMessage(key);
+    if (message) {
+      // Use innerHTML to support simple formatting like <b> in tooltips
+      if (
+        el.classList.contains("tooltip-bubble") ||
+        el.classList.contains("cache-info")
+      ) {
+        el.innerHTML = sanitizeHtml(message);
+      } else {
+        el.textContent = message;
+      }
+    }
+  });
 
-	document.querySelectorAll('[data-i18n-placeholder]').forEach((el) => {
-		const key = el.getAttribute('data-i18n-placeholder');
-		const message = browser.i18n.getMessage(key);
-		if (message) {
-			el.placeholder = message;
-		}
-	});
+  document.querySelectorAll("[data-i18n-placeholder]").forEach((el) => {
+    const key = el.getAttribute("data-i18n-placeholder");
+    const message = browser.i18n.getMessage(key);
+    if (message) {
+      el.placeholder = message;
+    }
+  });
 
-	document.querySelectorAll('[data-i18n-title]').forEach((el) => {
-		const key = el.getAttribute('data-i18n-title');
-		const message = browser.i18n.getMessage(key);
-		if (message) {
-			el.title = message;
-		}
-	});
+  document.querySelectorAll("[data-i18n-title]").forEach((el) => {
+    const key = el.getAttribute("data-i18n-title");
+    const message = browser.i18n.getMessage(key);
+    if (message) {
+      el.title = message;
+    }
+  });
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-	// Apply translations as soon as the DOM is ready
-	applyI18n();
-	setupButtonTooltips();
-
-	// Dark mode setup
-	const darkModeToggle = document.querySelector('img[alt="Night Mode"]');
-	const settingsIcon = document.getElementById('settingsIcon');
-	const body = document.body;
-	const homeButton = document.getElementById('homeButton');
-	const scrumHelperHeading = document.getElementById('scrumHelperHeading');
-	const settingsToggle = document.getElementById('settingsToggle');
-	const reportSection = document.getElementById('reportSection');
-	const settingsSection = document.getElementById('settingsSection');
-
-	let isSettingsVisible = false;
-	const githubTokenInput = document.getElementById('githubToken');
-	const toggleTokenBtn = document.getElementById('toggleTokenVisibility');
-	const tokenEyeIcon = document.getElementById('tokenEyeIcon');
-	const tokenPreview = document.getElementById('tokenPreview');
-	let tokenVisible = false;
-
-	// GitLab token elements
-	const gitlabTokenInput = document.getElementById('gitlabToken');
-	const toggleGitlabTokenBtn = document.getElementById('toggleGitlabTokenVisibility');
-	const gitlabTokenEyeIcon = document.getElementById('gitlabTokenEyeIcon');
-	let gitlabTokenVisible = false;
-
-	const orgInput = document.getElementById('orgInput');
-
-	const platformSelect = document.getElementById('platformSelect');
-	const usernameLabel = document.getElementById('usernameLabel');
-	const platformUsername = document.getElementById('platformUsername');
-	let showCommitsWarningTimeout;
-	let mergedPRsWarningTimeout;
-
-	function checkTokenForFilter() {
-		const useRepoFilter = document.getElementById('useRepoFilter');
-		const githubTokenInput = document.getElementById('githubToken');
-		const tokenWarning = document.getElementById('tokenWarningForFilter');
-		const repoFilterContainer = document.getElementById('repoFilterContainer');
-
-		if (!useRepoFilter || !githubTokenInput || !tokenWarning || !repoFilterContainer) {
-			return;
-		}
-		const isFilterEnabled = useRepoFilter.checked;
-		const hasToken = githubTokenInput.value.trim() !== '';
-
-		if (isFilterEnabled && !hasToken) {
-			useRepoFilter.checked = false;
-			repoFilterContainer.classList.add('hidden');
-			if (typeof hideDropdown === 'function') {
-				hideDropdown();
-			}
-			browser.storage.local.set({ useRepoFilter: false });
-		}
-		tokenWarning.classList.toggle('hidden', !isFilterEnabled || hasToken);
-		setTimeout(() => {
-			tokenWarning.classList.add('hidden');
-		}, 4000);
-	}
-
-	function showTokenWarningForMergedPRs({ animate = false, durationMs = 4000 } = {}) {
-		const tokenWarning = document.getElementById('tokenWarningForMergedPRs');
-		if (!tokenWarning) {
-			return;
-		}
-
-		tokenWarning.classList.remove('hidden');
-		if (animate) {
-			tokenWarning.classList.add('shake-animation');
-			setTimeout(() => tokenWarning.classList.remove('shake-animation'), 620);
-		}
-
-		if (mergedPRsWarningTimeout) {
-			clearTimeout(mergedPRsWarningTimeout);
-		}
-		mergedPRsWarningTimeout = setTimeout(() => {
-			tokenWarning.classList.add('hidden');
-		}, durationMs);
-	}
-
-	function checkTokenForMergedPRs({
-		showWarning = false,
-		animateWarning = false,
-		warningDurationMs = 4000,
-		persistState = false,
-	} = {}) {
-		const mergedPRsCheckbox = document.getElementById('onlyMergedPRs');
-		const githubTokenInput = document.getElementById('githubToken');
-
-		if (!mergedPRsCheckbox || !githubTokenInput) {
-			return;
-		}
-
-		const isMergedPRsEnabled = mergedPRsCheckbox.checked;
-		const hasToken = githubTokenInput.value.trim() !== '';
-
-		if (isMergedPRsEnabled && !hasToken) {
-			mergedPRsCheckbox.checked = false;
-			if (showWarning) {
-				showTokenWarningForMergedPRs({
-					animate: animateWarning,
-					durationMs: warningDurationMs,
-				});
-			}
-			chrome?.storage.local.set({ onlyMergedPRs: false });
-			return;
-		}
-
-		const tokenWarning = document.getElementById('tokenWarningForMergedPRs');
-		if (tokenWarning) {
-			if (mergedPRsWarningTimeout) {
-				clearTimeout(mergedPRsWarningTimeout);
-				mergedPRsWarningTimeout = null;
-			}
-			tokenWarning.classList.add('hidden');
-		}
-		if (persistState) {
-			chrome?.storage.local.set({ onlyMergedPRs: mergedPRsCheckbox.checked });
-		}
-	}
-
-	function showTokenWarningForShowCommits({ animate = false, durationMs = 4000 } = {}) {
-		const tokenWarning = document.getElementById('tokenWarningForShowCommits');
-		if (!tokenWarning) {
-			return;
-		}
-
-		tokenWarning.classList.remove('hidden');
-		if (animate) {
-			tokenWarning.classList.add('shake-animation');
-			setTimeout(() => tokenWarning.classList.remove('shake-animation'), 620);
-		}
-
-		if (showCommitsWarningTimeout) {
-			clearTimeout(showCommitsWarningTimeout);
-		}
-		showCommitsWarningTimeout = setTimeout(() => {
-			tokenWarning.classList.add('hidden');
-		}, durationMs);
-	}
-
-	function checkTokenForShowCommits({
-		showWarning = false,
-		animateWarning = false,
-		warningDurationMs = 4000,
-		persistState = false,
-	} = {}) {
-		const showCommits = document.getElementById('showCommits');
-		const githubTokenInput = document.getElementById('githubToken');
-
-		if (!showCommits || !githubTokenInput) {
-			return;
-		}
-
-		const isShowCommitsEnabled = showCommits.checked;
-		const hasToken = githubTokenInput.value.trim() !== '';
-
-		if (isShowCommitsEnabled && !hasToken) {
-			showCommits.checked = false;
-			if (showWarning) {
-				showTokenWarningForShowCommits({
-					animate: animateWarning,
-					durationMs: warningDurationMs,
-				});
-			}
-			// Always persist correction of invalid state
-			browser.storage.local.set({ showCommits: false });
-			return;
-		}
-
-		const tokenWarning = document.getElementById('tokenWarningForShowCommits');
-		if (tokenWarning) {
-			if (showCommitsWarningTimeout) {
-				clearTimeout(showCommitsWarningTimeout);
-				showCommitsWarningTimeout = null;
-			}
-			tokenWarning.classList.add('hidden');
-		}
-		if (persistState) {
-			browser.storage.local.set({ showCommits: showCommits.checked });
-		}
-	}
-
-	browser.storage.local.get(['darkMode']).then((result) => {
-		if (result.darkMode) {
-			body.classList.add('dark-mode');
-			darkModeToggle.src = 'icons/light-mode.png';
-			if (settingsIcon) {
-				settingsIcon.src = 'icons/settings-night.png';
-			}
-		}
-	});
-
-	toggleTokenBtn.addEventListener('click', () => {
-		tokenVisible = !tokenVisible;
-		githubTokenInput.type = tokenVisible ? 'text' : 'password';
-
-		tokenEyeIcon.classList.add('eye-animating');
-		setTimeout(() => tokenEyeIcon.classList.remove('eye-animating'), 400);
-		tokenEyeIcon.className = tokenVisible ? 'fa fa-eye-slash text-gray-600' : 'fa fa-eye text-gray-600';
-
-		githubTokenInput.classList.add('token-animating');
-		setTimeout(() => githubTokenInput.classList.remove('token-animating'), 300);
-	});
-
-	// GitLab token visibility toggle
-	if (toggleGitlabTokenBtn && gitlabTokenInput) {
-		toggleGitlabTokenBtn.addEventListener('click', () => {
-			gitlabTokenVisible = !gitlabTokenVisible;
-			gitlabTokenInput.type = gitlabTokenVisible ? 'text' : 'password';
-
-			gitlabTokenEyeIcon.classList.add('eye-animating');
-			setTimeout(() => gitlabTokenEyeIcon.classList.remove('eye-animating'), 400);
-			gitlabTokenEyeIcon.className = gitlabTokenVisible ? 'fa fa-eye-slash text-gray-600' : 'fa fa-eye text-gray-600';
-
-			gitlabTokenInput.classList.add('token-animating');
-			setTimeout(() => gitlabTokenInput.classList.remove('token-animating'), 300);
-		});
-	}
-
-	githubTokenInput.addEventListener('input', checkTokenForFilter);
-	githubTokenInput.addEventListener('input', () => checkTokenForShowCommits({ persistState: false }));
-	githubTokenInput.addEventListener('input', () => checkTokenForMergedPRs({ persistState: false }));
-
-	darkModeToggle.addEventListener('click', function () {
-		body.classList.toggle('dark-mode');
-		const isDarkMode = body.classList.contains('dark-mode');
-		browser.storage.local.set({ darkMode: isDarkMode });
-		this.src = isDarkMode ? 'icons/light-mode.png' : 'icons/night-mode.png';
-		const settingsIcon = document.getElementById('settingsIcon');
-		if (settingsIcon) {
-			settingsIcon.src = isDarkMode ? 'icons/settings-night.png' : 'icons/settings-light.png';
-		}
-		renderTokenPreview();
-	});
-
-	function renderTokenPreview() {
-		if (!tokenPreview || !githubTokenInput) return;
-		tokenPreview.innerHTML = '';
-		const value = githubTokenInput.value;
-		const isDark = document.body.classList.contains('dark-mode');
-		for (let i = 0; i < value.length; i++) {
-			const charBox = document.createElement('span');
-			charBox.className = 'token-preview-char' + (isDark ? ' dark-mode' : '');
-			if (tokenVisible) {
-				charBox.textContent = value[i];
-			} else {
-				const dot = document.createElement('span');
-				dot.className = 'token-preview-dot' + (isDark ? ' dark-mode' : '');
-				charBox.appendChild(dot);
-			}
-			tokenPreview.appendChild(charBox);
-			setTimeout(() => charBox.classList.add('flip'), 10 + i * 30);
-		}
-	}
-
-	browser.storage.local.remove(['enableToggle']).then(() => {
-		initializePopup();
-		checkTokenForFilter();
-		checkTokenForShowCommits();
-	});
-
-	browser.storage.onChanged.addListener((changes, namespace) => {
-		console.log('[DEBUG] Storage changed:', changes, namespace);
-		if (changes.startingDate || changes.endingDate) {
-			console.log('[POPUP-DEBUG] Date changed in storage, triggering repo fetch.', {
-				startingDate: changes.startingDate?.newValue,
-				endingDate: changes.endingDate?.newValue,
-			});
-			if (window.triggerRepoFetchIfEnabled) {
-				window.triggerRepoFetchIfEnabled();
-			}
-		}
-	});
-
-	function storageLocalGet(keys) {
-		return browser.storage.local.get(keys).catch((err) => {
-			console.error('Storage access failed:', err);
-			return {};
-		});
-	}
-
-	function parsePositiveInt(value) {
-		const n = Number.parseInt(value, 10);
-		return Number.isFinite(n) && n > 0 ? n : null;
-	}
-
-	function setGenerateButtonLoading(generateBtn, isLoading) {
-		if (!generateBtn) return;
-		if (!isLoading) return;
-
-		const msg = browser.i18n.getMessage('generatingButton') || 'Generating...';
-		generateBtn.innerHTML = `<i class="fa fa-spinner fa-spin"></i> ${msg}`;
-		generateBtn.disabled = true;
-	}
-
-	function updateGenerateButtonState() {
-		const generateBtn = document.getElementById('generateReport');
-		const platformUsername = document.getElementById('platformUsername');
-		if (!generateBtn || !platformUsername) {
-			return;
-		}
-
-		const applyGenerateButtonState = () => {
-			const hasUsername = Boolean(platformUsername.value.trim());
-			const shouldDisable = !hasUsername;
-
-			if (generateBtn.disabled !== shouldDisable) {
-				generateBtn.disabled = shouldDisable;
-			}
-		};
-
-		if (!platformUsername.dataset.generateButtonStateBound) {
-			platformUsername.addEventListener('input', applyGenerateButtonState);
-			platformUsername.addEventListener('change', applyGenerateButtonState);
-			platformUsername.dataset.generateButtonStateBound = 'true';
-		}
-
-		if (!generateBtn.dataset.generateButtonStateObserved && typeof MutationObserver !== 'undefined') {
-			const observer = new MutationObserver(() => {
-				const shouldDisable = !platformUsername.value.trim();
-				if (shouldDisable && generateBtn.disabled === false) {
-					generateBtn.disabled = true;
-				}
-			});
-
-			observer.observe(generateBtn, {
-				attributes: true,
-				attributeFilter: ['disabled'],
-			});
-
-			generateBtn.dataset.generateButtonStateObserved = 'true';
-		}
-
-		applyGenerateButtonState();
-	}
-
-	window.updateGenerateButtonState = updateGenerateButtonState;
-
-	async function bootstrapScrumReportOnPopupLoad(generateBtn) {
-		console.log('[BOOTSTRAP] bootstrapScrumReportOnPopupLoad called');
-
-		if (typeof window.generateScrumReport !== 'function') {
-			return;
-		}
-
-		const scrumReport = document.getElementById('scrumReport');
-		if (!scrumReport) {
-			return;
-		}
-
-		const { platform, cacheInput, githubCache, gitlabCache } = await storageLocalGet([
-			'platform',
-			'cacheInput',
-			'githubCache',
-			'gitlabCache',
-		]);
-
-		const ttlMinutes = parsePositiveInt(cacheInput) ?? 10;
-		const ttlMs = ttlMinutes * 60 * 1000;
-
-		const activePlatform = platform || 'github';
-		const cache = activePlatform === 'gitlab' ? gitlabCache : githubCache;
-
-		const hasCacheData = !!cache?.data;
-		const timestamp = typeof cache?.timestamp === 'number' ? cache.timestamp : 0;
-
-		if (!hasCacheData) {
-			setGenerateButtonLoading(generateBtn, true);
-			window.generateScrumReport();
-			return;
-		}
-
-		if (timestamp > 0) {
-			const age = Date.now() - timestamp;
-
-			const storageValues = await storageLocalGet([
-				`${activePlatform}LastScrumReportHtml`,
-				`${activePlatform}LastScrumReportCacheKey`,
-				`${activePlatform}LastScrumReportUsername`,
-				'lastScrumReportHtml',
-				'lastScrumReportPlatform',
-				'lastScrumReportCacheKey',
-				'lastScrumReportUsername',
-				'githubUsername',
-				'gitlabUsername',
-				'platformUsername',
-			]);
-
-			let lastScrumReportHtml = storageValues[`${activePlatform}LastScrumReportHtml`];
-			let lastScrumReportCacheKey = storageValues[`${activePlatform}LastScrumReportCacheKey`];
-			let lastScrumReportUsername = storageValues[`${activePlatform}LastScrumReportUsername`];
-
-			if (
-				storageValues.lastScrumReportHtml &&
-				(!storageValues.lastScrumReportPlatform || storageValues.lastScrumReportPlatform === activePlatform) &&
-				!lastScrumReportHtml
-			) {
-				lastScrumReportHtml = storageValues.lastScrumReportHtml;
-				lastScrumReportCacheKey = storageValues.lastScrumReportCacheKey;
-				lastScrumReportUsername = storageValues.lastScrumReportUsername;
-			}
-
-			const expectedUsername =
-				activePlatform === 'gitlab'
-					? storageValues.gitlabUsername || storageValues.platformUsername
-					: storageValues.githubUsername || storageValues.platformUsername;
-
-			const isUsernameMatch = lastScrumReportUsername
-				? lastScrumReportUsername === expectedUsername
-				: lastScrumReportCacheKey && expectedUsername && lastScrumReportCacheKey.startsWith(expectedUsername + '-');
-
-			if (age < ttlMs) {
-				const cacheKey = cache?.cacheKey ?? null;
-				const reportEmpty = !scrumReport.innerHTML || !scrumReport.innerHTML.trim();
-
-				const matches = (!lastScrumReportCacheKey || lastScrumReportCacheKey === cacheKey) && isUsernameMatch;
-
-				if (reportEmpty && lastScrumReportHtml && matches) {
-					scrumReport.innerHTML = sanitizeHtml(lastScrumReportHtml);
-					if (generateBtn) generateBtn.disabled = false;
-					return;
-				}
-
-				setGenerateButtonLoading(generateBtn, true);
-				window.generateScrumReport();
-				return;
-			}
-
-			// If cache is expired, still only show the old HTML if it was for the current username
-			if ((!scrumReport.innerHTML || !scrumReport.innerHTML.trim()) && lastScrumReportHtml && isUsernameMatch) {
-				scrumReport.innerHTML = sanitizeHtml(lastScrumReportHtml);
-			}
-
-			if (generateBtn) generateBtn.disabled = false;
-			return;
-		}
-
-		setGenerateButtonLoading(generateBtn, true);
-		window.generateScrumReport();
-	}
-
-	function initializePopup() {
-		browser.storage.local.get(['platform', 'platformUsername']).then((result) => {
-			if (result.platformUsername && result.platform) {
-				const platformUsernameKey = `${result.platform}Username`;
-				browser.storage.local.set({ [platformUsernameKey]: result.platformUsername });
-				browser.storage.local.remove(['platformUsername']);
-				console.log(`[MIGRATION] Migrated platformUsername to ${platformUsernameKey}`);
-			}
-		});
-
-		// Restore all persistent fields immediately on DOMContentLoaded
-		const projectNameInput = document.getElementById('projectName');
-		const orgInput = document.getElementById('orgInput');
-		const userReasonInput = document.getElementById('userReason');
-		const showOpenLabelCheckbox = document.getElementById('showOpenLabel');
-		const showCommitsCheckbox = document.getElementById('showCommits');
-		const onlyIssuesCheckbox = document.getElementById('onlyIssues');
-		const onlyPRsCheckbox = document.getElementById('onlyPRs');
-		const onlyRevPRsCheckbox = document.getElementById('onlyRevPRs');
-		const onlyMergedPRsCheckbox = document.getElementById('onlyMergedPRs');
-
-		const githubTokenInput = document.getElementById('githubToken');
-		const cacheInput = document.getElementById('cacheInput');
-		const yesterdayRadio = document.getElementById('yesterdayContribution');
-		const startingDateInput = document.getElementById('startingDate');
-		const endingDateInput = document.getElementById('endingDate');
-		const platformUsername = document.getElementById('platformUsername');
-		const usernameError = document.getElementById('usernameError');
-
-		browser.storage.local
-			.get([
-				'projectName',
-				'orgName',
-				'userReason',
-				'showOpenLabel',
-				'showCommits',
-				'githubToken',
-				'cacheInput',
-				'onlyIssues',
-				'onlyPRs',
-				'onlyRevPRs',
-				'onlyMergedPRs',
-				'yesterdayContribution',
-				'startingDate',
-				'endingDate',
-				'selectedTimeframe',
-				'platform',
-				'githubUsername',
-				'gitlabUsername',
-			])
-			.then((result) => {
-				if (result.projectName) projectNameInput.value = result.projectName;
-				if (result.orgName) orgInput.value = result.orgName;
-				if (result.userReason) userReasonInput.value = result.userReason;
-				if (typeof result.showOpenLabel !== 'undefined') {
-					showOpenLabelCheckbox.checked = result.showOpenLabel;
-				} else {
-					showOpenLabelCheckbox.checked = true; // Default to true for new users
-				}
-				if (typeof result.showCommits !== 'undefined') showCommitsCheckbox.checked = result.showCommits;
-				if (typeof result.onlyIssues !== 'undefined') {
-					onlyIssuesCheckbox.checked = result.onlyIssues;
-				}
-				if (typeof result.onlyPRs !== 'undefined') {
-					onlyPRsCheckbox.checked = result.onlyPRs;
-				}
-				if (typeof result.onlyRevPRs !== 'undefined') {
-					onlyRevPRsCheckbox.checked = result.onlyRevPRs;
-				}
-				if (typeof result.onlyMergedPRs !== 'undefined') {
-					onlyMergedPRsCheckbox.checked = result.onlyMergedPRs;
-				}
-
-				// Reconcile mutually exclusive "Only Issues" and "Only PRs" flags on initialization.
-				// If both are somehow true in storage (e.g., from an older version or manual edits),
-				// prefer "Only Issues" and clear "Only PRs", then persist the corrected state.
-				if (onlyIssuesCheckbox.checked && onlyPRsCheckbox.checked) {
-					onlyPRsCheckbox.checked = false;
-					browser?.storage.local.set({ onlyPRs: false });
-				}
-				if (onlyMergedPRsCheckbox.checked && onlyRevPRsCheckbox.checked) {
-					onlyRevPRsCheckbox.checked = false;
-					browser?.storage.local.set({ onlyRevPRs: false });
-				}
-				// onlyMergedPRs overrides onlyIssues and onlyPRs
-				if (onlyMergedPRsCheckbox.checked && onlyIssuesCheckbox.checked) {
-					onlyIssuesCheckbox.checked = false;
-					browser?.storage.local.set({ onlyIssues: false });
-				}
-				if (onlyMergedPRsCheckbox.checked && onlyPRsCheckbox.checked) {
-					onlyPRsCheckbox.checked = false;
-					browser?.storage.local.set({ onlyPRs: false });
-				}
-				if (result.githubToken) githubTokenInput.value = result.githubToken;
-				if (result.cacheInput) cacheInput.value = result.cacheInput;
-				if (typeof result.yesterdayContribution !== 'undefined') yesterdayRadio.checked = result.yesterdayContribution;
-				if (result.startingDate) startingDateInput.value = result.startingDate;
-				if (result.endingDate) endingDateInput.value = result.endingDate;
-				const wasNormalizedOnLoad = window.scrumDateRangeUtils.normalizeDateRangeValues(
-					startingDateInput,
-					endingDateInput,
-				);
-				if (wasNormalizedOnLoad) {
-					window.scrumDateRangeUtils.persistDateRange(startingDateInput, endingDateInput);
-				}
-
-				// Load platform-specific username
-				const platform = result.platform || 'github';
-				const platformUsernameKey = `${platform}Username`;
-				platformUsername.value = result[platformUsernameKey] || '';
-				window.updateGenerateButtonState && window.updateGenerateButtonState();
-				checkTokenForShowCommits();
-				checkTokenForMergedPRs();
-			});
-
-		// Button setup
-		const generateBtn = document.getElementById('generateReport');
-		const copyBtn = document.getElementById('copyReport');
-		const insertBtn = document.getElementById('insertInEmail');
-
-		if (insertBtn) {
-			insertBtn.addEventListener('click', () => {
-				const scrumReport = document.getElementById('scrumReport');
-				const content = scrumReport ? sanitizeHtml(scrumReport.innerHTML) : '';
-				const subject = buildScrumSubjectFromPopup();
-
-				if (!content) {
-					insertBtn._triggeredByShortcut = false;
-					return;
-				}
-
-				// Helper to handle insert-to-email failures consistently
-				const handleInsertFailure = (errorMsg) => {
-					console.warn('Insert to Email failed:', errorMsg);
-					const failureMessage =
-						browser.i18n.getMessage('insertToEmailFailedError') || 'open an email tab to insert report';
-					showPopupMessage(failureMessage);
-				};
-
-				browser.tabs
-					.query({ active: true, currentWindow: true })
-					.then((tabs) => {
-						const tabId = tabs?.[0]?.id;
-						if (!tabId) {
-							handleInsertFailure('No active tab found');
-							return;
-						}
-
-						browser.tabs
-							.sendMessage(tabId, { action: 'insertReportToEmail', content, subject })
-							.then((response) => {
-								if (!response?.success) {
-									handleInsertFailure(response?.error);
-								} else if (insertBtn._triggeredByShortcut) {
-									showShortcutNotification('insertedInEmailNotification');
-								}
-							})
-							.catch((error) => {
-								handleInsertFailure(error.message);
-							});
-					})
-					.catch((error) => {
-						handleInsertFailure('Failed to query tabs: ' + error.message);
-					})
-					.finally(() => {
-						insertBtn._triggeredByShortcut = false;
-					});
-			});
-		}
-
-		generateBtn.addEventListener('click', () => {
-			browser.storage.local.get(['platform']).then((result) => {
-				platformUsername.classList.remove('input-error');
-				usernameError.classList.remove('errorMessage');
-				usernameError.textContent = '';
-				const platform = result.platform || 'github';
-				const platformUsernameKey = `${platform}Username`;
-
-				browser.storage.local
-					.set({
-						platform: platformSelect.value,
-						[platformUsernameKey]: platformUsername.value,
-					})
-					.then(() => {
-						// Reload platform from storage before generating report
-						browser.storage.local.get(['platform']).then((res) => {
-							platformSelect.value = res.platform || 'github';
-							updatePlatformUI(platformSelect.value);
-							generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
-							generateBtn.disabled = true;
-							window.generateScrumReport && window.generateScrumReport();
-						});
-					});
-			});
-		});
-
-		copyBtn.addEventListener('click', function () {
-			const scrumReport = document.getElementById('scrumReport');
-			const tempDiv = document.createElement('div');
-			tempDiv.innerHTML = sanitizeHtml(scrumReport.innerHTML);
-			document.body.appendChild(tempDiv);
-			tempDiv.style.position = 'absolute';
-			tempDiv.style.left = '-9999px';
-
-			const range = document.createRange();
-			range.selectNode(tempDiv);
-			const selection = window.getSelection();
-			selection.removeAllRanges();
-			selection.addRange(range);
-
-			try {
-				document.execCommand('copy');
-				if (this._triggeredByShortcut) {
-					const notificationKey =
-						browser?.i18n && browser.i18n.getMessage('copiedReportNotification')
-							? 'copiedReportNotification'
-							: 'copiedButton';
-					showShortcutNotification(notificationKey);
-				}
-				this.innerHTML = `<i class="fa fa-check"></i> ${browser?.i18n.getMessage('copiedButton')}`;
-				setTimeout(() => {
-					this.innerHTML = `<i class="fa fa-copy"></i> ${browser.i18n.getMessage('copyReportButton')}`;
-				}, 2000);
-			} catch (err) {
-				console.error('Failed to copy: ', err);
-			} finally {
-				this._triggeredByShortcut = false;
-				selection.removeAllRanges();
-				document.body.removeChild(tempDiv);
-			}
-		});
-
-		// Custom date container click handler
-		document.getElementById('customDateContainer').addEventListener('click', () => {
-			document.querySelectorAll('input[name="timeframe"]').forEach((radio) => {
-				radio.checked = false;
-				radio.dataset.wasChecked = 'false';
-			});
-
-			const startDateInput = document.getElementById('startingDate');
-			const endDateInput = document.getElementById('endingDate');
-			startDateInput.readOnly = false;
-			endDateInput.readOnly = false;
-
-			browser.storage.local.set({
-				yesterdayContribution: false,
-				selectedTimeframe: null,
-			});
-		});
-
-		browser.storage.local
-			.get(['selectedTimeframe', 'yesterdayContribution', 'startingDate', 'endingDate'])
-			.then((items) => {
-				console.log('Restoring state:', items);
-
-				if (items.startingDate && items.endingDate && !items.yesterdayContribution) {
-					const startDateInput = document.getElementById('startingDate');
-					const endDateInput = document.getElementById('endingDate');
-
-					if (startDateInput && endDateInput) {
-						startDateInput.value = items.startingDate;
-						endDateInput.value = items.endingDate;
-						startDateInput.readOnly = false;
-						endDateInput.readOnly = false;
-					}
-					document.querySelectorAll('input[name="timeframe"]').forEach((radio) => {
-						radio.checked = false;
-						radio.dataset.wasChecked = 'false';
-					});
-					return;
-				}
-
-				if (!items.selectedTimeframe) {
-					items.selectedTimeframe = 'yesterdayContribution';
-					items.yesterdayContribution = true;
-				}
-
-				const radio = document.getElementById(items.selectedTimeframe);
-				if (radio) {
-					radio.checked = true;
-					radio.dataset.wasChecked = 'true';
-
-					const startDateInput = document.getElementById('startingDate');
-					const endDateInput = document.getElementById('endingDate');
-
-					if (items.selectedTimeframe === 'yesterdayContribution') {
-						startDateInput.value = getYesterday();
-						endDateInput.value = getToday();
-					}
-					startDateInput.readOnly = endDateInput.readOnly = true;
-
-					browser.storage.local.set({
-						startingDate: startDateInput.value,
-						endingDate: endDateInput.value,
-						yesterdayContribution: items.selectedTimeframe === 'yesterdayContribution',
-						selectedTimeframe: items.selectedTimeframe,
-					});
-				}
-			});
-
-		// Save all fields to storage on input/change
-		projectNameInput.addEventListener('input', () => {
-			browser.storage.local.set({ projectName: projectNameInput.value });
-		});
-
-		// Save to storage and validate ONLY when user clicks out (blur event)
-		orgInput.addEventListener('blur', () => {
-			const org = orgInput.value.trim().toLowerCase();
-			browser.storage.local.set({ orgName: org });
-
-			// Only validate if org name is not empty
-			if (org) {
-				validateOrgOnBlur(org);
-			} else {
-				window.clearScrumHelperToast?.();
-			}
-		});
-		if (userReasonInput) {
-			userReasonInput.addEventListener('input', () => {
-				browser.storage.local.set({ userReason: userReasonInput.value });
-			});
-		}
-		showOpenLabelCheckbox.addEventListener('change', () => {
-			browser.storage.local.set({ showOpenLabel: showOpenLabelCheckbox.checked });
-		});
-		if (onlyIssuesCheckbox && onlyPRsCheckbox) {
-			onlyIssuesCheckbox.addEventListener('change', () => {
-				const checked = onlyIssuesCheckbox.checked;
-				browser?.storage.local.set({ onlyIssues: checked }, () => {
-					if (checked) {
-						if (onlyPRsCheckbox.checked) {
-							onlyPRsCheckbox.checked = false;
-							browser?.storage.local.set({ onlyPRs: false });
-						}
-						if (onlyMergedPRsCheckbox && onlyMergedPRsCheckbox.checked) {
-							onlyMergedPRsCheckbox.checked = false;
-							browser?.storage.local.set({ onlyMergedPRs: false });
-						}
-					}
-				});
-			});
-
-			onlyPRsCheckbox.addEventListener('change', () => {
-				const checked = onlyPRsCheckbox.checked;
-				browser?.storage.local.set({ onlyPRs: checked }, () => {
-					if (checked) {
-						if (onlyIssuesCheckbox.checked) {
-							onlyIssuesCheckbox.checked = false;
-							browser?.storage.local.set({ onlyIssues: false });
-						}
-						if (onlyMergedPRsCheckbox && onlyMergedPRsCheckbox.checked) {
-							onlyMergedPRsCheckbox.checked = false;
-							browser?.storage.local.set({ onlyMergedPRs: false });
-						}
-					}
-				});
-			});
-
-			if (onlyRevPRsCheckbox) {
-				onlyRevPRsCheckbox.addEventListener('change', () => {
-					const checked = onlyRevPRsCheckbox.checked;
-					browser?.storage.local.set({ onlyRevPRs: checked }, () => {
-						if (checked && onlyMergedPRsCheckbox && onlyMergedPRsCheckbox.checked) {
-							onlyMergedPRsCheckbox.checked = false;
-							browser?.storage.local.set({ onlyMergedPRs: false });
-						}
-					});
-				});
-			}
-			if (onlyMergedPRsCheckbox) {
-				onlyMergedPRsCheckbox.addEventListener('change', () => {
-					if (onlyMergedPRsCheckbox.checked) {
-						if (onlyRevPRsCheckbox && onlyRevPRsCheckbox.checked) {
-							onlyRevPRsCheckbox.checked = false;
-							browser?.storage.local.set({ onlyRevPRs: false });
-						}
-						if (onlyIssuesCheckbox && onlyIssuesCheckbox.checked) {
-							onlyIssuesCheckbox.checked = false;
-							browser?.storage.local.set({ onlyIssues: false });
-						}
-						if (onlyPRsCheckbox && onlyPRsCheckbox.checked) {
-							onlyPRsCheckbox.checked = false;
-							browser?.storage.local.set({ onlyPRs: false });
-						}
-					}
-					checkTokenForMergedPRs({
-						showWarning: true,
-						animateWarning: true,
-						warningDurationMs: 3000,
-						persistState: true,
-					});
-				});
-			}
-		}
-		showCommitsCheckbox.addEventListener('change', () => {
-			checkTokenForShowCommits({
-				showWarning: true,
-				animateWarning: true,
-				warningDurationMs: 3000,
-				persistState: true,
-			});
-		});
-		githubTokenInput.addEventListener('input', () => {
-			browser.storage.local.set({ githubToken: githubTokenInput.value });
-		});
-		cacheInput.addEventListener('input', () => {
-			browser.storage.local.set({ cacheInput: cacheInput.value });
-		});
-
-		// Display mode (popup / sidepanel)
-		// Apply the stored display mode class on next launch
-		function applyDisplayModeClass(mode) {
-			// If opened via Firefox sidebar_action, force sidepanel mode
-			if (window.location.search.includes('view=sidebar')) {
-				mode = 'sidepanel';
-				document.documentElement.classList.add('firefox-sidebar');
-				document.body.classList.add('firefox-sidebar');
-			}
-
-			const className = mode === 'popup' ? 'mode-popup' : 'mode-sidepanel';
-			if (!document.documentElement.classList.contains(className)) {
-				document.documentElement.classList.remove('mode-popup', 'mode-sidepanel');
-				body.classList.remove('mode-popup', 'mode-sidepanel');
-				document.documentElement.classList.add(className);
-				body.classList.add(className);
-			}
-		}
-
-		browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
-			applyDisplayModeClass(result.displayMode);
-		});
-
-		const displayModeSelect = document.getElementById('displayModeSelect');
-		const displayModeNotice = document.getElementById('displayModeNotice');
-		const displayModeNoticeText = document.getElementById('displayModeNoticeText');
-		if (displayModeSelect) {
-			browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
-				displayModeSelect.value = result.displayMode;
-			});
-			displayModeSelect.addEventListener('change', () => {
-				const mode = displayModeSelect.value;
-				browser.storage.local.set({ displayMode: mode });
-				// Show notice instead of applying immediately
-				const modeLabel = mode === 'popup' ? 'Popup' : 'Side Panel';
-				if (displayModeNotice && displayModeNoticeText) {
-					displayModeNoticeText.textContent =
-						chrome?.i18n.getMessage('displayModeNotice', [modeLabel]) ||
-						`The extension will open in ${modeLabel} mode on the next launch.`;
-					displayModeNotice.classList.remove('hidden');
-				}
-			});
-		}
-
-		yesterdayRadio.addEventListener('change', () => {
-			browser.storage.local.set({ yesterdayContribution: yesterdayRadio.checked });
-		});
-		startingDateInput.addEventListener('input', () => {
-			window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(startingDateInput, endingDateInput);
-		});
-		endingDateInput.addEventListener('input', () => {
-			window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(startingDateInput, endingDateInput);
-		});
-
-		// Save username to storage on input and update button state
-		platformUsername.addEventListener('input', () => {
-			browser.storage.local.get(['platform']).then((result) => {
-				const platform = result.platform || 'github';
-				const platformUsernameKey = `${platform}Username`;
-				browser.storage.local.set({ [platformUsernameKey]: platformUsername.value });
-			});
-			window.updateGenerateButtonState && window.updateGenerateButtonState();
-		});
-		// Bootstrap report on popup open (restore cache / auto-generate / expired-cache toast)
-		bootstrapScrumReportOnPopupLoad(generateBtn).catch((err) => {
-			console.error('[POPUP] bootstrapScrumReportOnPopupLoad failed', err);
-		});
-	}
-
-	function showReportView() {
-		isSettingsVisible = false;
-		reportSection.classList.remove('hidden');
-		settingsSection.classList.add('hidden');
-		settingsToggle.classList.remove('active');
-	}
-
-	function showSettingsView() {
-		isSettingsVisible = true;
-		reportSection.classList.add('hidden');
-		settingsSection.classList.remove('hidden');
-		settingsToggle.classList.add('active');
-	}
-
-	if (settingsToggle) {
-		settingsToggle.addEventListener('click', () => {
-			if (isSettingsVisible) {
-				showReportView();
-			} else {
-				showSettingsView();
-			}
-		});
-	}
-
-	if (homeButton) {
-		homeButton.addEventListener('click', showReportView);
-	}
-	if (scrumHelperHeading) {
-		scrumHelperHeading.addEventListener('click', showReportView);
-	}
-
-	showReportView();
-
-	//report filter
-	const repoSearch = document.getElementById('repoSearch');
-	const repoDropdown = document.getElementById('repoDropdown');
-	const selectedReposDiv = document.getElementById('selectedRepos');
-	const repoTags = document.getElementById('repoTags');
-	const repoPlaceholder = document.getElementById('repoPlaceholder');
-	const repoCount = document.getElementById('repoCount');
-	const repoStatus = document.getElementById('repoStatus');
-	const useRepoFilter = document.getElementById('useRepoFilter');
-	const repoFilterContainer = document.getElementById('repoFilterContainer');
-
-	if (repoSearch && useRepoFilter && repoFilterContainer) {
-		repoSearch.addEventListener('click', () => {
-			if (!useRepoFilter.checked) {
-				useRepoFilter.checked = true;
-				repoFilterContainer.classList.remove('hidden');
-				browser.storage.local.set({ useRepoFilter: true });
-			}
-		});
-	}
-
-	if (!repoSearch || !useRepoFilter) {
-		console.log('Repository, filter elements not found in DOM');
-	} else {
-		let availableRepos = [];
-		let selectedRepos = [];
-		let highlightedIndex = -1;
-
-		async function triggerRepoFetchIfEnabled() {
-			// --- PLATFORM CHECK: Only run for GitHub ---
-			let platform = 'github';
-			try {
-				const items = await browser.storage.local.get(['platform']);
-				platform = items.platform || 'github';
-			} catch {}
-			if (platform !== 'github') {
-				// Do not run repo fetch for non-GitHub platforms
-				if (repoStatus)
-					repoStatus.textContent =
-						chrome?.i18n.getMessage('repoFilteringGithubOnly') || 'Repository filtering is only available for GitHub.';
-				return;
-			}
-			if (!useRepoFilter.checked) {
-				return;
-			}
-
-			if (repoStatus) {
-				repoStatus.textContent = browser.i18n.getMessage('repoRefetching');
-			}
-
-			try {
-				const cacheData = await browser.storage.local.get(['repoCache']);
-				const items = await browser.storage.local.get([
-					'platform',
-					'githubUsername',
-					'gitlabUsername',
-					'githubToken',
-					'orgName',
-				]);
-
-				const platform = items.platform || 'github';
-				const platformUsernameKey = `${platform}Username`;
-				const username = items[platformUsernameKey];
-
-				if (!username) {
-					if (repoStatus) {
-						repoStatus.textContent = chrome?.i18n.getMessage('usernameMissingError') || 'Username required';
-					}
-					return;
-				}
-
-				if (window.fetchUserRepositories) {
-					const repos = await window.fetchUserRepositories(username, items.githubToken, items.orgName || '');
-
-					availableRepos = repos;
-
-					if (repoStatus) {
-						repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [repos.length]);
-					}
-
-					const repoCacheKey = `repos-${username}-${items.orgName || ''}`;
-					browser.storage.local.set({
-						repoCache: {
-							data: repos,
-							cacheKey: repoCacheKey,
-							timestamp: Date.now(),
-						},
-					});
-
-					if (document.activeElement === repoSearch) {
-						filterAndDisplayRepos(repoSearch.value.toLowerCase());
-					} else if (repoSearch.value) {
-						filterAndDisplayRepos(repoSearch.value.toLowerCase());
-					} else {
-						filterAndDisplayRepos('');
-					}
-				}
-			} catch (err) {
-				if (repoStatus) {
-					repoStatus.textContent = `${browser.i18n.getMessage('errorLabel')}: ${err.message || browser.i18n.getMessage('repoRefetchFailed')}`;
-				}
-			}
-		}
-
-		window.triggerRepoFetchIfEnabled = triggerRepoFetchIfEnabled;
-
-		browser.storage.local.get(['selectedRepos', 'useRepoFilter']).then((items) => {
-			if (items.selectedRepos) {
-				selectedRepos = items.selectedRepos;
-				updateRepoDisplay();
-			}
-			if (items.useRepoFilter) {
-				useRepoFilter.checked = items.useRepoFilter;
-				repoFilterContainer.classList.toggle('hidden', !items.useRepoFilter);
-			}
-		});
-
-		useRepoFilter.addEventListener(
-			'change',
-			debounce(async () => {
-				let platform = 'github';
-				try {
-					const items = await browser.storage.local.get(['platform']);
-					platform = items.platform || 'github';
-				} catch {}
-				if (platform !== 'github') {
-					repoFilterContainer.classList.add('hidden');
-					useRepoFilter.checked = false;
-					if (repoStatus)
-						repoStatus.textContent =
-							chrome?.i18n.getMessage('repoFilteringGithubOnly') ||
-							'Repository filtering is only available for GitHub.';
-					return;
-				}
-				const enabled = useRepoFilter.checked;
-				const hasToken = githubTokenInput.value.trim() !== '';
-				repoFilterContainer.classList.toggle('hidden', !enabled);
-
-				if (enabled && !hasToken) {
-					useRepoFilter.checked = false;
-					repoFilterContainer.classList.add('hidden'); // hide the container
-					hideDropdown();
-					const tokenWarning = document.getElementById('tokenWarningForFilter');
-					if (tokenWarning) {
-						tokenWarning.classList.remove('hidden');
-						tokenWarning.classList.add('shake-animation');
-						setTimeout(() => tokenWarning.classList.remove('shake-animation'), 620);
-						setTimeout(() => {
-							tokenWarning.classList.add('hidden');
-						}, 3000);
-					}
-					return;
-				}
-				repoFilterContainer.classList.toggle('hidden', !enabled);
-
-				browser.storage.local.set({
-					useRepoFilter: enabled,
-					githubCache: null, //forces refresh
-				});
-				checkTokenForFilter();
-				if (enabled) {
-					repoStatus.textContent =
-						chrome?.i18n.getMessage('loadingReposAutomatically') || 'Loading repos automatically...';
-
-					try {
-						const cacheData = await browser.storage.local.get(['repoCache']);
-						const items = await browser.storage.local.get([
-							'platform',
-							'githubUsername',
-							'gitlabUsername',
-							'githubToken',
-							'orgName',
-						]);
-
-						const platform = items.platform || 'github';
-						const platformUsernameKey = `${platform}Username`;
-						const username = items[platformUsernameKey];
-
-						if (!username) {
-							repoStatus.textContent = chrome?.i18n.getMessage('usernameMissingError') || 'Username required';
-							return;
-						}
-
-						const repoCacheKey = `repos-${username}-${items.orgName || ''}`;
-
-						const now = Date.now();
-						const cacheAge = cacheData.repoCache?.timestamp
-							? now - cacheData.repoCache.timestamp
-							: Number.POSITIVE_INFINITY;
-						const cacheTTL = 10 * 60 * 1000; // 10 minutes
-
-						if (cacheData.repoCache && cacheData.repoCache.cacheKey === repoCacheKey && cacheAge < cacheTTL) {
-							console.log('Using cached repositories');
-							availableRepos = cacheData.repoCache.data;
-							repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [availableRepos.length]);
-
-							if (document.activeElement === repoSearch) {
-								filterAndDisplayRepos(repoSearch.value.toLowerCase());
-							}
-							return;
-						}
-
-						if (window.fetchUserRepositories) {
-							const repos = await window.fetchUserRepositories(
-								username,
-
-								items.githubToken,
-								items.orgName || '',
-							);
-							availableRepos = repos;
-							repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [repos.length]);
-
-							browser.storage.local.set({
-								repoCache: {
-									data: repos,
-									cacheKey: repoCacheKey,
-									timestamp: now,
-								},
-							});
-
-							if (document.activeElement === repoSearch) {
-								filterAndDisplayRepos(repoSearch.value.toLowerCase());
-							}
-						}
-					} catch (err) {
-						console.error('Auto load repos failed', err);
-
-						if (err.message?.includes('401')) {
-							repoStatus.textContent = browser.i18n.getMessage('repoTokenPrivate');
-						} else if (err.message?.includes('username')) {
-							repoStatus.textContent = browser.i18n.getMessage('githubUsernamePlaceholder');
-						} else {
-							repoStatus.textContent = `${browser.i18n.getMessage('errorLabel')}: ${err.message || browser.i18n.getMessage('repoLoadFailed')}`;
-						}
-					}
-				} else {
-					selectedRepos = [];
-					updateRepoDisplay();
-					browser.storage.local.set({ selectedRepos: [] });
-					repoStatus.textContent = '';
-				}
-			}, 300),
-		);
-
-		repoSearch.addEventListener('keydown', (e) => {
-			const items = repoDropdown.querySelectorAll('.repository-dropdown-item');
-
-			switch (e.key) {
-				case 'ArrowDown':
-					e.preventDefault();
-					highlightedIndex = Math.min(highlightedIndex + 1, items.length - 1);
-					updateHighlight(items);
-					break;
-				case 'ArrowUp':
-					e.preventDefault();
-					highlightedIndex = Math.max(highlightedIndex - 1, 0);
-					updateHighlight(items);
-					break;
-				case 'Enter':
-					e.preventDefault();
-					if (highlightedIndex >= 0 && items[highlightedIndex]) {
-						fnSelectedRepos(items[highlightedIndex].dataset.repoName);
-					}
-					break;
-				case 'Escape':
-					hideDropdown();
-					break;
-			}
-		});
-
-		repoSearch.addEventListener('input', (e) => {
-			const query = e.target.value.toLowerCase();
-			filterAndDisplayRepos(query);
-		});
-		let programmaticFocus = false;
-		repoSearch.addEventListener('focus', () => {
-			if (programmaticFocus) {
-				programmaticFocus = false;
-				return;
-			}
-			const searchTerm = repoSearch.value.toLowerCase();
-			filterAndDisplayRepos(searchTerm);
-		});
-
-		document.addEventListener('click', (e) => {
-			if (!e.target.closest('#repoSearch') && !e.target.closest('#repoDropdown')) {
-				hideDropdown();
-			}
-		});
-
-		function debugRepoFetch() {
-			browser.storage.local.get(['platform', 'githubUsername', 'githubToken', 'orgName']).then((items) => {
-				const platform = items.platform || 'github';
-				const platformUsernameKey = `${platform}Username`;
-				const username = items[platformUsernameKey];
-				console.log('Current settings:', {
-					username: username,
-					hasToken: !!items.githubToken,
-					org: items.orgName || '',
-				});
-			});
-		}
-		debugRepoFetch();
-		async function loadRepos() {
-			// --- PLATFORM CHECK: Only run for GitHub ---
-			let platform = 'github';
-			try {
-				const items = await browser.storage.local.get(['platform']);
-				platform = items.platform || 'github';
-			} catch {}
-			if (platform !== 'github') {
-				if (repoStatus)
-					repoStatus.textContent =
-						chrome?.i18n.getMessage('repoLoadingGithubOnly') || 'Repository loading is only available for GitHub.';
-				return;
-			}
-			console.log('window.fetchUserRepositories exists:', !!window.fetchUserRepositories);
-			console.log(
-				'Available functions:',
-				Object.keys(window).filter((key) => key.includes('fetch')),
-			);
-
-			if (!window.fetchUserRepositories) {
-				repoStatus.textContent = 'Repository fetching not available';
-				return;
-			}
-
-			browser.storage.local.get(['platform', 'githubUsername', 'githubToken']).then((items) => {
-				const platform = items.platform || 'github';
-				const platformUsernameKey = `${platform}Username`;
-				const username = items[platformUsernameKey];
-				console.log('Storage data for repo fetch:', {
-					hasUsername: !!username,
-					hasToken: !!items.githubToken,
-					username: username,
-				});
-
-				if (!username) {
-					repoStatus.textContent = chrome?.i18n.getMessage('usernameMissingError') || 'Username required';
-					return;
-				}
-
-				performRepoFetch();
-			});
-		}
-
-		async function performRepoFetch() {
-			let platform = 'github';
-			try {
-				const items = await browser.storage.local.get(['platform']);
-				platform = items.platform || 'github';
-			} catch (e) {}
-			if (platform !== 'github') {
-				if (repoStatus)
-					repoStatus.textContent =
-						chrome?.i18n.getMessage('repoFetchingGithubOnly') || 'Repository fetching is only available for GitHub.';
-				return;
-			}
-			console.log('[POPUP-DEBUG] performRepoFetch called.');
-			repoStatus.textContent = browser.i18n.getMessage('repoLoading');
-			repoSearch.classList.add('repository-search-loading');
-
-			try {
-				const cacheData = await browser.storage.local.get(['repoCache']);
-				const storageItems = await browser.storage.local.get([
-					'platform',
-					'githubUsername',
-					'gitlabUsername',
-					'githubToken',
-					'orgName',
-				]);
-				const platform = storageItems.platform || 'github';
-				const platformUsernameKey = `${platform}Username`;
-				const username = storageItems[platformUsernameKey];
-				const repoCacheKey = `repos-${username}-${storageItems.orgName || ''}`;
-				const now = Date.now();
-				const cacheAge = cacheData.repoCache?.timestamp
-					? now - cacheData.repoCache.timestamp
-					: Number.POSITIVE_INFINITY;
-				const cacheTTL = 10 * 60 * 1000; // 10 minutes
-
-				console.log('[POPUP-DEBUG] Repo cache check:', {
-					key: repoCacheKey,
-					cacheKeyInCache: cacheData.repoCache?.cacheKey,
-					isMatch: cacheData.repoCache?.cacheKey === repoCacheKey,
-					age: cacheAge,
-					isFresh: cacheAge < cacheTTL,
-				});
-
-				if (cacheData.repoCache && cacheData.repoCache.cacheKey === repoCacheKey && cacheAge < cacheTTL) {
-					console.log('[POPUP-DEBUG] Using cached repositories in manual fetch');
-					availableRepos = cacheData.repoCache.data;
-					repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [availableRepos.length]);
-
-					if (document.activeElement === repoSearch) {
-						filterAndDisplayRepos(repoSearch.value.toLowerCase());
-					}
-					return;
-				}
-				console.log('[POPUP-DEBUG] No valid cache. Fetching from network.');
-				availableRepos = await window.fetchUserRepositories(
-					username,
-
-					storageItems.githubToken,
-					storageItems.orgName || '',
-				);
-				repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [availableRepos.length]);
-				console.log(`[POPUP-DEBUG] Fetched and loaded ${availableRepos.length} repos.`);
-
-				browser.storage.local.set({
-					repoCache: {
-						data: availableRepos,
-						cacheKey: repoCacheKey,
-						timestamp: now,
-					},
-				});
-
-				if (document.activeElement === repoSearch) {
-					filterAndDisplayRepos(repoSearch.value.toLowerCase());
-				}
-			} catch (err) {
-				console.error(`Failed to load repos:`, err);
-
-				if (err.message && err.message.includes('401')) {
-					repoStatus.textContent = browser.i18n.getMessage('repoTokenPrivate');
-				} else if (err.message && err.message.includes('username')) {
-					repoStatus.textContent = browser.i18n.getMessage('githubUsernamePlaceholder');
-				} else {
-					repoStatus.textContent = `${browser.i18n.getMessage('errorLabel')}: ${err.message || browser.i18n.getMessage('repoLoadFailed')}`;
-				}
-			} finally {
-				repoSearch.classList.remove('repository-search-loading');
-			}
-		}
-
-		function filterAndDisplayRepos(query) {
-			if (availableRepos.length === 0) {
-				repoDropdown.innerHTML = `<div class="p-3 text-center text-gray-500 text-sm">${browser.i18n.getMessage('repoLoading')}</div>`;
-				showDropdown();
-				return;
-			}
-
-			const filtered = availableRepos.filter((repo) => {
-				if (selectedRepos.includes(repo.fullName)) {
-					return false;
-				}
-				if (!query) {
-					return true;
-				}
-				return repo.name.toLowerCase().includes(query) || repo.description?.toLowerCase().includes(query);
-			});
-
-			if (filtered.length === 0) {
-				repoDropdown.innerHTML = `<div class="p-3 text-center text-gray-500 text-sm" style="padding-left: 10px; ">${browser.i18n.getMessage('repoNotFound')}</div>`;
-			} else {
-				repoDropdown.innerHTML = sanitizeHtml(
-					filtered
-						.slice(0, 10)
-						.map(
-							(repo) => `
+document.addEventListener("DOMContentLoaded", () => {
+  // Apply translations as soon as the DOM is ready
+  applyI18n();
+  setupButtonTooltips();
+
+  // Dark mode setup
+  const darkModeToggle = document.querySelector('img[alt="Night Mode"]');
+  const settingsIcon = document.getElementById("settingsIcon");
+  const body = document.body;
+  const homeButton = document.getElementById("homeButton");
+  const scrumHelperHeading = document.getElementById("scrumHelperHeading");
+  const settingsToggle = document.getElementById("settingsToggle");
+  const reportSection = document.getElementById("reportSection");
+  const settingsSection = document.getElementById("settingsSection");
+
+  let isSettingsVisible = false;
+  const githubTokenInput = document.getElementById("githubToken");
+  const toggleTokenBtn = document.getElementById("toggleTokenVisibility");
+  const tokenEyeIcon = document.getElementById("tokenEyeIcon");
+  const tokenPreview = document.getElementById("tokenPreview");
+  let tokenVisible = false;
+
+  // GitLab token elements
+  const gitlabTokenInput = document.getElementById("gitlabToken");
+  const toggleGitlabTokenBtn = document.getElementById(
+    "toggleGitlabTokenVisibility",
+  );
+  const gitlabTokenEyeIcon = document.getElementById("gitlabTokenEyeIcon");
+  let gitlabTokenVisible = false;
+
+  const orgInput = document.getElementById("orgInput");
+
+  const platformSelect = document.getElementById("platformSelect");
+  const usernameLabel = document.getElementById("usernameLabel");
+  const platformUsername = document.getElementById("platformUsername");
+  let showCommitsWarningTimeout;
+  let mergedPRsWarningTimeout;
+
+  function checkTokenForFilter() {
+    const useRepoFilter = document.getElementById("useRepoFilter");
+    const githubTokenInput = document.getElementById("githubToken");
+    const tokenWarning = document.getElementById("tokenWarningForFilter");
+    const repoFilterContainer = document.getElementById("repoFilterContainer");
+
+    if (
+      !useRepoFilter ||
+      !githubTokenInput ||
+      !tokenWarning ||
+      !repoFilterContainer
+    ) {
+      return;
+    }
+    const isFilterEnabled = useRepoFilter.checked;
+    const hasToken = githubTokenInput.value.trim() !== "";
+
+    if (isFilterEnabled && !hasToken) {
+      useRepoFilter.checked = false;
+      repoFilterContainer.classList.add("hidden");
+      if (typeof hideDropdown === "function") {
+        hideDropdown();
+      }
+      browser.storage.local.set({ useRepoFilter: false });
+    }
+    tokenWarning.classList.toggle("hidden", !isFilterEnabled || hasToken);
+    setTimeout(() => {
+      tokenWarning.classList.add("hidden");
+    }, 4000);
+  }
+
+  function showTokenWarningForMergedPRs({
+    animate = false,
+    durationMs = 4000,
+  } = {}) {
+    const tokenWarning = document.getElementById("tokenWarningForMergedPRs");
+    if (!tokenWarning) {
+      return;
+    }
+
+    tokenWarning.classList.remove("hidden");
+    if (animate) {
+      tokenWarning.classList.add("shake-animation");
+      setTimeout(() => tokenWarning.classList.remove("shake-animation"), 620);
+    }
+
+    if (mergedPRsWarningTimeout) {
+      clearTimeout(mergedPRsWarningTimeout);
+    }
+    mergedPRsWarningTimeout = setTimeout(() => {
+      tokenWarning.classList.add("hidden");
+    }, durationMs);
+  }
+
+  function checkTokenForMergedPRs({
+    showWarning = false,
+    animateWarning = false,
+    warningDurationMs = 4000,
+    persistState = false,
+  } = {}) {
+    const mergedPRsCheckbox = document.getElementById("onlyMergedPRs");
+    const githubTokenInput = document.getElementById("githubToken");
+
+    if (!mergedPRsCheckbox || !githubTokenInput) {
+      return;
+    }
+
+    const isMergedPRsEnabled = mergedPRsCheckbox.checked;
+    const hasToken = githubTokenInput.value.trim() !== "";
+
+    if (isMergedPRsEnabled && !hasToken) {
+      mergedPRsCheckbox.checked = false;
+      if (showWarning) {
+        showTokenWarningForMergedPRs({
+          animate: animateWarning,
+          durationMs: warningDurationMs,
+        });
+      }
+      chrome?.storage.local.set({ onlyMergedPRs: false });
+      return;
+    }
+
+    const tokenWarning = document.getElementById("tokenWarningForMergedPRs");
+    if (tokenWarning) {
+      if (mergedPRsWarningTimeout) {
+        clearTimeout(mergedPRsWarningTimeout);
+        mergedPRsWarningTimeout = null;
+      }
+      tokenWarning.classList.add("hidden");
+    }
+    if (persistState) {
+      chrome?.storage.local.set({ onlyMergedPRs: mergedPRsCheckbox.checked });
+    }
+  }
+
+  function showTokenWarningForShowCommits({
+    animate = false,
+    durationMs = 4000,
+  } = {}) {
+    const tokenWarning = document.getElementById("tokenWarningForShowCommits");
+    if (!tokenWarning) {
+      return;
+    }
+
+    tokenWarning.classList.remove("hidden");
+    if (animate) {
+      tokenWarning.classList.add("shake-animation");
+      setTimeout(() => tokenWarning.classList.remove("shake-animation"), 620);
+    }
+
+    if (showCommitsWarningTimeout) {
+      clearTimeout(showCommitsWarningTimeout);
+    }
+    showCommitsWarningTimeout = setTimeout(() => {
+      tokenWarning.classList.add("hidden");
+    }, durationMs);
+  }
+
+  function checkTokenForShowCommits({
+    showWarning = false,
+    animateWarning = false,
+    warningDurationMs = 4000,
+    persistState = false,
+  } = {}) {
+    const showCommits = document.getElementById("showCommits");
+    const githubTokenInput = document.getElementById("githubToken");
+
+    if (!showCommits || !githubTokenInput) {
+      return;
+    }
+
+    const isShowCommitsEnabled = showCommits.checked;
+    const hasToken = githubTokenInput.value.trim() !== "";
+
+    if (isShowCommitsEnabled && !hasToken) {
+      showCommits.checked = false;
+      if (showWarning) {
+        showTokenWarningForShowCommits({
+          animate: animateWarning,
+          durationMs: warningDurationMs,
+        });
+      }
+      // Always persist correction of invalid state
+      browser.storage.local.set({ showCommits: false });
+      return;
+    }
+
+    const tokenWarning = document.getElementById("tokenWarningForShowCommits");
+    if (tokenWarning) {
+      if (showCommitsWarningTimeout) {
+        clearTimeout(showCommitsWarningTimeout);
+        showCommitsWarningTimeout = null;
+      }
+      tokenWarning.classList.add("hidden");
+    }
+    if (persistState) {
+      browser.storage.local.set({ showCommits: showCommits.checked });
+    }
+  }
+
+  browser.storage.local.get(["darkMode"]).then((result) => {
+    if (result.darkMode) {
+      body.classList.add("dark-mode");
+      darkModeToggle.src = "icons/light-mode.png";
+      if (settingsIcon) {
+        settingsIcon.src = "icons/settings-night.png";
+      }
+    }
+  });
+
+  toggleTokenBtn.addEventListener("click", () => {
+    tokenVisible = !tokenVisible;
+    githubTokenInput.type = tokenVisible ? "text" : "password";
+
+    tokenEyeIcon.classList.add("eye-animating");
+    setTimeout(() => tokenEyeIcon.classList.remove("eye-animating"), 400);
+    tokenEyeIcon.className = tokenVisible
+      ? "fa fa-eye-slash text-gray-600"
+      : "fa fa-eye text-gray-600";
+
+    githubTokenInput.classList.add("token-animating");
+    setTimeout(() => githubTokenInput.classList.remove("token-animating"), 300);
+  });
+
+  // GitLab token visibility toggle
+  if (toggleGitlabTokenBtn && gitlabTokenInput) {
+    toggleGitlabTokenBtn.addEventListener("click", () => {
+      gitlabTokenVisible = !gitlabTokenVisible;
+      gitlabTokenInput.type = gitlabTokenVisible ? "text" : "password";
+
+      gitlabTokenEyeIcon.classList.add("eye-animating");
+      setTimeout(
+        () => gitlabTokenEyeIcon.classList.remove("eye-animating"),
+        400,
+      );
+      gitlabTokenEyeIcon.className = gitlabTokenVisible
+        ? "fa fa-eye-slash text-gray-600"
+        : "fa fa-eye text-gray-600";
+
+      gitlabTokenInput.classList.add("token-animating");
+      setTimeout(
+        () => gitlabTokenInput.classList.remove("token-animating"),
+        300,
+      );
+    });
+  }
+
+  githubTokenInput.addEventListener("input", checkTokenForFilter);
+  githubTokenInput.addEventListener("input", () =>
+    checkTokenForShowCommits({ persistState: false }),
+  );
+  githubTokenInput.addEventListener("input", () =>
+    checkTokenForMergedPRs({ persistState: false }),
+  );
+
+  darkModeToggle.addEventListener("click", function () {
+    body.classList.toggle("dark-mode");
+    const isDarkMode = body.classList.contains("dark-mode");
+    browser.storage.local.set({ darkMode: isDarkMode });
+    this.src = isDarkMode ? "icons/light-mode.png" : "icons/night-mode.png";
+    const settingsIcon = document.getElementById("settingsIcon");
+    if (settingsIcon) {
+      settingsIcon.src = isDarkMode
+        ? "icons/settings-night.png"
+        : "icons/settings-light.png";
+    }
+    renderTokenPreview();
+  });
+
+  function renderTokenPreview() {
+    if (!tokenPreview || !githubTokenInput) return;
+    tokenPreview.innerHTML = "";
+    const value = githubTokenInput.value;
+    const isDark = document.body.classList.contains("dark-mode");
+    for (let i = 0; i < value.length; i++) {
+      const charBox = document.createElement("span");
+      charBox.className = "token-preview-char" + (isDark ? " dark-mode" : "");
+      if (tokenVisible) {
+        charBox.textContent = value[i];
+      } else {
+        const dot = document.createElement("span");
+        dot.className = "token-preview-dot" + (isDark ? " dark-mode" : "");
+        charBox.appendChild(dot);
+      }
+      tokenPreview.appendChild(charBox);
+      setTimeout(() => charBox.classList.add("flip"), 10 + i * 30);
+    }
+  }
+
+  browser.storage.local.remove(["enableToggle"]).then(() => {
+    initializePopup();
+    checkTokenForFilter();
+    checkTokenForShowCommits();
+  });
+
+  browser.storage.onChanged.addListener((changes, namespace) => {
+    console.log("[DEBUG] Storage changed:", changes, namespace);
+    if (changes.startingDate || changes.endingDate) {
+      console.log(
+        "[POPUP-DEBUG] Date changed in storage, triggering repo fetch.",
+        {
+          startingDate: changes.startingDate?.newValue,
+          endingDate: changes.endingDate?.newValue,
+        },
+      );
+      if (window.triggerRepoFetchIfEnabled) {
+        window.triggerRepoFetchIfEnabled();
+      }
+    }
+  });
+
+  function storageLocalGet(keys) {
+    return browser.storage.local.get(keys).catch((err) => {
+      console.error("Storage access failed:", err);
+      return {};
+    });
+  }
+
+  function parsePositiveInt(value) {
+    const n = Number.parseInt(value, 10);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  }
+
+  function setGenerateButtonLoading(generateBtn, isLoading) {
+    if (!generateBtn) return;
+    if (!isLoading) return;
+
+    const msg = browser.i18n.getMessage("generatingButton") || "Generating...";
+    generateBtn.innerHTML = `<i class="fa fa-spinner fa-spin"></i> ${msg}`;
+    generateBtn.disabled = true;
+  }
+
+  function updateGenerateButtonState() {
+    const generateBtn = document.getElementById("generateReport");
+    const platformUsername = document.getElementById("platformUsername");
+    if (!generateBtn || !platformUsername) {
+      return;
+    }
+
+    const applyGenerateButtonState = () => {
+      const hasUsername = Boolean(platformUsername.value.trim());
+      const shouldDisable = !hasUsername;
+
+      if (generateBtn.disabled !== shouldDisable) {
+        generateBtn.disabled = shouldDisable;
+      }
+    };
+
+    if (!platformUsername.dataset.generateButtonStateBound) {
+      platformUsername.addEventListener("input", applyGenerateButtonState);
+      platformUsername.addEventListener("change", applyGenerateButtonState);
+      platformUsername.dataset.generateButtonStateBound = "true";
+    }
+
+    if (
+      !generateBtn.dataset.generateButtonStateObserved &&
+      typeof MutationObserver !== "undefined"
+    ) {
+      const observer = new MutationObserver(() => {
+        const shouldDisable = !platformUsername.value.trim();
+        if (shouldDisable && generateBtn.disabled === false) {
+          generateBtn.disabled = true;
+        }
+      });
+
+      observer.observe(generateBtn, {
+        attributes: true,
+        attributeFilter: ["disabled"],
+      });
+
+      generateBtn.dataset.generateButtonStateObserved = "true";
+    }
+
+    applyGenerateButtonState();
+  }
+
+  window.updateGenerateButtonState = updateGenerateButtonState;
+
+  async function bootstrapScrumReportOnPopupLoad(generateBtn) {
+    console.log("[BOOTSTRAP] bootstrapScrumReportOnPopupLoad called");
+
+    if (typeof window.generateScrumReport !== "function") {
+      return;
+    }
+
+    const scrumReport = document.getElementById("scrumReport");
+    if (!scrumReport) {
+      return;
+    }
+
+    const { platform, cacheInput, githubCache, gitlabCache } =
+      await storageLocalGet([
+        "platform",
+        "cacheInput",
+        "githubCache",
+        "gitlabCache",
+      ]);
+
+    const ttlMinutes = parsePositiveInt(cacheInput) ?? 10;
+    const ttlMs = ttlMinutes * 60 * 1000;
+
+    const activePlatform = platform || "github";
+    const cache = activePlatform === "gitlab" ? gitlabCache : githubCache;
+
+    const hasCacheData = !!cache?.data;
+    const timestamp =
+      typeof cache?.timestamp === "number" ? cache.timestamp : 0;
+
+    updateCacheStatusBadge(timestamp || null, ttlMs);
+    startCacheAgeTicker(timestamp || null, ttlMs);
+
+    if (!hasCacheData) {
+      setGenerateButtonLoading(generateBtn, true);
+      window.generateScrumReport();
+      return;
+    }
+
+    if (timestamp > 0) {
+      const age = Date.now() - timestamp;
+
+      const storageValues = await storageLocalGet([
+        `${activePlatform}LastScrumReportHtml`,
+        `${activePlatform}LastScrumReportCacheKey`,
+        `${activePlatform}LastScrumReportUsername`,
+        "lastScrumReportHtml",
+        "lastScrumReportPlatform",
+        "lastScrumReportCacheKey",
+        "lastScrumReportUsername",
+        "githubUsername",
+        "gitlabUsername",
+        "platformUsername",
+      ]);
+
+      let lastScrumReportHtml =
+        storageValues[`${activePlatform}LastScrumReportHtml`];
+      let lastScrumReportCacheKey =
+        storageValues[`${activePlatform}LastScrumReportCacheKey`];
+      let lastScrumReportUsername =
+        storageValues[`${activePlatform}LastScrumReportUsername`];
+
+      if (
+        storageValues.lastScrumReportHtml &&
+        (!storageValues.lastScrumReportPlatform ||
+          storageValues.lastScrumReportPlatform === activePlatform) &&
+        !lastScrumReportHtml
+      ) {
+        lastScrumReportHtml = storageValues.lastScrumReportHtml;
+        lastScrumReportCacheKey = storageValues.lastScrumReportCacheKey;
+        lastScrumReportUsername = storageValues.lastScrumReportUsername;
+      }
+
+      const expectedUsername =
+        activePlatform === "gitlab"
+          ? storageValues.gitlabUsername || storageValues.platformUsername
+          : storageValues.githubUsername || storageValues.platformUsername;
+
+      const isUsernameMatch = lastScrumReportUsername
+        ? lastScrumReportUsername === expectedUsername
+        : lastScrumReportCacheKey &&
+          expectedUsername &&
+          lastScrumReportCacheKey.startsWith(expectedUsername + "-");
+
+      if (age < ttlMs) {
+        const cacheKey = cache?.cacheKey ?? null;
+        const reportEmpty =
+          !scrumReport.innerHTML || !scrumReport.innerHTML.trim();
+
+        const matches =
+          (!lastScrumReportCacheKey || lastScrumReportCacheKey === cacheKey) &&
+          isUsernameMatch;
+
+        if (reportEmpty && lastScrumReportHtml && matches) {
+          scrumReport.innerHTML = sanitizeHtml(lastScrumReportHtml);
+          if (generateBtn) generateBtn.disabled = false;
+          return;
+        }
+
+        setGenerateButtonLoading(generateBtn, true);
+        window.generateScrumReport();
+        return;
+      }
+
+      // If cache is expired, still only show the old HTML if it was for the current username
+      if (
+        (!scrumReport.innerHTML || !scrumReport.innerHTML.trim()) &&
+        lastScrumReportHtml &&
+        isUsernameMatch
+      ) {
+        scrumReport.innerHTML = sanitizeHtml(lastScrumReportHtml);
+      }
+
+      if (generateBtn) generateBtn.disabled = false;
+      return;
+    }
+
+    setGenerateButtonLoading(generateBtn, true);
+    window.generateScrumReport();
+  }
+
+  function initializePopup() {
+    browser.storage.local
+      .get(["platform", "platformUsername"])
+      .then((result) => {
+        if (result.platformUsername && result.platform) {
+          const platformUsernameKey = `${result.platform}Username`;
+          browser.storage.local.set({
+            [platformUsernameKey]: result.platformUsername,
+          });
+          browser.storage.local.remove(["platformUsername"]);
+          console.log(
+            `[MIGRATION] Migrated platformUsername to ${platformUsernameKey}`,
+          );
+        }
+      });
+
+    // Restore all persistent fields immediately on DOMContentLoaded
+    const projectNameInput = document.getElementById("projectName");
+    const orgInput = document.getElementById("orgInput");
+    const userReasonInput = document.getElementById("userReason");
+    const showOpenLabelCheckbox = document.getElementById("showOpenLabel");
+    const showCommitsCheckbox = document.getElementById("showCommits");
+    const onlyIssuesCheckbox = document.getElementById("onlyIssues");
+    const onlyPRsCheckbox = document.getElementById("onlyPRs");
+    const onlyRevPRsCheckbox = document.getElementById("onlyRevPRs");
+    const onlyMergedPRsCheckbox = document.getElementById("onlyMergedPRs");
+
+    const githubTokenInput = document.getElementById("githubToken");
+    const cacheInput = document.getElementById("cacheInput");
+    const yesterdayRadio = document.getElementById("yesterdayContribution");
+    const startingDateInput = document.getElementById("startingDate");
+    const endingDateInput = document.getElementById("endingDate");
+    const platformUsername = document.getElementById("platformUsername");
+    const usernameError = document.getElementById("usernameError");
+
+    browser.storage.local
+      .get([
+        "projectName",
+        "orgName",
+        "userReason",
+        "showOpenLabel",
+        "showCommits",
+        "githubToken",
+        "cacheInput",
+        "onlyIssues",
+        "onlyPRs",
+        "onlyRevPRs",
+        "onlyMergedPRs",
+        "yesterdayContribution",
+        "startingDate",
+        "endingDate",
+        "selectedTimeframe",
+        "platform",
+        "githubUsername",
+        "gitlabUsername",
+      ])
+      .then((result) => {
+        if (result.projectName) projectNameInput.value = result.projectName;
+        if (result.orgName) orgInput.value = result.orgName;
+        if (result.userReason) userReasonInput.value = result.userReason;
+        if (typeof result.showOpenLabel !== "undefined") {
+          showOpenLabelCheckbox.checked = result.showOpenLabel;
+        } else {
+          showOpenLabelCheckbox.checked = true; // Default to true for new users
+        }
+        if (typeof result.showCommits !== "undefined")
+          showCommitsCheckbox.checked = result.showCommits;
+        if (typeof result.onlyIssues !== "undefined") {
+          onlyIssuesCheckbox.checked = result.onlyIssues;
+        }
+        if (typeof result.onlyPRs !== "undefined") {
+          onlyPRsCheckbox.checked = result.onlyPRs;
+        }
+        if (typeof result.onlyRevPRs !== "undefined") {
+          onlyRevPRsCheckbox.checked = result.onlyRevPRs;
+        }
+        if (typeof result.onlyMergedPRs !== "undefined") {
+          onlyMergedPRsCheckbox.checked = result.onlyMergedPRs;
+        }
+
+        // Reconcile mutually exclusive "Only Issues" and "Only PRs" flags on initialization.
+        // If both are somehow true in storage (e.g., from an older version or manual edits),
+        // prefer "Only Issues" and clear "Only PRs", then persist the corrected state.
+        if (onlyIssuesCheckbox.checked && onlyPRsCheckbox.checked) {
+          onlyPRsCheckbox.checked = false;
+          browser?.storage.local.set({ onlyPRs: false });
+        }
+        if (onlyMergedPRsCheckbox.checked && onlyRevPRsCheckbox.checked) {
+          onlyRevPRsCheckbox.checked = false;
+          browser?.storage.local.set({ onlyRevPRs: false });
+        }
+        // onlyMergedPRs overrides onlyIssues and onlyPRs
+        if (onlyMergedPRsCheckbox.checked && onlyIssuesCheckbox.checked) {
+          onlyIssuesCheckbox.checked = false;
+          browser?.storage.local.set({ onlyIssues: false });
+        }
+        if (onlyMergedPRsCheckbox.checked && onlyPRsCheckbox.checked) {
+          onlyPRsCheckbox.checked = false;
+          browser?.storage.local.set({ onlyPRs: false });
+        }
+        if (result.githubToken) githubTokenInput.value = result.githubToken;
+        if (result.cacheInput) cacheInput.value = result.cacheInput;
+        if (typeof result.yesterdayContribution !== "undefined")
+          yesterdayRadio.checked = result.yesterdayContribution;
+        if (result.startingDate) startingDateInput.value = result.startingDate;
+        if (result.endingDate) endingDateInput.value = result.endingDate;
+        const wasNormalizedOnLoad =
+          window.scrumDateRangeUtils.normalizeDateRangeValues(
+            startingDateInput,
+            endingDateInput,
+          );
+        if (wasNormalizedOnLoad) {
+          window.scrumDateRangeUtils.persistDateRange(
+            startingDateInput,
+            endingDateInput,
+          );
+        }
+
+        // Load platform-specific username
+        const platform = result.platform || "github";
+        const platformUsernameKey = `${platform}Username`;
+        platformUsername.value = result[platformUsernameKey] || "";
+        window.updateGenerateButtonState && window.updateGenerateButtonState();
+        checkTokenForShowCommits();
+        checkTokenForMergedPRs();
+      });
+
+    // Button setup
+    const generateBtn = document.getElementById("generateReport");
+    const copyBtn = document.getElementById("copyReport");
+    const insertBtn = document.getElementById("insertInEmail");
+
+    if (insertBtn) {
+      insertBtn.addEventListener("click", () => {
+        const scrumReport = document.getElementById("scrumReport");
+        const content = scrumReport ? sanitizeHtml(scrumReport.innerHTML) : "";
+        const subject = buildScrumSubjectFromPopup();
+
+        if (!content) {
+          insertBtn._triggeredByShortcut = false;
+          return;
+        }
+
+        // Helper to handle insert-to-email failures consistently
+        const handleInsertFailure = (errorMsg) => {
+          console.warn("Insert to Email failed:", errorMsg);
+          const failureMessage =
+            browser.i18n.getMessage("insertToEmailFailedError") ||
+            "open an email tab to insert report";
+          showPopupMessage(failureMessage);
+        };
+
+        browser.tabs
+          .query({ active: true, currentWindow: true })
+          .then((tabs) => {
+            const tabId = tabs?.[0]?.id;
+            if (!tabId) {
+              handleInsertFailure("No active tab found");
+              return;
+            }
+
+            browser.tabs
+              .sendMessage(tabId, {
+                action: "insertReportToEmail",
+                content,
+                subject,
+              })
+              .then((response) => {
+                if (!response?.success) {
+                  handleInsertFailure(response?.error);
+                } else if (insertBtn._triggeredByShortcut) {
+                  showShortcutNotification("insertedInEmailNotification");
+                }
+              })
+              .catch((error) => {
+                handleInsertFailure(error.message);
+              });
+          })
+          .catch((error) => {
+            handleInsertFailure("Failed to query tabs: " + error.message);
+          })
+          .finally(() => {
+            insertBtn._triggeredByShortcut = false;
+          });
+      });
+    }
+
+    // DIFF 1: hideCacheStatusBadge() is called before generateScrumReport(),
+    // so the badge clears as soon as generation begins.
+    generateBtn.addEventListener("click", () => {
+      browser.storage.local.get(["platform"]).then((result) => {
+        platformUsername.classList.remove("input-error");
+        usernameError.classList.remove("errorMessage");
+        usernameError.textContent = "";
+        const platform = result.platform || "github";
+        const platformUsernameKey = `${platform}Username`;
+
+        browser.storage.local
+          .set({
+            platform: platformSelect.value,
+            [platformUsernameKey]: platformUsername.value,
+          })
+          .then(() => {
+            // Reload platform from storage before generating report
+            browser.storage.local.get(["platform"]).then((res) => {
+              platformSelect.value = res.platform || "github";
+              updatePlatformUI(platformSelect.value);
+              generateBtn.innerHTML =
+                '<i class="fa fa-spinner fa-spin"></i> Generating...';
+              generateBtn.disabled = true;
+              hideCacheStatusBadge();
+              window.generateScrumReport && window.generateScrumReport();
+            });
+          });
+      });
+    });
+
+    copyBtn.addEventListener("click", function () {
+      const scrumReport = document.getElementById("scrumReport");
+      const tempDiv = document.createElement("div");
+      tempDiv.innerHTML = sanitizeHtml(scrumReport.innerHTML);
+      document.body.appendChild(tempDiv);
+      tempDiv.style.position = "absolute";
+      tempDiv.style.left = "-9999px";
+
+      const range = document.createRange();
+      range.selectNode(tempDiv);
+      const selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+
+      try {
+        document.execCommand("copy");
+        if (this._triggeredByShortcut) {
+          const notificationKey =
+            browser?.i18n && browser.i18n.getMessage("copiedReportNotification")
+              ? "copiedReportNotification"
+              : "copiedButton";
+          showShortcutNotification(notificationKey);
+        }
+        this.innerHTML = `<i class="fa fa-check"></i> ${browser?.i18n.getMessage("copiedButton")}`;
+        setTimeout(() => {
+          this.innerHTML = `<i class="fa fa-copy"></i> ${browser.i18n.getMessage("copyReportButton")}`;
+        }, 2000);
+      } catch (err) {
+        console.error("Failed to copy: ", err);
+      } finally {
+        this._triggeredByShortcut = false;
+        selection.removeAllRanges();
+        document.body.removeChild(tempDiv);
+      }
+    });
+
+    // Custom date container click handler
+    document
+      .getElementById("customDateContainer")
+      .addEventListener("click", () => {
+        document
+          .querySelectorAll('input[name="timeframe"]')
+          .forEach((radio) => {
+            radio.checked = false;
+            radio.dataset.wasChecked = "false";
+          });
+
+        const startDateInput = document.getElementById("startingDate");
+        const endDateInput = document.getElementById("endingDate");
+        startDateInput.readOnly = false;
+        endDateInput.readOnly = false;
+
+        browser.storage.local.set({
+          yesterdayContribution: false,
+          selectedTimeframe: null,
+        });
+      });
+
+    browser.storage.local
+      .get([
+        "selectedTimeframe",
+        "yesterdayContribution",
+        "startingDate",
+        "endingDate",
+      ])
+      .then((items) => {
+        console.log("Restoring state:", items);
+
+        if (
+          items.startingDate &&
+          items.endingDate &&
+          !items.yesterdayContribution
+        ) {
+          const startDateInput = document.getElementById("startingDate");
+          const endDateInput = document.getElementById("endingDate");
+
+          if (startDateInput && endDateInput) {
+            startDateInput.value = items.startingDate;
+            endDateInput.value = items.endingDate;
+            startDateInput.readOnly = false;
+            endDateInput.readOnly = false;
+          }
+          document
+            .querySelectorAll('input[name="timeframe"]')
+            .forEach((radio) => {
+              radio.checked = false;
+              radio.dataset.wasChecked = "false";
+            });
+          return;
+        }
+
+        if (!items.selectedTimeframe) {
+          items.selectedTimeframe = "yesterdayContribution";
+          items.yesterdayContribution = true;
+        }
+
+        const radio = document.getElementById(items.selectedTimeframe);
+        if (radio) {
+          radio.checked = true;
+          radio.dataset.wasChecked = "true";
+
+          const startDateInput = document.getElementById("startingDate");
+          const endDateInput = document.getElementById("endingDate");
+
+          if (items.selectedTimeframe === "yesterdayContribution") {
+            startDateInput.value = getYesterday();
+            endDateInput.value = getToday();
+          }
+          startDateInput.readOnly = endDateInput.readOnly = true;
+
+          browser.storage.local.set({
+            startingDate: startDateInput.value,
+            endingDate: endDateInput.value,
+            yesterdayContribution:
+              items.selectedTimeframe === "yesterdayContribution",
+            selectedTimeframe: items.selectedTimeframe,
+          });
+        }
+      });
+
+    // Save all fields to storage on input/change
+    projectNameInput.addEventListener("input", () => {
+      browser.storage.local.set({ projectName: projectNameInput.value });
+    });
+
+    // Save to storage and validate ONLY when user clicks out (blur event)
+    orgInput.addEventListener("blur", () => {
+      const org = orgInput.value.trim().toLowerCase();
+      browser.storage.local.set({ orgName: org });
+
+      // Only validate if org name is not empty
+      if (org) {
+        validateOrgOnBlur(org);
+      } else {
+        window.clearScrumHelperToast?.();
+      }
+    });
+    if (userReasonInput) {
+      userReasonInput.addEventListener("input", () => {
+        browser.storage.local.set({ userReason: userReasonInput.value });
+      });
+    }
+    showOpenLabelCheckbox.addEventListener("change", () => {
+      browser.storage.local.set({
+        showOpenLabel: showOpenLabelCheckbox.checked,
+      });
+    });
+    if (onlyIssuesCheckbox && onlyPRsCheckbox) {
+      onlyIssuesCheckbox.addEventListener("change", () => {
+        const checked = onlyIssuesCheckbox.checked;
+        browser?.storage.local.set({ onlyIssues: checked }, () => {
+          if (checked) {
+            if (onlyPRsCheckbox.checked) {
+              onlyPRsCheckbox.checked = false;
+              browser?.storage.local.set({ onlyPRs: false });
+            }
+            if (onlyMergedPRsCheckbox && onlyMergedPRsCheckbox.checked) {
+              onlyMergedPRsCheckbox.checked = false;
+              browser?.storage.local.set({ onlyMergedPRs: false });
+            }
+          }
+        });
+      });
+
+      onlyPRsCheckbox.addEventListener("change", () => {
+        const checked = onlyPRsCheckbox.checked;
+        browser?.storage.local.set({ onlyPRs: checked }, () => {
+          if (checked) {
+            if (onlyIssuesCheckbox.checked) {
+              onlyIssuesCheckbox.checked = false;
+              browser?.storage.local.set({ onlyIssues: false });
+            }
+            if (onlyMergedPRsCheckbox && onlyMergedPRsCheckbox.checked) {
+              onlyMergedPRsCheckbox.checked = false;
+              browser?.storage.local.set({ onlyMergedPRs: false });
+            }
+          }
+        });
+      });
+
+      if (onlyRevPRsCheckbox) {
+        onlyRevPRsCheckbox.addEventListener("change", () => {
+          const checked = onlyRevPRsCheckbox.checked;
+          browser?.storage.local.set({ onlyRevPRs: checked }, () => {
+            if (
+              checked &&
+              onlyMergedPRsCheckbox &&
+              onlyMergedPRsCheckbox.checked
+            ) {
+              onlyMergedPRsCheckbox.checked = false;
+              browser?.storage.local.set({ onlyMergedPRs: false });
+            }
+          });
+        });
+      }
+      if (onlyMergedPRsCheckbox) {
+        onlyMergedPRsCheckbox.addEventListener("change", () => {
+          if (onlyMergedPRsCheckbox.checked) {
+            if (onlyRevPRsCheckbox && onlyRevPRsCheckbox.checked) {
+              onlyRevPRsCheckbox.checked = false;
+              browser?.storage.local.set({ onlyRevPRs: false });
+            }
+            if (onlyIssuesCheckbox && onlyIssuesCheckbox.checked) {
+              onlyIssuesCheckbox.checked = false;
+              browser?.storage.local.set({ onlyIssues: false });
+            }
+            if (onlyPRsCheckbox && onlyPRsCheckbox.checked) {
+              onlyPRsCheckbox.checked = false;
+              browser?.storage.local.set({ onlyPRs: false });
+            }
+          }
+          checkTokenForMergedPRs({
+            showWarning: true,
+            animateWarning: true,
+            warningDurationMs: 3000,
+            persistState: true,
+          });
+        });
+      }
+    }
+    showCommitsCheckbox.addEventListener("change", () => {
+      checkTokenForShowCommits({
+        showWarning: true,
+        animateWarning: true,
+        warningDurationMs: 3000,
+        persistState: true,
+      });
+    });
+    githubTokenInput.addEventListener("input", () => {
+      browser.storage.local.set({ githubToken: githubTokenInput.value });
+    });
+    cacheInput.addEventListener("input", () => {
+      browser.storage.local.set({ cacheInput: cacheInput.value });
+    });
+
+    // Display mode (popup / sidepanel)
+    // Apply the stored display mode class on next launch
+    function applyDisplayModeClass(mode) {
+      // If opened via Firefox sidebar_action, force sidepanel mode
+      if (window.location.search.includes("view=sidebar")) {
+        mode = "sidepanel";
+        document.documentElement.classList.add("firefox-sidebar");
+        document.body.classList.add("firefox-sidebar");
+      }
+
+      const className = mode === "popup" ? "mode-popup" : "mode-sidepanel";
+      if (!document.documentElement.classList.contains(className)) {
+        document.documentElement.classList.remove(
+          "mode-popup",
+          "mode-sidepanel",
+        );
+        body.classList.remove("mode-popup", "mode-sidepanel");
+        document.documentElement.classList.add(className);
+        body.classList.add(className);
+      }
+    }
+
+    browser.storage.local.get({ displayMode: "sidePanel" }).then((result) => {
+      applyDisplayModeClass(result.displayMode);
+    });
+
+    const displayModeSelect = document.getElementById("displayModeSelect");
+    const displayModeNotice = document.getElementById("displayModeNotice");
+    const displayModeNoticeText = document.getElementById(
+      "displayModeNoticeText",
+    );
+    if (displayModeSelect) {
+      browser.storage.local.get({ displayMode: "sidePanel" }).then((result) => {
+        displayModeSelect.value = result.displayMode;
+      });
+      displayModeSelect.addEventListener("change", () => {
+        const mode = displayModeSelect.value;
+        browser.storage.local.set({ displayMode: mode });
+        // Show notice instead of applying immediately
+        const modeLabel = mode === "popup" ? "Popup" : "Side Panel";
+        if (displayModeNotice && displayModeNoticeText) {
+          displayModeNoticeText.textContent =
+            chrome?.i18n.getMessage("displayModeNotice", [modeLabel]) ||
+            `The extension will open in ${modeLabel} mode on the next launch.`;
+          displayModeNotice.classList.remove("hidden");
+        }
+      });
+    }
+
+    yesterdayRadio.addEventListener("change", () => {
+      browser.storage.local.set({
+        yesterdayContribution: yesterdayRadio.checked,
+      });
+    });
+    startingDateInput.addEventListener("input", () => {
+      window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(
+        startingDateInput,
+        endingDateInput,
+      );
+    });
+    endingDateInput.addEventListener("input", () => {
+      window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(
+        startingDateInput,
+        endingDateInput,
+      );
+    });
+
+    // Save username to storage on input and update button state
+    platformUsername.addEventListener("input", () => {
+      browser.storage.local.get(["platform"]).then((result) => {
+        const platform = result.platform || "github";
+        const platformUsernameKey = `${platform}Username`;
+        browser.storage.local.set({
+          [platformUsernameKey]: platformUsername.value,
+        });
+      });
+      window.updateGenerateButtonState && window.updateGenerateButtonState();
+    });
+    // Bootstrap report on popup open (restore cache / auto-generate / expired-cache toast)
+    bootstrapScrumReportOnPopupLoad(generateBtn).catch((err) => {
+      console.error("[POPUP] bootstrapScrumReportOnPopupLoad failed", err);
+    });
+  }
+
+  function showReportView() {
+    isSettingsVisible = false;
+    reportSection.classList.remove("hidden");
+    settingsSection.classList.add("hidden");
+    settingsToggle.classList.remove("active");
+  }
+
+  function showSettingsView() {
+    isSettingsVisible = true;
+    reportSection.classList.add("hidden");
+    settingsSection.classList.remove("hidden");
+    settingsToggle.classList.add("active");
+  }
+
+  if (settingsToggle) {
+    settingsToggle.addEventListener("click", () => {
+      if (isSettingsVisible) {
+        showReportView();
+      } else {
+        showSettingsView();
+      }
+    });
+  }
+
+  if (homeButton) {
+    homeButton.addEventListener("click", showReportView);
+  }
+  if (scrumHelperHeading) {
+    scrumHelperHeading.addEventListener("click", showReportView);
+  }
+
+  showReportView();
+
+  //report filter
+  const repoSearch = document.getElementById("repoSearch");
+  const repoDropdown = document.getElementById("repoDropdown");
+  const selectedReposDiv = document.getElementById("selectedRepos");
+  const repoTags = document.getElementById("repoTags");
+  const repoPlaceholder = document.getElementById("repoPlaceholder");
+  const repoCount = document.getElementById("repoCount");
+  const repoStatus = document.getElementById("repoStatus");
+  const useRepoFilter = document.getElementById("useRepoFilter");
+  const repoFilterContainer = document.getElementById("repoFilterContainer");
+
+  if (repoSearch && useRepoFilter && repoFilterContainer) {
+    repoSearch.addEventListener("click", () => {
+      if (!useRepoFilter.checked) {
+        useRepoFilter.checked = true;
+        repoFilterContainer.classList.remove("hidden");
+        browser.storage.local.set({ useRepoFilter: true });
+      }
+    });
+  }
+
+  if (!repoSearch || !useRepoFilter) {
+    console.log("Repository, filter elements not found in DOM");
+  } else {
+    let availableRepos = [];
+    let selectedRepos = [];
+    let highlightedIndex = -1;
+
+    async function triggerRepoFetchIfEnabled() {
+      // --- PLATFORM CHECK: Only run for GitHub ---
+      let platform = "github";
+      try {
+        const items = await browser.storage.local.get(["platform"]);
+        platform = items.platform || "github";
+      } catch {}
+      if (platform !== "github") {
+        // Do not run repo fetch for non-GitHub platforms
+        if (repoStatus)
+          repoStatus.textContent =
+            chrome?.i18n.getMessage("repoFilteringGithubOnly") ||
+            "Repository filtering is only available for GitHub.";
+        return;
+      }
+      if (!useRepoFilter.checked) {
+        return;
+      }
+
+      if (repoStatus) {
+        repoStatus.textContent = browser.i18n.getMessage("repoRefetching");
+      }
+
+      try {
+        const cacheData = await browser.storage.local.get(["repoCache"]);
+        const items = await browser.storage.local.get([
+          "platform",
+          "githubUsername",
+          "gitlabUsername",
+          "githubToken",
+          "orgName",
+        ]);
+
+        const platform = items.platform || "github";
+        const platformUsernameKey = `${platform}Username`;
+        const username = items[platformUsernameKey];
+
+        if (!username) {
+          if (repoStatus) {
+            repoStatus.textContent =
+              chrome?.i18n.getMessage("usernameMissingError") ||
+              "Username required";
+          }
+          return;
+        }
+
+        if (window.fetchUserRepositories) {
+          const repos = await window.fetchUserRepositories(
+            username,
+            items.githubToken,
+            items.orgName || "",
+          );
+
+          availableRepos = repos;
+
+          if (repoStatus) {
+            repoStatus.textContent = browser.i18n.getMessage("repoLoaded", [
+              repos.length,
+            ]);
+          }
+
+          const repoCacheKey = `repos-${username}-${items.orgName || ""}`;
+          browser.storage.local.set({
+            repoCache: {
+              data: repos,
+              cacheKey: repoCacheKey,
+              timestamp: Date.now(),
+            },
+          });
+
+          if (document.activeElement === repoSearch) {
+            filterAndDisplayRepos(repoSearch.value.toLowerCase());
+          } else if (repoSearch.value) {
+            filterAndDisplayRepos(repoSearch.value.toLowerCase());
+          } else {
+            filterAndDisplayRepos("");
+          }
+        }
+      } catch (err) {
+        if (repoStatus) {
+          repoStatus.textContent = `${browser.i18n.getMessage("errorLabel")}: ${err.message || browser.i18n.getMessage("repoRefetchFailed")}`;
+        }
+      }
+    }
+
+    window.triggerRepoFetchIfEnabled = triggerRepoFetchIfEnabled;
+
+    browser.storage.local
+      .get(["selectedRepos", "useRepoFilter"])
+      .then((items) => {
+        if (items.selectedRepos) {
+          selectedRepos = items.selectedRepos;
+          updateRepoDisplay();
+        }
+        if (items.useRepoFilter) {
+          useRepoFilter.checked = items.useRepoFilter;
+          repoFilterContainer.classList.toggle("hidden", !items.useRepoFilter);
+        }
+      });
+
+    useRepoFilter.addEventListener(
+      "change",
+      debounce(async () => {
+        let platform = "github";
+        try {
+          const items = await browser.storage.local.get(["platform"]);
+          platform = items.platform || "github";
+        } catch {}
+        if (platform !== "github") {
+          repoFilterContainer.classList.add("hidden");
+          useRepoFilter.checked = false;
+          if (repoStatus)
+            repoStatus.textContent =
+              chrome?.i18n.getMessage("repoFilteringGithubOnly") ||
+              "Repository filtering is only available for GitHub.";
+          return;
+        }
+        const enabled = useRepoFilter.checked;
+        const hasToken = githubTokenInput.value.trim() !== "";
+        repoFilterContainer.classList.toggle("hidden", !enabled);
+
+        if (enabled && !hasToken) {
+          useRepoFilter.checked = false;
+          repoFilterContainer.classList.add("hidden"); // hide the container
+          hideDropdown();
+          const tokenWarning = document.getElementById("tokenWarningForFilter");
+          if (tokenWarning) {
+            tokenWarning.classList.remove("hidden");
+            tokenWarning.classList.add("shake-animation");
+            setTimeout(
+              () => tokenWarning.classList.remove("shake-animation"),
+              620,
+            );
+            setTimeout(() => {
+              tokenWarning.classList.add("hidden");
+            }, 3000);
+          }
+          return;
+        }
+        repoFilterContainer.classList.toggle("hidden", !enabled);
+
+        browser.storage.local.set({
+          useRepoFilter: enabled,
+          githubCache: null, //forces refresh
+        });
+        checkTokenForFilter();
+        if (enabled) {
+          repoStatus.textContent =
+            chrome?.i18n.getMessage("loadingReposAutomatically") ||
+            "Loading repos automatically...";
+
+          try {
+            const cacheData = await browser.storage.local.get(["repoCache"]);
+            const items = await browser.storage.local.get([
+              "platform",
+              "githubUsername",
+              "gitlabUsername",
+              "githubToken",
+              "orgName",
+            ]);
+
+            const platform = items.platform || "github";
+            const platformUsernameKey = `${platform}Username`;
+            const username = items[platformUsernameKey];
+
+            if (!username) {
+              repoStatus.textContent =
+                chrome?.i18n.getMessage("usernameMissingError") ||
+                "Username required";
+              return;
+            }
+
+            const repoCacheKey = `repos-${username}-${items.orgName || ""}`;
+
+            const now = Date.now();
+            const cacheAge = cacheData.repoCache?.timestamp
+              ? now - cacheData.repoCache.timestamp
+              : Number.POSITIVE_INFINITY;
+            const cacheTTL = 10 * 60 * 1000; // 10 minutes
+
+            if (
+              cacheData.repoCache &&
+              cacheData.repoCache.cacheKey === repoCacheKey &&
+              cacheAge < cacheTTL
+            ) {
+              console.log("Using cached repositories");
+              availableRepos = cacheData.repoCache.data;
+              repoStatus.textContent = browser.i18n.getMessage("repoLoaded", [
+                availableRepos.length,
+              ]);
+
+              if (document.activeElement === repoSearch) {
+                filterAndDisplayRepos(repoSearch.value.toLowerCase());
+              }
+              return;
+            }
+
+            if (window.fetchUserRepositories) {
+              const repos = await window.fetchUserRepositories(
+                username,
+                items.githubToken,
+                items.orgName || "",
+              );
+              availableRepos = repos;
+              repoStatus.textContent = browser.i18n.getMessage("repoLoaded", [
+                repos.length,
+              ]);
+
+              browser.storage.local.set({
+                repoCache: {
+                  data: repos,
+                  cacheKey: repoCacheKey,
+                  timestamp: now,
+                },
+              });
+
+              if (document.activeElement === repoSearch) {
+                filterAndDisplayRepos(repoSearch.value.toLowerCase());
+              }
+            }
+          } catch (err) {
+            console.error("Auto load repos failed", err);
+
+            if (err.message?.includes("401")) {
+              repoStatus.textContent =
+                browser.i18n.getMessage("repoTokenPrivate");
+            } else if (err.message?.includes("username")) {
+              repoStatus.textContent = browser.i18n.getMessage(
+                "githubUsernamePlaceholder",
+              );
+            } else {
+              repoStatus.textContent = `${browser.i18n.getMessage("errorLabel")}: ${err.message || browser.i18n.getMessage("repoLoadFailed")}`;
+            }
+          }
+        } else {
+          selectedRepos = [];
+          updateRepoDisplay();
+          browser.storage.local.set({ selectedRepos: [] });
+          repoStatus.textContent = "";
+        }
+      }, 300),
+    );
+
+    repoSearch.addEventListener("keydown", (e) => {
+      const items = repoDropdown.querySelectorAll(".repository-dropdown-item");
+
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          highlightedIndex = Math.min(highlightedIndex + 1, items.length - 1);
+          updateHighlight(items);
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          highlightedIndex = Math.max(highlightedIndex - 1, 0);
+          updateHighlight(items);
+          break;
+        case "Enter":
+          e.preventDefault();
+          if (highlightedIndex >= 0 && items[highlightedIndex]) {
+            fnSelectedRepos(items[highlightedIndex].dataset.repoName);
+          }
+          break;
+        case "Escape":
+          hideDropdown();
+          break;
+      }
+    });
+
+    repoSearch.addEventListener("input", (e) => {
+      const query = e.target.value.toLowerCase();
+      filterAndDisplayRepos(query);
+    });
+    let programmaticFocus = false;
+    repoSearch.addEventListener("focus", () => {
+      if (programmaticFocus) {
+        programmaticFocus = false;
+        return;
+      }
+      const searchTerm = repoSearch.value.toLowerCase();
+      filterAndDisplayRepos(searchTerm);
+    });
+
+    document.addEventListener("click", (e) => {
+      if (
+        !e.target.closest("#repoSearch") &&
+        !e.target.closest("#repoDropdown")
+      ) {
+        hideDropdown();
+      }
+    });
+
+    function debugRepoFetch() {
+      browser.storage.local
+        .get(["platform", "githubUsername", "githubToken", "orgName"])
+        .then((items) => {
+          const platform = items.platform || "github";
+          const platformUsernameKey = `${platform}Username`;
+          const username = items[platformUsernameKey];
+          console.log("Current settings:", {
+            username: username,
+            hasToken: !!items.githubToken,
+            org: items.orgName || "",
+          });
+        });
+    }
+    debugRepoFetch();
+    async function loadRepos() {
+      // --- PLATFORM CHECK: Only run for GitHub ---
+      let platform = "github";
+      try {
+        const items = await browser.storage.local.get(["platform"]);
+        platform = items.platform || "github";
+      } catch {}
+      if (platform !== "github") {
+        if (repoStatus)
+          repoStatus.textContent =
+            chrome?.i18n.getMessage("repoLoadingGithubOnly") ||
+            "Repository loading is only available for GitHub.";
+        return;
+      }
+      console.log(
+        "window.fetchUserRepositories exists:",
+        !!window.fetchUserRepositories,
+      );
+      console.log(
+        "Available functions:",
+        Object.keys(window).filter((key) => key.includes("fetch")),
+      );
+
+      if (!window.fetchUserRepositories) {
+        repoStatus.textContent = "Repository fetching not available";
+        return;
+      }
+
+      browser.storage.local
+        .get(["platform", "githubUsername", "githubToken"])
+        .then((items) => {
+          const platform = items.platform || "github";
+          const platformUsernameKey = `${platform}Username`;
+          const username = items[platformUsernameKey];
+          console.log("Storage data for repo fetch:", {
+            hasUsername: !!username,
+            hasToken: !!items.githubToken,
+            username: username,
+          });
+
+          if (!username) {
+            repoStatus.textContent =
+              chrome?.i18n.getMessage("usernameMissingError") ||
+              "Username required";
+            return;
+          }
+
+          performRepoFetch();
+        });
+    }
+
+    async function performRepoFetch() {
+      let platform = "github";
+      try {
+        const items = await browser.storage.local.get(["platform"]);
+        platform = items.platform || "github";
+      } catch (e) {}
+      if (platform !== "github") {
+        if (repoStatus)
+          repoStatus.textContent =
+            chrome?.i18n.getMessage("repoFetchingGithubOnly") ||
+            "Repository fetching is only available for GitHub.";
+        return;
+      }
+      console.log("[POPUP-DEBUG] performRepoFetch called.");
+      repoStatus.textContent = browser.i18n.getMessage("repoLoading");
+      repoSearch.classList.add("repository-search-loading");
+
+      try {
+        const cacheData = await browser.storage.local.get(["repoCache"]);
+        const storageItems = await browser.storage.local.get([
+          "platform",
+          "githubUsername",
+          "gitlabUsername",
+          "githubToken",
+          "orgName",
+        ]);
+        const platform = storageItems.platform || "github";
+        const platformUsernameKey = `${platform}Username`;
+        const username = storageItems[platformUsernameKey];
+        const repoCacheKey = `repos-${username}-${storageItems.orgName || ""}`;
+        const now = Date.now();
+        const cacheAge = cacheData.repoCache?.timestamp
+          ? now - cacheData.repoCache.timestamp
+          : Number.POSITIVE_INFINITY;
+        const cacheTTL = 10 * 60 * 1000; // 10 minutes
+
+        console.log("[POPUP-DEBUG] Repo cache check:", {
+          key: repoCacheKey,
+          cacheKeyInCache: cacheData.repoCache?.cacheKey,
+          isMatch: cacheData.repoCache?.cacheKey === repoCacheKey,
+          age: cacheAge,
+          isFresh: cacheAge < cacheTTL,
+        });
+
+        if (
+          cacheData.repoCache &&
+          cacheData.repoCache.cacheKey === repoCacheKey &&
+          cacheAge < cacheTTL
+        ) {
+          console.log(
+            "[POPUP-DEBUG] Using cached repositories in manual fetch",
+          );
+          availableRepos = cacheData.repoCache.data;
+          repoStatus.textContent = browser.i18n.getMessage("repoLoaded", [
+            availableRepos.length,
+          ]);
+
+          if (document.activeElement === repoSearch) {
+            filterAndDisplayRepos(repoSearch.value.toLowerCase());
+          }
+          return;
+        }
+        console.log("[POPUP-DEBUG] No valid cache. Fetching from network.");
+        availableRepos = await window.fetchUserRepositories(
+          username,
+          storageItems.githubToken,
+          storageItems.orgName || "",
+        );
+        repoStatus.textContent = browser.i18n.getMessage("repoLoaded", [
+          availableRepos.length,
+        ]);
+        console.log(
+          `[POPUP-DEBUG] Fetched and loaded ${availableRepos.length} repos.`,
+        );
+
+        browser.storage.local.set({
+          repoCache: {
+            data: availableRepos,
+            cacheKey: repoCacheKey,
+            timestamp: now,
+          },
+        });
+
+        if (document.activeElement === repoSearch) {
+          filterAndDisplayRepos(repoSearch.value.toLowerCase());
+        }
+      } catch (err) {
+        console.error(`Failed to load repos:`, err);
+
+        if (err.message && err.message.includes("401")) {
+          repoStatus.textContent = browser.i18n.getMessage("repoTokenPrivate");
+        } else if (err.message && err.message.includes("username")) {
+          repoStatus.textContent = browser.i18n.getMessage(
+            "githubUsernamePlaceholder",
+          );
+        } else {
+          repoStatus.textContent = `${browser.i18n.getMessage("errorLabel")}: ${err.message || browser.i18n.getMessage("repoLoadFailed")}`;
+        }
+      } finally {
+        repoSearch.classList.remove("repository-search-loading");
+      }
+    }
+
+    function filterAndDisplayRepos(query) {
+      if (availableRepos.length === 0) {
+        repoDropdown.innerHTML = `<div class="p-3 text-center text-gray-500 text-sm">${browser.i18n.getMessage("repoLoading")}</div>`;
+        showDropdown();
+        return;
+      }
+
+      const filtered = availableRepos.filter((repo) => {
+        if (selectedRepos.includes(repo.fullName)) {
+          return false;
+        }
+        if (!query) {
+          return true;
+        }
+        return (
+          repo.name.toLowerCase().includes(query) ||
+          repo.description?.toLowerCase().includes(query)
+        );
+      });
+
+      if (filtered.length === 0) {
+        repoDropdown.innerHTML = `<div class="p-3 text-center text-gray-500 text-sm" style="padding-left: 10px; ">${browser.i18n.getMessage("repoNotFound")}</div>`;
+      } else {
+        repoDropdown.innerHTML = sanitizeHtml(
+          filtered
+            .slice(0, 10)
+            .map(
+              (repo) => `
                     <div class="repository-dropdown-item" data-repo-name="${repo.fullName}">
                         <div class="repo-name">
                             <span>${repo.name}</span>
-                            ${repo.language ? `<span class="repo-language">${repo.language}</span>` : ''}
-                            ${repo.stars ? `<span class="repo-stars"><i class="fa fa-star"></i> ${repo.stars}</span>` : ''}
+                            ${repo.language ? `<span class="repo-language">${repo.language}</span>` : ""}
+                            ${repo.stars ? `<span class="repo-stars"><i class="fa fa-star"></i> ${repo.stars}</span>` : ""}
                         </div>
                         <div class="repo-info">
-                            ${repo.description ? `<span class="repo-desc">${repo.description.substring(0, 50)}${repo.description.length > 50 ? '...' : ''}</span>` : ''}
+                            ${repo.description ? `<span class="repo-desc">${repo.description.substring(0, 50)}${repo.description.length > 50 ? "..." : ""}</span>` : ""}
                         </div>
                     </div>
                 `,
-						)
-						.join(''),
-				);
+            )
+            .join(""),
+        );
 
-				repoDropdown.querySelectorAll('.repository-dropdown-item').forEach((item) => {
-					item.addEventListener('click', (e) => {
-						e.stopPropagation();
-						fnSelectedRepos(item.dataset.repoName);
-					});
-				});
-			}
-			highlightedIndex = -1;
-			showDropdown();
-		}
+        repoDropdown
+          .querySelectorAll(".repository-dropdown-item")
+          .forEach((item) => {
+            item.addEventListener("click", (e) => {
+              e.stopPropagation();
+              fnSelectedRepos(item.dataset.repoName);
+            });
+          });
+      }
+      highlightedIndex = -1;
+      showDropdown();
+    }
 
-		function fnSelectedRepos(repoFullName) {
-			if (!selectedRepos.includes(repoFullName)) {
-				selectedRepos.push(repoFullName);
-				updateRepoDisplay();
-				saveRepoSelection();
-			}
+    function fnSelectedRepos(repoFullName) {
+      if (!selectedRepos.includes(repoFullName)) {
+        selectedRepos.push(repoFullName);
+        updateRepoDisplay();
+        saveRepoSelection();
+      }
 
-			repoSearch.value = '';
-			filterAndDisplayRepos('');
-			programmaticFocus = true;
-			repoSearch.focus();
-		}
+      repoSearch.value = "";
+      filterAndDisplayRepos("");
+      programmaticFocus = true;
+      repoSearch.focus();
+    }
 
-		function removeRepo(repoFullName) {
-			selectedRepos = selectedRepos.filter((name) => name !== repoFullName);
-			updateRepoDisplay();
-			saveRepoSelection();
+    function removeRepo(repoFullName) {
+      selectedRepos = selectedRepos.filter((name) => name !== repoFullName);
+      updateRepoDisplay();
+      saveRepoSelection();
 
-			if (repoSearch.value) {
-				filterAndDisplayRepos(repoSearch.value.toLowerCase());
-			}
-		}
+      if (repoSearch.value) {
+        filterAndDisplayRepos(repoSearch.value.toLowerCase());
+      }
+    }
 
-		function updateRepoDisplay() {
-			if (selectedRepos.length === 0) {
-				repoTags.innerHTML = `<span class="text-xs text-gray-500 select-none" id="repoPlaceholder">${browser.i18n.getMessage('repoPlaceholder')}</span>`;
-				repoCount.textContent = browser.i18n.getMessage('repoCountNone');
-			} else {
-				repoTags.innerHTML = sanitizeHtml(
-					selectedRepos
-						.map((repoFullName) => {
-							const repoName = repoFullName.split('/')[1] || repoFullName;
-							return `
+    function updateRepoDisplay() {
+      if (selectedRepos.length === 0) {
+        repoTags.innerHTML = `<span class="text-xs text-gray-500 select-none" id="repoPlaceholder">${browser.i18n.getMessage("repoPlaceholder")}</span>`;
+        repoCount.textContent = browser.i18n.getMessage("repoCountNone");
+      } else {
+        repoTags.innerHTML = sanitizeHtml(
+          selectedRepos
+            .map((repoFullName) => {
+              const repoName = repoFullName.split("/")[1] || repoFullName;
+              return `
                         <span class="inline-flex items-center px-2 py-1 bg-blue-100 text-blue-800 text-xs font-medium rounded-full" style="margin:5px;">
                             ${repoName}
                             <button type="button" class="ml-1 text-blue-600 hover:text-blue-800 remove-repo-btn cursor-pointer" data-repo-name="${repoFullName}">
@@ -1585,556 +1845,609 @@ document.addEventListener('DOMContentLoaded', () => {
                             </button>
                         </span>
                     `;
-						})
-						.join(' '),
-				);
-				repoTags.querySelectorAll('.remove-repo-btn').forEach((btn) => {
-					btn.addEventListener('click', (e) => {
-						e.stopPropagation();
-						const repoFullName = btn.dataset.repoName;
-						removeRepo(repoFullName);
-					});
-				});
-				repoCount.textContent = browser.i18n.getMessage('repoCount', [selectedRepos.length]);
-			}
-		}
+            })
+            .join(" "),
+        );
+        repoTags.querySelectorAll(".remove-repo-btn").forEach((btn) => {
+          btn.addEventListener("click", (e) => {
+            e.stopPropagation();
+            const repoFullName = btn.dataset.repoName;
+            removeRepo(repoFullName);
+          });
+        });
+        repoCount.textContent = browser.i18n.getMessage("repoCount", [
+          selectedRepos.length,
+        ]);
+      }
+    }
 
-		function saveRepoSelection() {
-			const cleanedRepos = selectedRepos.filter((repo) => repo !== null);
-			browser.storage.local.set({
-				selectedRepos: cleanedRepos,
-				githubCache: null,
-			});
-		}
+    function saveRepoSelection() {
+      const cleanedRepos = selectedRepos.filter((repo) => repo !== null);
+      browser.storage.local.set({
+        selectedRepos: cleanedRepos,
+        githubCache: null,
+      });
+    }
 
-		function showDropdown() {
-			repoDropdown.classList.remove('hidden');
-		}
+    function showDropdown() {
+      repoDropdown.classList.remove("hidden");
+    }
 
-		function hideDropdown() {
-			repoDropdown.classList.add('hidden');
-			highlightedIndex = -1;
-		}
+    function hideDropdown() {
+      repoDropdown.classList.add("hidden");
+      highlightedIndex = -1;
+    }
 
-		function updateHighlight(items) {
-			items.forEach((item, index) => {
-				item.classList.toggle('highlighted', index === highlightedIndex);
-			});
+    function updateHighlight(items) {
+      items.forEach((item, index) => {
+        item.classList.toggle("highlighted", index === highlightedIndex);
+      });
 
-			if (highlightedIndex >= 0 && items[highlightedIndex]) {
-				items[highlightedIndex].scrollIntoView({ block: 'nearest' });
-			}
-		}
+      if (highlightedIndex >= 0 && items[highlightedIndex]) {
+        items[highlightedIndex].scrollIntoView({ block: "nearest" });
+      }
+    }
 
-		window.removeRepo = removeRepo;
+    window.removeRepo = removeRepo;
 
-		browser.storage.local.get(['platform', 'githubUsername']).then((items) => {
-			const platform = items.platform || 'github';
-			const platformUsernameKey = `${platform}Username`;
-			const username = items[platformUsernameKey];
-			if (username && useRepoFilter.checked && availableRepos.length === 0) {
-				setTimeout(() => loadRepos(), 1000);
-			}
-		});
-	}
+    browser.storage.local.get(["platform", "githubUsername"]).then((items) => {
+      const platform = items.platform || "github";
+      const platformUsernameKey = `${platform}Username`;
+      const username = items[platformUsernameKey];
+      if (username && useRepoFilter.checked && availableRepos.length === 0) {
+        setTimeout(() => loadRepos(), 1000);
+      }
+    });
+  }
 });
 
-const cacheInput = document.getElementById('cacheInput');
+const cacheInput = document.getElementById("cacheInput");
 if (cacheInput) {
-	browser.storage.local.get(['cacheInput']).then((result) => {
-		if (result.cacheInput) {
-			cacheInput.value = result.cacheInput;
-		} else {
-			cacheInput.value = 10;
-		}
-	});
+  browser.storage.local.get(["cacheInput"]).then((result) => {
+    if (result.cacheInput) {
+      cacheInput.value = result.cacheInput;
+    } else {
+      cacheInput.value = 10;
+    }
+  });
 
-	cacheInput.addEventListener('blur', function () {
-		let ttlValue = Number.parseInt(this.value, 10);
-		if (Number.isNaN(ttlValue) || ttlValue <= 0 || this.value.trim() === '') {
-			ttlValue = 10;
-			this.value = ttlValue;
-			this.style.borderColor = '#ef4444';
-		} else if (ttlValue > 1440) {
-			ttlValue = 1440;
-			this.value = ttlValue;
-			this.style.borderColor = '#f59e0b';
-		} else {
-			this.style.borderColor = '#10b981';
-		}
+  cacheInput.addEventListener("blur", function () {
+    let ttlValue = Number.parseInt(this.value, 10);
+    if (Number.isNaN(ttlValue) || ttlValue <= 0 || this.value.trim() === "") {
+      ttlValue = 10;
+      this.value = ttlValue;
+      this.style.borderColor = "#ef4444";
+    } else if (ttlValue > 1440) {
+      ttlValue = 1440;
+      this.value = ttlValue;
+      this.style.borderColor = "#f59e0b";
+    } else {
+      this.style.borderColor = "#10b981";
+    }
 
-		browser.storage.local.set({ cacheInput: ttlValue }).then(() => {
-			console.log('Cache TTL saved:', ttlValue, 'minutes');
-		});
-	});
+    browser.storage.local.set({ cacheInput: ttlValue }).then(() => {
+      console.log("Cache TTL saved:", ttlValue, "minutes");
+    });
+  });
 }
 
-browser.storage.local.get(['platform']).then((result) => {
-	const platform = result.platform || 'github';
-	platformSelect.value = platform;
-	updatePlatformUI(platform);
+browser.storage.local.get(["platform"]).then((result) => {
+  const platform = result.platform || "github";
+  platformSelect.value = platform;
+  updatePlatformUI(platform);
 });
 
 // Update UI for platform
 function updatePlatformUI(platform) {
-	const usernameLabel = document.getElementById('usernameLabel');
-	if (usernameLabel) {
-		if (platform === 'gitlab') {
-			usernameLabel.setAttribute('data-i18n', 'gitlabUsernameLabel');
-		} else {
-			usernameLabel.setAttribute('data-i18n', 'githubUsernameLabel');
-		}
-		const key = usernameLabel.getAttribute('data-i18n');
-		const message = browser.i18n.getMessage(key);
-		if (message) {
-			usernameLabel.textContent = message;
-		}
-	}
+  const usernameLabel = document.getElementById("usernameLabel");
+  if (usernameLabel) {
+    if (platform === "gitlab") {
+      usernameLabel.setAttribute("data-i18n", "gitlabUsernameLabel");
+    } else {
+      usernameLabel.setAttribute("data-i18n", "githubUsernameLabel");
+    }
+    const key = usernameLabel.getAttribute("data-i18n");
+    const message = browser.i18n.getMessage(key);
+    if (message) {
+      usernameLabel.textContent = message;
+    }
+  }
 
-	const orgSection = document.querySelector('.orgSection');
-	if (orgSection) {
-		if (platform === 'gitlab') {
-			orgSection.classList.add('hidden');
-		} else {
-			orgSection.classList.remove('hidden');
-		}
-	}
-	const githubOnlySections = document.querySelectorAll('.githubOnlySection');
-	githubOnlySections.forEach((el) => {
-		if (platform === 'gitlab') {
-			el.classList.add('hidden');
-		} else {
-			el.classList.remove('hidden');
-		}
-	});
-	const gitlabOnlySections = document.querySelectorAll('.gitlabOnlySection');
-	gitlabOnlySections.forEach((el) => {
-		if (platform === 'github') {
-			el.classList.add('hidden');
-		} else {
-			el.classList.remove('hidden');
-		}
-	});
+  const orgSection = document.querySelector(".orgSection");
+  if (orgSection) {
+    if (platform === "gitlab") {
+      orgSection.classList.add("hidden");
+    } else {
+      orgSection.classList.remove("hidden");
+    }
+  }
+  const githubOnlySections = document.querySelectorAll(".githubOnlySection");
+  githubOnlySections.forEach((el) => {
+    if (platform === "gitlab") {
+      el.classList.add("hidden");
+    } else {
+      el.classList.remove("hidden");
+    }
+  });
+  const gitlabOnlySections = document.querySelectorAll(".gitlabOnlySection");
+  gitlabOnlySections.forEach((el) => {
+    if (platform === "github") {
+      el.classList.add("hidden");
+    } else {
+      el.classList.remove("hidden");
+    }
+  });
 }
 
-platformSelect.addEventListener('change', () => {
-	const platform = platformSelect.value;
-	browser.storage.local.set({ platform }).then(() => {
-		const scrumReport = document.getElementById('scrumReport');
-		if (scrumReport) {
-			scrumReport.innerHTML = '';
-		}
-		const generateBtn = document.getElementById('generateReport');
-		if (typeof bootstrapScrumReportOnPopupLoad === 'function') {
-			bootstrapScrumReportOnPopupLoad(generateBtn);
-		}
-	});
-	const platformUsername = document.getElementById('platformUsername');
-	if (platformUsername) {
-		const currentPlatform = platformSelect.value === 'github' ? 'gitlab' : 'github'; // Get the platform we're switching from
-		const currentUsername = platformUsername.value;
-		if (currentUsername.trim()) {
-			browser.storage.local.set({ [`${currentPlatform}Username`]: currentUsername });
-		}
-	}
+platformSelect.addEventListener("change", () => {
+  const platform = platformSelect.value;
+  browser.storage.local.set({ platform }).then(() => {
+    const scrumReport = document.getElementById("scrumReport");
+    if (scrumReport) {
+      scrumReport.innerHTML = "";
+    }
+    const generateBtn = document.getElementById("generateReport");
+    if (typeof bootstrapScrumReportOnPopupLoad === "function") {
+      bootstrapScrumReportOnPopupLoad(generateBtn);
+    }
+  });
+  const platformUsername = document.getElementById("platformUsername");
+  if (platformUsername) {
+    const currentPlatform =
+      platformSelect.value === "github" ? "gitlab" : "github"; // Get the platform we're switching from
+    const currentUsername = platformUsername.value;
+    if (currentUsername.trim()) {
+      browser.storage.local.set({
+        [`${currentPlatform}Username`]: currentUsername,
+      });
+    }
+  }
 
-	browser.storage.local.get([`${platform}Username`]).then((result) => {
-		if (platformUsername) {
-			platformUsername.value = result[`${platform}Username`] || '';
-			window.updateGenerateButtonState && window.updateGenerateButtonState();
-		}
-	});
+  browser.storage.local.get([`${platform}Username`]).then((result) => {
+    if (platformUsername) {
+      platformUsername.value = result[`${platform}Username`] || "";
+      window.updateGenerateButtonState && window.updateGenerateButtonState();
+    }
+  });
 
-	updatePlatformUI(platform);
+  updatePlatformUI(platform);
 });
 
-const customDropdown = document.getElementById('customPlatformDropdown');
-const dropdownBtn = document.getElementById('platformDropdownBtn');
-const dropdownList = document.getElementById('platformDropdownList');
-const dropdownSelected = document.getElementById('platformDropdownSelected');
-const platformSelectHidden = document.getElementById('platformSelect');
+const customDropdown = document.getElementById("customPlatformDropdown");
+const dropdownBtn = document.getElementById("platformDropdownBtn");
+const dropdownList = document.getElementById("platformDropdownList");
+const dropdownSelected = document.getElementById("platformDropdownSelected");
+const platformSelectHidden = document.getElementById("platformSelect");
 
 function buildScrumSubjectFromPopup() {
-	const projectName = document.getElementById('projectName')?.value?.trim() || '';
-	const now = new Date();
-	const dateCode =
-		String(now.getFullYear()) + String(now.getMonth() + 1).padStart(2, '0') + String(now.getDate()).padStart(2, '0');
+  const projectName =
+    document.getElementById("projectName")?.value?.trim() || "";
+  const now = new Date();
+  const dateCode =
+    String(now.getFullYear()) +
+    String(now.getMonth() + 1).padStart(2, "0") +
+    String(now.getDate()).padStart(2, "0");
 
-	return `[Scrum]${projectName ? ' - ' + projectName : ''} - ${dateCode}`;
+  return `[Scrum]${projectName ? " - " + projectName : ""} - ${dateCode}`;
 }
 
 function setPlatformDropdown(value) {
-	if (value === 'gitlab') {
-		dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
-	} else {
-		dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
-	}
+  if (value === "gitlab") {
+    dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
+  } else {
+    dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
+  }
 
-	const platformUsername = document.getElementById('platformUsername');
-	if (platformUsername) {
-		const currentPlatform = platformSelectHidden.value;
-		const currentUsername = platformUsername.value;
-		if (currentUsername.trim()) {
-			browser.storage.local.set({ [`${currentPlatform}Username`]: currentUsername });
-		}
-	}
+  const platformUsername = document.getElementById("platformUsername");
+  if (platformUsername) {
+    const currentPlatform = platformSelectHidden.value;
+    const currentUsername = platformUsername.value;
+    if (currentUsername.trim()) {
+      browser.storage.local.set({
+        [`${currentPlatform}Username`]: currentUsername,
+      });
+    }
+  }
 
-	platformSelectHidden.value = value;
-	browser.storage.local.set({ platform: value }).then(() => {
-		const scrumReport = document.getElementById('scrumReport');
-		if (scrumReport) scrumReport.innerHTML = '';
+  platformSelectHidden.value = value;
+  browser.storage.local.set({ platform: value }).then(() => {
+    const scrumReport = document.getElementById("scrumReport");
+    if (scrumReport) scrumReport.innerHTML = "";
 
-		const generateBtn = document.getElementById('generateReport');
-		if (typeof bootstrapScrumReportOnPopupLoad === 'function') {
-			bootstrapScrumReportOnPopupLoad(generateBtn);
-		}
-	});
+    const generateBtn = document.getElementById("generateReport");
+    if (typeof bootstrapScrumReportOnPopupLoad === "function") {
+      bootstrapScrumReportOnPopupLoad(generateBtn);
+    }
+  });
 
-	browser.storage.local.get([`${value}Username`]).then((result) => {
-		if (platformUsername) {
-			platformUsername.value = result[`${value}Username`] || '';
-			window.updateGenerateButtonState && window.updateGenerateButtonState();
-		}
-	});
+  browser.storage.local.get([`${value}Username`]).then((result) => {
+    if (platformUsername) {
+      platformUsername.value = result[`${value}Username`] || "";
+      window.updateGenerateButtonState && window.updateGenerateButtonState();
+    }
+  });
 
-	updatePlatformUI(value);
+  updatePlatformUI(value);
 }
 
-dropdownBtn.addEventListener('click', (e) => {
-	e.stopPropagation();
-	customDropdown.classList.toggle('open');
-	dropdownList.classList.toggle('hidden');
+dropdownBtn.addEventListener("click", (e) => {
+  e.stopPropagation();
+  customDropdown.classList.toggle("open");
+  dropdownList.classList.toggle("hidden");
 });
 
-dropdownList.querySelectorAll('li').forEach((item) => {
-	item.addEventListener('click', function (e) {
-		const newPlatform = this.getAttribute('data-value');
-		const currentPlatform = platformSelectHidden.value;
-		const platformUsername = document.getElementById('platformUsername');
-		const usernameError = document.getElementById('usernameError');
-		platformUsername.classList.remove('input-error');
-		usernameError.classList.remove('errorMessage');
-		usernameError.textContent = '';
+dropdownList.querySelectorAll("li").forEach((item) => {
+  item.addEventListener("click", function (e) {
+    const newPlatform = this.getAttribute("data-value");
+    const currentPlatform = platformSelectHidden.value;
+    const platformUsername = document.getElementById("platformUsername");
+    const usernameError = document.getElementById("usernameError");
+    platformUsername.classList.remove("input-error");
+    usernameError.classList.remove("errorMessage");
+    usernameError.textContent = "";
 
-		if (newPlatform !== currentPlatform) {
-			const platformUsername = document.getElementById('platformUsername');
-			if (platformUsername) {
-				const currentUsername = platformUsername.value;
-				if (currentUsername.trim()) {
-					browser.storage.local.set({ [`${currentPlatform}Username`]: currentUsername });
-				}
-			}
-		}
+    if (newPlatform !== currentPlatform) {
+      const platformUsername = document.getElementById("platformUsername");
+      if (platformUsername) {
+        const currentUsername = platformUsername.value;
+        if (currentUsername.trim()) {
+          browser.storage.local.set({
+            [`${currentPlatform}Username`]: currentUsername,
+          });
+        }
+      }
+    }
 
-		setPlatformDropdown(newPlatform);
-		customDropdown.classList.remove('open');
-		dropdownList.classList.add('hidden');
-	});
+    setPlatformDropdown(newPlatform);
+    customDropdown.classList.remove("open");
+    dropdownList.classList.add("hidden");
+  });
 });
 
-document.addEventListener('click', (e) => {
-	if (!customDropdown.contains(e.target)) {
-		customDropdown.classList.remove('open');
-		dropdownList.classList.add('hidden');
-	}
+document.addEventListener("click", (e) => {
+  if (!customDropdown.contains(e.target)) {
+    customDropdown.classList.remove("open");
+    dropdownList.classList.add("hidden");
+  }
 });
 
 // Keyboard navigation
-platformDropdownBtn.addEventListener('keydown', (e) => {
-	if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
-		e.preventDefault();
-		customDropdown.classList.add('open');
-		dropdownList.classList.remove('hidden');
-		dropdownList.querySelector('li').focus();
-	}
+platformDropdownBtn.addEventListener("keydown", (e) => {
+  if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+    e.preventDefault();
+    customDropdown.classList.add("open");
+    dropdownList.classList.remove("hidden");
+    dropdownList.querySelector("li").focus();
+  }
 });
-dropdownList.querySelectorAll('li').forEach((item, idx, arr) => {
-	item.setAttribute('tabindex', '0');
-	item.addEventListener('keydown', function (e) {
-		if (e.key === 'ArrowDown') {
-			e.preventDefault();
-			(arr[idx + 1] || arr[0]).focus();
-		} else if (e.key === 'ArrowUp') {
-			e.preventDefault();
-			(arr[idx - 1] || arr[arr.length - 1]).focus();
-		} else if (e.key === 'Enter' || e.key === ' ') {
-			e.preventDefault();
-			const newPlatform = this.getAttribute('data-value');
-			const currentPlatform = platformSelectHidden.value;
+dropdownList.querySelectorAll("li").forEach((item, idx, arr) => {
+  item.setAttribute("tabindex", "0");
+  item.addEventListener("keydown", function (e) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      (arr[idx + 1] || arr[0]).focus();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      (arr[idx - 1] || arr[arr.length - 1]).focus();
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      const newPlatform = this.getAttribute("data-value");
+      const currentPlatform = platformSelectHidden.value;
 
-			// Save current username for current platform before switching
-			if (newPlatform !== currentPlatform) {
-				const platformUsername = document.getElementById('platformUsername');
-				if (platformUsername) {
-					const currentUsername = platformUsername.value;
-					if (currentUsername.trim()) {
-						browser.storage.local.set({ [`${currentPlatform}Username`]: currentUsername });
-					}
-				}
-			}
+      // Save current username for current platform before switching
+      if (newPlatform !== currentPlatform) {
+        const platformUsername = document.getElementById("platformUsername");
+        if (platformUsername) {
+          const currentUsername = platformUsername.value;
+          if (currentUsername.trim()) {
+            browser.storage.local.set({
+              [`${currentPlatform}Username`]: currentUsername,
+            });
+          }
+        }
+      }
 
-			setPlatformDropdown(newPlatform);
-			customDropdown.classList.remove('open');
-			dropdownList.classList.add('hidden');
-			dropdownBtn.focus();
-		}
-	});
+      setPlatformDropdown(newPlatform);
+      customDropdown.classList.remove("open");
+      dropdownList.classList.add("hidden");
+      dropdownBtn.focus();
+    }
+  });
 });
 
 // On load, restore platform from storage
-browser.storage.local.get(['platform']).then((result) => {
-	const platform = result.platform || 'github';
-	// Just update the UI without clearing username when restoring from storage
-	if (platform === 'gitlab') {
-		dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
-	} else {
-		dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
-	}
-	platformSelectHidden.value = platform;
-	updatePlatformUI(platform);
+browser.storage.local.get(["platform"]).then((result) => {
+  const platform = result.platform || "github";
+  // Just update the UI without clearing username when restoring from storage
+  if (platform === "gitlab") {
+    dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
+  } else {
+    dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
+  }
+  platformSelectHidden.value = platform;
+  updatePlatformUI(platform);
 });
 
 // Tooltip bubble
-document.querySelectorAll('.tooltip-container').forEach((container) => {
-	const bubble = container.querySelector('.tooltip-bubble');
-	if (!bubble) return;
+document.querySelectorAll(".tooltip-container").forEach((container) => {
+  const bubble = container.querySelector(".tooltip-bubble");
+  if (!bubble) return;
 
-	function positionTooltip() {
-		const icon = container.querySelector('.question-icon') || container;
-		const rect = icon.getBoundingClientRect();
-		const bubbleRect = bubble.getBoundingClientRect();
-		const padding = 8;
+  function positionTooltip() {
+    const icon = container.querySelector(".question-icon") || container;
+    const rect = icon.getBoundingClientRect();
+    const bubbleRect = bubble.getBoundingClientRect();
+    const padding = 8;
 
-		let top = rect.top + window.scrollY;
-		let left = rect.right + padding + window.scrollX;
+    let top = rect.top + window.scrollY;
+    let left = rect.right + padding + window.scrollX;
 
-		if (left + bubbleRect.width > window.innerWidth - 10) {
-			left = rect.left - bubbleRect.width - padding + window.scrollX;
-		}
-		if (left < 8) left = 8;
-		if (top + bubbleRect.height > window.innerHeight - 10) {
-			top = rect.top - bubbleRect.height - padding + window.scrollY;
-		}
-		if (top < 8) top = 8;
+    if (left + bubbleRect.width > window.innerWidth - 10) {
+      left = rect.left - bubbleRect.width - padding + window.scrollX;
+    }
+    if (left < 8) left = 8;
+    if (top + bubbleRect.height > window.innerHeight - 10) {
+      top = rect.top - bubbleRect.height - padding + window.scrollY;
+    }
+    if (top < 8) top = 8;
 
-		bubble.style.left = left + 'px';
-		bubble.style.top = top + 'px';
-	}
+    bubble.style.left = left + "px";
+    bubble.style.top = top + "px";
+  }
 
-	container.addEventListener('mouseenter', positionTooltip);
-	container.addEventListener('focusin', positionTooltip);
-	container.addEventListener('mousemove', positionTooltip);
-	container.addEventListener('mouseleave', () => {
-		bubble.style.left = '';
-		bubble.style.top = '';
-	});
-	container.addEventListener('focusout', () => {
-		bubble.style.left = '';
-		bubble.style.top = '';
-	});
+  container.addEventListener("mouseenter", positionTooltip);
+  container.addEventListener("focusin", positionTooltip);
+  container.addEventListener("mousemove", positionTooltip);
+  container.addEventListener("mouseleave", () => {
+    bubble.style.left = "";
+    bubble.style.top = "";
+  });
+  container.addEventListener("focusout", () => {
+    bubble.style.left = "";
+    bubble.style.top = "";
+  });
 });
 
 // Radio button click handlers with toggle functionality
 document.querySelectorAll('input[name="timeframe"]').forEach((radio) => {
-	radio.addEventListener('click', function () {
-		if (this.dataset.wasChecked === 'true') {
-			this.checked = false;
-			this.dataset.wasChecked = 'false';
+  radio.addEventListener("click", function () {
+    if (this.dataset.wasChecked === "true") {
+      this.checked = false;
+      this.dataset.wasChecked = "false";
 
-			const startDateInput = document.getElementById('startingDate');
-			const endDateInput = document.getElementById('endingDate');
-			startDateInput.readOnly = false;
-			endDateInput.readOnly = false;
+      const startDateInput = document.getElementById("startingDate");
+      const endDateInput = document.getElementById("endingDate");
+      startDateInput.readOnly = false;
+      endDateInput.readOnly = false;
 
-			browser.storage.local.set({
-				yesterdayContribution: false,
-				selectedTimeframe: null,
-			});
-		} else {
-			document.querySelectorAll('input[name="timeframe"]').forEach((r) => {
-				r.dataset.wasChecked = 'false';
-			});
-			this.dataset.wasChecked = 'true';
-			toggleRadio(this);
-		}
-	});
+      browser.storage.local.set({
+        yesterdayContribution: false,
+        selectedTimeframe: null,
+      });
+    } else {
+      document.querySelectorAll('input[name="timeframe"]').forEach((r) => {
+        r.dataset.wasChecked = "false";
+      });
+      this.dataset.wasChecked = "true";
+      toggleRadio(this);
+    }
+  });
 
-	// Handle clicks on links within scrumReport to open in new tabs
-	document.addEventListener(
-		'click',
-		(e) => {
-			const target = e.target.closest('a');
-			if (target && target.closest('#scrumReport')) {
-				e.preventDefault();
-				e.stopPropagation();
-				e.stopImmediatePropagation();
-				const href = target.getAttribute('href');
-				if (href && href.startsWith('http')) {
-					browser.tabs.create({ url: href });
-				}
-				return false;
-			}
-		},
-		true,
-	); // Use capture phase to handle before contentEditable
+  // Handle clicks on links within scrumReport to open in new tabs
+  document.addEventListener(
+    "click",
+    (e) => {
+      const target = e.target.closest("a");
+      if (target && target.closest("#scrumReport")) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        const href = target.getAttribute("href");
+        if (href && href.startsWith("http")) {
+          browser.tabs.create({ url: href });
+        }
+        return false;
+      }
+    },
+    true,
+  ); // Use capture phase to handle before contentEditable
 });
 
-// refresh cache button
+// DIFF 2: refreshCache button resets the cache badge to "no cache" state
+// after clearing storage, so the UI accurately reflects there is nothing cached.
+document
+  .getElementById("refreshCache")
+  .addEventListener("click", async function () {
+    const originalText = this.innerHTML;
 
-document.getElementById('refreshCache').addEventListener('click', async function () {
-	const originalText = this.innerHTML;
+    this.classList.add("loading");
+    this.innerHTML = `<i class="fa fa-refresh fa-spin"></i><span>${browser.i18n.getMessage("refreshingButton")}</span>`;
+    this.disabled = true;
 
-	this.classList.add('loading');
-	this.innerHTML = `<i class="fa fa-refresh fa-spin"></i><span>${browser.i18n.getMessage('refreshingButton')}</span>`;
-	this.disabled = true;
+    try {
+      // Determine platform
+      let platform = "github";
+      try {
+        const items = await browser.storage.local.get(["platform"]);
+        platform = items.platform || "github";
+      } catch (e) {}
 
-	try {
-		// Determine platform
-		let platform = 'github';
-		try {
-			const items = await browser.storage.local.get(['platform']);
-			platform = items.platform || 'github';
-		} catch (e) {}
+      // Clear all caches
+      const keysToRemove = ["githubCache", "repoCache", "gitlabCache"];
+      await browser.storage.local.remove(keysToRemove);
 
-		// Clear all caches
-		const keysToRemove = ['githubCache', 'repoCache', 'gitlabCache'];
-		await browser.storage.local.remove(keysToRemove);
+      // Clear the scrum report
+      const scrumReport = document.getElementById("scrumReport");
+      if (scrumReport) {
+        scrumReport.innerHTML = `<p style="text-align: center; color: #666; padding: 20px;">${browser.i18n.getMessage("cacheClearedMessage")}</p>`;
+      }
 
-		// Clear the scrum report
-		const scrumReport = document.getElementById('scrumReport');
-		if (scrumReport) {
-			scrumReport.innerHTML = `<p style="text-align: center; color: #666; padding: 20px;">${browser.i18n.getMessage('cacheClearedMessage')}</p>`;
-		}
+      if (typeof availableRepos !== "undefined") {
+        availableRepos = [];
+      }
 
-		if (typeof availableRepos !== 'undefined') {
-			availableRepos = [];
-		}
+      const repoStatus = document.getElementById("repoStatus");
+      if (repoStatus) {
+        repoStatus.textContent = "";
+      }
 
-		const repoStatus = document.getElementById('repoStatus');
-		if (repoStatus) {
-			repoStatus.textContent = '';
-		}
+      this.innerHTML = `<i class="fa fa-check"></i><span>${browser.i18n.getMessage("cacheClearedButton")}</span>`;
+      this.classList.remove("loading");
 
-		this.innerHTML = `<i class="fa fa-check"></i><span>${browser.i18n.getMessage('cacheClearedButton')}</span>`;
-		this.classList.remove('loading');
+      // Reset badge to "no cache" since storage was just wiped
+      updateCacheStatusBadge(null, 10 * 60 * 1000);
+      stopCacheAgeTicker();
 
-		// Do NOT trigger report generation automatically
+      // Do NOT trigger report generation automatically
 
-		setTimeout(() => {
-			this.innerHTML = originalText;
-			this.disabled = false;
-		}, 2000);
-	} catch (error) {
-		console.error('Cache clear failed:', error);
-		this.innerHTML = `<i class="fa fa-exclamation-triangle"></i><span>${browser.i18n.getMessage('cacheClearFailed')}</span>`;
-		this.classList.remove('loading');
+      setTimeout(() => {
+        this.innerHTML = originalText;
+        this.disabled = false;
+      }, 2000);
+    } catch (error) {
+      console.error("Cache clear failed:", error);
+      this.innerHTML = `<i class="fa fa-exclamation-triangle"></i><span>${browser.i18n.getMessage("cacheClearFailed")}</span>`;
+      this.classList.remove("loading");
 
-		setTimeout(() => {
-			this.innerHTML = originalText;
-			this.disabled = false;
-		}, 3000);
-	}
-});
+      setTimeout(() => {
+        this.innerHTML = originalText;
+        this.disabled = false;
+      }, 3000);
+    }
+  });
 
 function toggleRadio(radio) {
-	const startDateInput = document.getElementById('startingDate');
-	const endDateInput = document.getElementById('endingDate');
+  const startDateInput = document.getElementById("startingDate");
+  const endDateInput = document.getElementById("endingDate");
 
-	console.log('Toggling radio:', radio.id);
+  console.log("Toggling radio:", radio.id);
 
-	if (radio.id === 'yesterdayContribution') {
-		startDateInput.value = getYesterday();
-		endDateInput.value = getToday();
-	}
+  if (radio.id === "yesterdayContribution") {
+    startDateInput.value = getYesterday();
+    endDateInput.value = getToday();
+  }
 
-	startDateInput.readOnly = endDateInput.readOnly = true;
+  startDateInput.readOnly = endDateInput.readOnly = true;
 
-	browser.storage.local
-		.set({
-			startingDate: startDateInput.value,
-			endingDate: endDateInput.value,
-			yesterdayContribution: radio.id === 'yesterdayContribution',
-			selectedTimeframe: radio.id,
-			githubCache: null, // Clear cache to force new fetch
-		})
-		.then(() => {
-			console.log('State saved, dates:', {
-				start: startDateInput.value,
-				end: endDateInput.value,
-			});
+  browser.storage.local
+    .set({
+      startingDate: startDateInput.value,
+      endingDate: endDateInput.value,
+      yesterdayContribution: radio.id === "yesterdayContribution",
+      selectedTimeframe: radio.id,
+      githubCache: null, // Clear cache to force new fetch
+    })
+    .then(() => {
+      console.log("State saved, dates:", {
+        start: startDateInput.value,
+        end: endDateInput.value,
+      });
 
-			triggerRepoFetchIfEnabled();
-		});
+      triggerRepoFetchIfEnabled();
+    });
 }
 
 async function triggerRepoFetchIfEnabled() {
-	if (window.triggerRepoFetchIfEnabled) {
-		await window.triggerRepoFetchIfEnabled();
-	}
+  if (window.triggerRepoFetchIfEnabled) {
+    await window.triggerRepoFetchIfEnabled();
+  }
 }
 
 // Keyboard shortcuts: Ctrl+G / Cmd+G to generate, Ctrl+Shift+Y / Cmd+Shift+Y to copy, Ctrl+Shift+M / Cmd+Shift+M to insert in email
-document.addEventListener('keydown', (e) => {
-	if (!document.hasFocus()) {
-		return;
-	}
+document.addEventListener("keydown", (e) => {
+  if (!document.hasFocus()) {
+    return;
+  }
 
-	const target = e.target;
-	const tagName = target?.tagName;
-	const editableAncestor = typeof target?.closest === 'function' ? target.closest('[contenteditable="true"]') : null;
-	const isFormField = tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT';
-	const isContentEditable = !!(editableAncestor || (target && target.isContentEditable));
+  const target = e.target;
+  const tagName = target?.tagName;
+  const editableAncestor =
+    typeof target?.closest === "function"
+      ? target.closest('[contenteditable="true"]')
+      : null;
+  const isFormField =
+    tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT";
+  const isContentEditable = !!(
+    editableAncestor ||
+    (target && target.isContentEditable)
+  );
 
-	if (isFormField || isContentEditable) {
-		return;
-	}
+  if (isFormField || isContentEditable) {
+    return;
+  }
 
-	const key = (e.key || '').toLowerCase();
-	const modifier = isMacOS() ? e.metaKey : e.ctrlKey;
+  const key = (e.key || "").toLowerCase();
+  const modifier = isMacOS() ? e.metaKey : e.ctrlKey;
 
-	const generateBtn = document.getElementById('generateReport');
-	const copyBtn = document.getElementById('copyReport');
-	const insertEmailBtn = document.getElementById('insertInEmail');
+  const generateBtn = document.getElementById("generateReport");
+  const copyBtn = document.getElementById("copyReport");
+  const insertEmailBtn = document.getElementById("insertInEmail");
 
-	if (modifier && !e.shiftKey && !e.altKey && key === 'g' && !e.repeat && generateBtn && !generateBtn.disabled) {
-		e.preventDefault();
-		showShortcutNotification('generatingReportNotification');
-		generateBtn.click();
-	}
+  if (
+    modifier &&
+    !e.shiftKey &&
+    !e.altKey &&
+    key === "g" &&
+    !e.repeat &&
+    generateBtn &&
+    !generateBtn.disabled
+  ) {
+    e.preventDefault();
+    showShortcutNotification("generatingReportNotification");
+    generateBtn.click();
+  }
 
-	if (modifier && e.shiftKey && !e.altKey && key === 'y' && !e.repeat && copyBtn && !copyBtn.disabled) {
-		e.preventDefault();
-		showShortcutNotification('copyingReportNotification');
-		copyBtn._triggeredByShortcut = true;
-		copyBtn.click();
-	}
+  if (
+    modifier &&
+    e.shiftKey &&
+    !e.altKey &&
+    key === "y" &&
+    !e.repeat &&
+    copyBtn &&
+    !copyBtn.disabled
+  ) {
+    e.preventDefault();
+    showShortcutNotification("copyingReportNotification");
+    copyBtn._triggeredByShortcut = true;
+    copyBtn.click();
+  }
 
-	if (modifier && e.shiftKey && !e.altKey && key === 'm' && !e.repeat && insertEmailBtn && !insertEmailBtn.disabled) {
-		e.preventDefault();
-		showShortcutNotification('insertingInEmailNotification');
-		insertEmailBtn._triggeredByShortcut = true;
-		insertEmailBtn.click();
-	}
+  if (
+    modifier &&
+    e.shiftKey &&
+    !e.altKey &&
+    key === "m" &&
+    !e.repeat &&
+    insertEmailBtn &&
+    !insertEmailBtn.disabled
+  ) {
+    e.preventDefault();
+    showShortcutNotification("insertingInEmailNotification");
+    insertEmailBtn._triggeredByShortcut = true;
+    insertEmailBtn.click();
+  }
 });
 
-// Validate organization only when user is done typing (on blur)
+// Validate organization only when user is done typing
 function validateOrgOnBlur(org) {
-	console.log('[Org Check] Checking organization on blur:', org);
-	fetch(`https://api.github.com/orgs/${org}`)
-		.then((res) => {
-			console.log('[Org Check] Response status for', org, ':', res.status);
-			if (res.status === 404) {
-				console.log('[Org Check] Organization not found on GitHub:', org);
-				showPopupMessage(browser.i18n.getMessage('orgNotFoundMessage'));
-				return;
-			}
-			window.clearScrumHelperToast?.();
-			console.log('[Org Check] Organisation exists on GitHub:', org);
-			browser.storage.local.remove(['githubCache', 'repoCache']);
-			triggerRepoFetchIfEnabled();
-		})
-		.catch((err) => {
-			console.log('[Org Check] Error validating organisation:', org, err);
-			showPopupMessage(browser.i18n.getMessage('orgValidationErrorMessage'), { variant: 'error' });
-		});
+  console.log("[Org Check] Checking organization on blur:", org);
+  fetch(`https://api.github.com/orgs/${org}`)
+    .then((res) => {
+      console.log("[Org Check] Response status for", org, ":", res.status);
+      if (res.status === 404) {
+        console.log("[Org Check] Organization not found on GitHub:", org);
+        showPopupMessage(browser.i18n.getMessage("orgNotFoundMessage"));
+        return;
+      }
+      window.clearScrumHelperToast?.();
+      console.log("[Org Check] Organisation exists on GitHub:", org);
+      browser.storage.local.remove(["githubCache", "repoCache"]);
+      triggerRepoFetchIfEnabled();
+    })
+    .catch((err) => {
+      console.log("[Org Check] Error validating organisation:", org, err);
+      showPopupMessage(browser.i18n.getMessage("orgValidationErrorMessage"), {
+        variant: "error",
+      });
+    });
 }


### PR DESCRIPTION
### 📌 Fixes

Fixes #574 

---

## 📝 Summary of Changes

- Added a cache status badge below the scrum report showing Cached · X min ago (green), Stale · X min ago (amber), or No cache (grey) depending on cache state and configured TTL
- Badge hides when Generate is clicked and resets to "No cache" when the Refresh Data button clears storage
- Added a stale nudge line ("Data may be outdated. Click Generate to refresh.") that appears only when cache has exceeded TTL
- Badge uses aria-live="polite" and role="status" for screen reader support
- Added 5 i18n keys to _locales/en/messages.json (cacheStatusNoCache, cacheStatusFresh, cacheStatusStale, cacheStatusTooltip, cacheStaleWarning-)
- All badge styles are self-contained in popup.html and include dark mode variants
---


### ✅ Checklist

- [x] I’ve tested my changes locally
- [x] I’ve added tests (if applicable)
- [x] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

