### PR TITLE
feat: integrate Gitea platform support for Scrum reports

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -77,10 +77,11 @@
 		}
 
 		/* Firefox Sidebar Fixes ONLY */
-		html.firefox-sidebar, 
+		html.firefox-sidebar,
 		body.firefox-sidebar {
 			min-width: 100% !important;
 		}
+
 		body.firefox-sidebar #popupRoot {
 			min-width: 100% !important;
 		}
@@ -90,7 +91,7 @@
 <body class="mode-sidepanel text-gray-800 bg-gray-50 flex flex-col font-sans">
 
 	<div id="scrumHelperToastContainer" class="scrum-toast-container"></div>
-	
+
 	<div id="popupRoot" class="pl-1 py-2 rounded-2xl">
 		<div class="bg-white px-4 py-4 mx-2 mb-2 rounded-3xl">
 			<div class="flex justify-between py-2">
@@ -146,6 +147,10 @@
 									class="hover:bg-gray-100" data-value="gitlab">
 									<i class="fab fa-gitlab" style="margin-right: 12px; font-size: 18px;"></i> GitLab
 								</li>
+								<li style="padding-left: 8px; padding-right: 16px; padding-top: 8px; padding-bottom: 8px; display: flex; align-items: center; cursor: pointer;"
+									class="hover:bg-gray-100" data-value="gitea">
+									<i class="fa fa-code" style="margin-right: 12px; font-size: 18px;"></i> Gitea
+								</li>
 							</ul>
 						</div>
 					</div>
@@ -166,7 +171,8 @@
 
 						<input id="projectName" type="text"
 							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2"
-							data-i18n-placeholder="projectNamePlaceholder" style="margin-top: 0.3rem; margin-bottom: 0.8rem;">
+							data-i18n-placeholder="projectNamePlaceholder"
+							style="margin-top: 0.3rem; margin-bottom: 0.8rem;">
 					</div>
 					<div>
 
@@ -180,7 +186,8 @@
 					</div>
 
 					<div>
-						<p class="text-lg mb-1 font-medium text-sm" data-i18n="contributionsLabel" style="margin-top: 0.6rem;">Fetch your
+						<p class="text-lg mb-1 font-medium text-sm" data-i18n="contributionsLabel"
+							style="margin-top: 0.6rem;">Fetch your
 							contributions between:</p>
 
 
@@ -213,9 +220,11 @@
 					</div>
 
 					<details class="group mb-4" style="margin-top: 1rem;">
-						<summary class="flex items-center justify-between cursor-pointer list-none font-medium text-sm outline-none select-none pr-1">
+						<summary
+							class="flex items-center justify-between cursor-pointer list-none font-medium text-sm outline-none select-none pr-1">
 							<span data-i18n="advancedFiltersLabel">Advanced Filters</span>
-							<i class="fa fa-chevron-down text-gray-500 w-4 text-center transition-transform duration-200 group-open:-rotate-180"></i>
+							<i
+								class="fa fa-chevron-down text-gray-500 w-4 text-center transition-transform duration-200 group-open:-rotate-180"></i>
 						</summary>
 						<div class="mt-4 border-l-2 border-gray-200" style="margin-left: 0.25rem; padding-left: 1rem;">
 							<div class="my-2 flex items-center">
@@ -235,7 +244,8 @@
 									<span class="tooltip-container">
 										<i class="fa fa-question-circle question-icon"></i>
 										<span class="tooltip-bubble" data-i18n="onlyIssuesTooltip">
-											If checked, the report will only include issues created or assigned to the user.
+											If checked, the report will only include issues created or assigned to the
+											user.
 										</span>
 									</span>
 								</div>
@@ -244,8 +254,8 @@
 							<div class="my-4">
 								<div class="flex items-center">
 									<input type="checkbox" id="onlyPRs" class="form-checkbox text-blue-600">
-									<label for="onlyPRs" class="font-medium text-sm flex items-center" style="margin-left: 4px;"
-										data-i18n="onlyPRsLabel">
+									<label for="onlyPRs" class="font-medium text-sm flex items-center"
+										style="margin-left: 4px;" data-i18n="onlyPRsLabel">
 										Include only PRs in the report
 									</label>
 									<span class="tooltip-container">
@@ -283,24 +293,27 @@
 									<span class="tooltip-container">
 										<i class="fa fa-question-circle question-icon"></i>
 										<span class="tooltip-bubble" data-i18n="onlyMergedPRsTooltip">
-											If checked, the report will only include merged PRs. A GitHub token is required.
+											If checked, the report will only include merged PRs. A GitHub token is
+											required.
 										</span>
 									</span>
 								</div>
 								<div id="tokenWarningForMergedPRs"
 									class="hidden text-xs text-red-600 p-2 bg-red-50 border border-red-200 rounded-xl mt-2">
-									<span data-i18n="tokenRequiredMergedPRsWarning">A GitHub token is required to filter by merged PRs. Please add one in the settings.</span>
+									<span data-i18n="tokenRequiredMergedPRsWarning">A GitHub token is required to filter
+										by merged PRs. Please add one in the settings.</span>
 								</div>
 							</div>
 
 							<div class="my-4 githubOnlySection">
 								<div class="flex items-center">
-									<input type="checkbox" id="showCommits" checked class="form-checkbox text-blue-600 ">
+									<input type="checkbox" id="showCommits" checked
+										class="form-checkbox text-blue-600 ">
 
 									<label id="showCommitsLabel" for="showCommits"
-										class="font-medium text-sm flex items-center pl-5 ml-4" style="margin-left: 4px;"
-										data-i18n="showCommitsLabel">Show commits on open PRs/ draft PRs</label><span
-										class="tooltip-container">
+										class="font-medium text-sm flex items-center pl-5 ml-4"
+										style="margin-left: 4px;" data-i18n="showCommitsLabel">Show commits on open PRs/
+										draft PRs</label><span class="tooltip-container">
 										<i class="fa fa-question-circle question-icon"></i>
 										<span class="tooltip-bubble" data-i18n="showCommitsTooltip">
 											Github Token required, add it in the settings.
@@ -310,7 +323,8 @@
 								</div>
 								<div id="tokenWarningForShowCommits"
 									class="hidden text-xs text-red-600 p-2 bg-red-50 border border-red-200 rounded-xl mt-2">
-									<span data-i18n="tokenRequiredShowCommitsWarning">A GitHub token is required to show commits
+									<span data-i18n="tokenRequiredShowCommitsWarning">A GitHub token is required to show
+										commits
 										on open or draft PRs. Please add one in the settings.</span>
 								</div>
 							</div>
@@ -504,7 +518,8 @@
 									<i class="fa fa-question-circle question-icon"></i>
 									<span class="tooltip-bubble" data-i18n="gitlabTokenTooltip">
 										<b>Why add a GitLab token?</b><br>
-										Scrum Helper works without a token for public projects, but a personal access token enables
+										Scrum Helper works without a token for public projects, but a personal access
+										token enables
 										private repos and better rate limits. Your token stays local and is only used to
 										fetch your GitLab data.<br><br>
 										<b>How to get one:</b><br>
@@ -526,6 +541,17 @@
 						<input id="gitlabToken" type="password"
 							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2 pr-10"
 							data-i18n-placeholder="gitlabTokenPlaceholder">
+					</div>
+
+					<div class="giteaOnlySection hidden mt-3">
+						<div class="flex items-center justify-between">
+							<div class="flex">
+								<p class="text-sm font-medium" data-i18n="giteaBaseUrlLabel">Gitea Base URL</p>
+							</div>
+						</div>
+						<input id="giteaBaseUrl" type="text"
+							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2"
+							data-i18n-placeholder="giteaBaseUrlPlaceholder" value="https://gitea.com">
 					</div>
 
 					<div class="cacheSection mt-3">
@@ -615,14 +641,15 @@
 		</div>
 	</div>
 	<!-- WebExtensions Polyfill for Cross-Browser compatibility (Chrome, Firefox, Edge, etc.) -->
-	 <script src="libs/purify.min.js"></script>
-	 <script src="scripts/domSanitizer.js"></script>
+	<script src="libs/purify.min.js"></script>
+	<script src="scripts/domSanitizer.js"></script>
 	<script src="scripts/browser-polyfill.min.js"></script>
 	<script src="scripts/jquery-3.2.1.min.js"></script>
 	<script type="text/javascript" src="materialize/js/materialize.min.js"></script>
 	<script src="scripts/emailClientAdapter.js"></script>
 	<script src="scripts/main.js"></script>
 	<script src="scripts/gitlabHelper.js"></script>
+	<script src="scripts/giteaHelper.js"></script>
 	<script src="scripts/scrumHelper.js"></script>
 	<script src="scripts/popup.js"></script>
 </body>

--- a/src/scripts/giteaHelper.js
+++ b/src/scripts/giteaHelper.js
@@ -1,0 +1,163 @@
+// Gitea API Helper for Scrum Helper Extension
+const DEFAULT_GITEA_API_BASE_URL = 'https://gitea.com/api/v1';
+
+function normalizeGiteaApiBaseUrl(apiBaseUrl) {
+	const value = typeof apiBaseUrl === 'string' && apiBaseUrl.trim() ? apiBaseUrl.trim() : DEFAULT_GITEA_API_BASE_URL;
+	let url = value.replace(/\/+$/, '');
+	if (!url.includes('/api/v1')) {
+		url = `${url}/api/v1`;
+	}
+	return url;
+}
+
+class GiteaHelper {
+	constructor(apiBaseUrl = DEFAULT_GITEA_API_BASE_URL) {
+		this.baseUrl = normalizeGiteaApiBaseUrl(apiBaseUrl);
+		this.cache = {
+			data: null,
+			cacheKey: null,
+			timestamp: 0,
+			ttl: 10 * 60 * 1000, // 10 minutes
+			fetching: false,
+			queue: [],
+		};
+	}
+
+	async getCacheTTL() {
+		try {
+			const items = await browser.storage.local.get(['cacheInput']);
+			return items.cacheInput ? Number.parseInt(items.cacheInput, 10) * 60 * 1000 : 10 * 60 * 1000;
+		} catch (error) {
+			console.error('Error getting cache TTL:', error);
+			return 10 * 60 * 1000;
+		}
+	}
+
+	async saveToStorage(data) {
+		try {
+			await browser.storage.local.set({
+				giteaCache: {
+					data: data,
+					cacheKey: this.cache.cacheKey,
+					timestamp: this.cache.timestamp,
+				},
+			});
+		} catch (error) {
+			console.error('Error saving to storage:', error);
+		}
+	}
+
+	async loadFromStorage() {
+		try {
+			const items = await browser.storage.local.get(['giteaCache']);
+			if (items.giteaCache) {
+				this.cache.data = items.giteaCache.data;
+				this.cache.cacheKey = items.giteaCache.cacheKey;
+				this.cache.timestamp = items.giteaCache.timestamp;
+			}
+		} catch (error) {
+			console.error('Error loading from storage:', error);
+		}
+	}
+
+	async fetchGiteaData(username, startDate, endDate) {
+		const cacheKey = `${this.baseUrl}-${username}-${startDate}-${endDate}`;
+
+		if (!this.cache.data && !this.cache.fetching) {
+			await this.loadFromStorage();
+		}
+
+		this.cache.ttl = await this.getCacheTTL();
+
+		const now = Date.now();
+		const isCacheFresh = now - this.cache.timestamp < this.cache.ttl;
+		const isCacheKeyMatch = this.cache.cacheKey === cacheKey;
+
+		if (this.cache.data && isCacheFresh && isCacheKeyMatch) {
+			return this.cache.data;
+		}
+
+		if (!isCacheKeyMatch) {
+			this.cache.data = null;
+		}
+
+		if (this.cache.fetching) {
+			return new Promise((resolve, reject) => {
+				this.cache.queue.push({ resolve, reject });
+			});
+		}
+
+		this.cache.fetching = true;
+		this.cache.cacheKey = cacheKey;
+
+		try {
+			// Throttle 500ms to avoid burst
+			await new Promise((res) => setTimeout(res, 500));
+
+			// Verify user exists
+			const userRes = await fetch(`${this.baseUrl}/users/${username}`);
+			if (!userRes.ok) {
+				if (userRes.status === 404) {
+					throw new Error(
+						(typeof chrome !== 'undefined' && chrome?.i18n?.getMessage('giteaUserNotFoundError', [username])) ||
+						`Gitea user '${username}' not found`,
+					);
+				}
+				throw new Error(
+					(typeof chrome !== 'undefined' && chrome?.i18n?.getMessage('giteaUserFetchError', [userRes.status, userRes.statusText])) ||
+					`Error fetching Gitea user: ${userRes.status} ${userRes.statusText}`,
+				);
+			}
+			const user = await userRes.json();
+
+			// Single API call to get all PRs created by user in date range
+			const url = `${this.baseUrl}/repos/issues/search?type=pulls&created_by=${username}&since=${startDate}T00:00:00Z&before=${endDate}T23:59:59Z&limit=50&state=all`;
+			const res = await fetch(url);
+			if (!res.ok) {
+				throw new Error(
+					(typeof chrome !== 'undefined' && chrome?.i18n?.getMessage('giteaPRReviewFetchError', [res.status, res.statusText])) ||
+					`Error fetching Gitea pull requests: ${res.status} ${res.statusText}`,
+				);
+			}
+			const pullRequests = await res.json();
+
+			const giteaData = {
+				user: user,
+				pullRequests: pullRequests || [],
+				issues: [],
+			};
+
+			// Cache the data
+			this.cache.data = giteaData;
+			this.cache.timestamp = Date.now();
+			await this.saveToStorage(giteaData);
+
+			this.cache.queue.forEach(({ resolve }) => resolve(giteaData));
+			this.cache.queue = [];
+
+			return giteaData;
+		} catch (err) {
+			console.error('Gitea Fetch Failed:', err);
+			this.cache.queue.forEach(({ reject }) => reject(err));
+			this.cache.queue = [];
+			throw err;
+		} finally {
+			this.cache.fetching = false;
+		}
+	}
+
+	processGiteaData(data) {
+		return {
+			pullRequests: data.pullRequests || [],
+			issues: data.issues || [],
+			user: data.user,
+		};
+	}
+}
+
+// Export for use in other scripts
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = GiteaHelper;
+} else {
+	window.GiteaHelper = GiteaHelper;
+}

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -164,6 +164,7 @@ function handleBodyOnLoad() {
 			'platform',
 			'githubUsername',
 			'gitlabUsername',
+			'giteaUsername',
 			'projectName',
 			'startingDate',
 			'endingDate',

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -457,18 +457,19 @@ document.addEventListener('DOMContentLoaded', () => {
 			return;
 		}
 
-		const { platform, cacheInput, githubCache, gitlabCache } = await storageLocalGet([
+		const { platform, cacheInput, githubCache, gitlabCache, giteaCache } = await storageLocalGet([
 			'platform',
 			'cacheInput',
 			'githubCache',
 			'gitlabCache',
+			'giteaCache',
 		]);
 
 		const ttlMinutes = parsePositiveInt(cacheInput) ?? 10;
 		const ttlMs = ttlMinutes * 60 * 1000;
 
 		const activePlatform = platform || 'github';
-		const cache = activePlatform === 'gitlab' ? gitlabCache : githubCache;
+		const cache = activePlatform === 'gitlab' ? gitlabCache : activePlatform === 'gitea' ? giteaCache : githubCache;
 
 		const hasCacheData = !!cache?.data;
 		const timestamp = typeof cache?.timestamp === 'number' ? cache.timestamp : 0;
@@ -492,6 +493,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				'lastScrumReportUsername',
 				'githubUsername',
 				'gitlabUsername',
+				'giteaUsername',
 				'platformUsername',
 			]);
 
@@ -512,7 +514,9 @@ document.addEventListener('DOMContentLoaded', () => {
 			const expectedUsername =
 				activePlatform === 'gitlab'
 					? storageValues.gitlabUsername || storageValues.platformUsername
-					: storageValues.githubUsername || storageValues.platformUsername;
+					: activePlatform === 'gitea'
+						? storageValues.giteaUsername || storageValues.platformUsername
+						: storageValues.githubUsername || storageValues.platformUsername;
 
 			const isUsernameMatch = lastScrumReportUsername
 				? lastScrumReportUsername === expectedUsername
@@ -1121,7 +1125,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			try {
 				const items = await browser.storage.local.get(['platform']);
 				platform = items.platform || 'github';
-			} catch {}
+			} catch { }
 			if (platform !== 'github') {
 				// Do not run repo fetch for non-GitHub platforms
 				if (repoStatus)
@@ -1211,7 +1215,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				try {
 					const items = await browser.storage.local.get(['platform']);
 					platform = items.platform || 'github';
-				} catch {}
+				} catch { }
 				if (platform !== 'github') {
 					repoFilterContainer.classList.add('hidden');
 					useRepoFilter.checked = false;
@@ -1396,7 +1400,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			try {
 				const items = await browser.storage.local.get(['platform']);
 				platform = items.platform || 'github';
-			} catch {}
+			} catch { }
 			if (platform !== 'github') {
 				if (repoStatus)
 					repoStatus.textContent =
@@ -1438,7 +1442,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			try {
 				const items = await browser.storage.local.get(['platform']);
 				platform = items.platform || 'github';
-			} catch (e) {}
+			} catch (e) { }
 			if (platform !== 'github') {
 				if (repoStatus)
 					repoStatus.textContent =
@@ -1709,6 +1713,8 @@ function updatePlatformUI(platform) {
 	if (usernameLabel) {
 		if (platform === 'gitlab') {
 			usernameLabel.setAttribute('data-i18n', 'gitlabUsernameLabel');
+		} else if (platform === 'gitea') {
+			usernameLabel.setAttribute('data-i18n', 'giteaUsernameLabel');
 		} else {
 			usernameLabel.setAttribute('data-i18n', 'githubUsernameLabel');
 		}
@@ -1721,7 +1727,7 @@ function updatePlatformUI(platform) {
 
 	const orgSection = document.querySelector('.orgSection');
 	if (orgSection) {
-		if (platform === 'gitlab') {
+		if (platform === 'gitlab' || platform === 'gitea') {
 			orgSection.classList.add('hidden');
 		} else {
 			orgSection.classList.remove('hidden');
@@ -1729,7 +1735,7 @@ function updatePlatformUI(platform) {
 	}
 	const githubOnlySections = document.querySelectorAll('.githubOnlySection');
 	githubOnlySections.forEach((el) => {
-		if (platform === 'gitlab') {
+		if (platform === 'gitlab' || platform === 'gitea') {
 			el.classList.add('hidden');
 		} else {
 			el.classList.remove('hidden');
@@ -1737,10 +1743,10 @@ function updatePlatformUI(platform) {
 	});
 	const gitlabOnlySections = document.querySelectorAll('.gitlabOnlySection');
 	gitlabOnlySections.forEach((el) => {
-		if (platform === 'github') {
-			el.classList.add('hidden');
-		} else {
+		if (platform === 'gitlab') {
 			el.classList.remove('hidden');
+		} else {
+			el.classList.add('hidden');
 		}
 	});
 }
@@ -1759,7 +1765,7 @@ platformSelect.addEventListener('change', () => {
 	});
 	const platformUsername = document.getElementById('platformUsername');
 	if (platformUsername) {
-		const currentPlatform = platformSelect.value === 'github' ? 'gitlab' : 'github'; // Get the platform we're switching from
+		const currentPlatform = platformSelectHidden.value; // Get the platform we're switching from
 		const currentUsername = platformUsername.value;
 		if (currentUsername.trim()) {
 			browser.storage.local.set({ [`${currentPlatform}Username`]: currentUsername });
@@ -1794,6 +1800,8 @@ function buildScrumSubjectFromPopup() {
 function setPlatformDropdown(value) {
 	if (value === 'gitlab') {
 		dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
+	} else if (value === 'gitea') {
+		dropdownSelected.innerHTML = '<i class="fa fa-code mr-2"></i> Gitea';
 	} else {
 		dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
 	}
@@ -1915,6 +1923,8 @@ browser.storage.local.get(['platform']).then((result) => {
 	// Just update the UI without clearing username when restoring from storage
 	if (platform === 'gitlab') {
 		dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
+	} else if (platform === 'gitea') {
+		dropdownSelected.innerHTML = '<i class="fa fa-code mr-2"></i> Gitea';
 	} else {
 		dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
 	}
@@ -2022,10 +2032,10 @@ document.getElementById('refreshCache').addEventListener('click', async function
 		try {
 			const items = await browser.storage.local.get(['platform']);
 			platform = items.platform || 'github';
-		} catch (e) {}
+		} catch (e) { }
 
 		// Clear all caches
-		const keysToRemove = ['githubCache', 'repoCache', 'gitlabCache'];
+		const keysToRemove = ['githubCache', 'repoCache', 'gitlabCache', 'giteaCache'];
 		await browser.storage.local.remove(keysToRemove);
 
 		// Clear the scrum report

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -22,6 +22,7 @@ let platformUsername = '';
 let gitlabToken = '';
 let gitlabBaseUrl = '';
 let gitlabHelper = null;
+let giteaHelper = null;
 let usernameValidationListenerAttached = false;
 
 const scrumReportEl = document.getElementById('scrumReport');
@@ -95,10 +96,54 @@ function mapGitLabReportData(data, gitlabApiBaseUrl) {
 	};
 }
 
+function mapGiteaReportItem(item, type, giteaApiBaseUrl) {
+	let repoName = 'unknown';
+	let repoUrl = '';
+	if (item.repository) {
+		repoName = item.repository.name;
+		repoUrl = item.repository.html_url || item.repository.url;
+	} else if (item.html_url) {
+		const parts = item.html_url.split('/');
+		if (parts.length >= 5) {
+			repoName = parts[4];
+			repoUrl = parts.slice(0, 5).join('/');
+		}
+	}
+
+	return {
+		...item,
+		repository_url: repoUrl,
+		html_url: item.html_url,
+		number: item.number,
+		title: item.title,
+		state: type === 'issue' && item.state === 'open' ? 'open' : item.state,
+		project: repoName,
+		pull_request: typeof item.pull_request === 'object' && item.pull_request !== null ? item.pull_request : (type === 'pr' || type === 'mr' ? { merged_at: item.merged_at || null } : false),
+	};
+}
+
+function mapGiteaReportData(data, giteaApiBaseUrl) {
+	const mappedIssues = (data.issues || []).map((issue) =>
+		mapGiteaReportItem(issue, 'issue', giteaApiBaseUrl),
+	);
+	const mappedPRs = (data.pullRequests || []).map((pr) =>
+		mapGiteaReportItem(pr, 'pr', giteaApiBaseUrl),
+	);
+
+	return {
+		githubIssuesData: { items: mappedIssues },
+		githubPrsReviewData: { items: mappedPRs },
+		githubUserData: data.user || {},
+	};
+}
+
 function allIncluded(outputTarget = 'email') {
 	// Always re-instantiate gitlabHelper for gitlab platform to ensure fresh cache after refresh
 	if (platform === 'gitlab' || (typeof platform === 'undefined' && window.GitLabHelper)) {
 		gitlabHelper = new window.GitLabHelper(gitlabBaseUrl);
+	}
+	if (platform === 'gitea' || (typeof platform === 'undefined' && window.GiteaHelper)) {
+		giteaHelper = new window.GiteaHelper();
 	}
 	if (scrumGenerationInProgress) {
 		return;
@@ -349,6 +394,97 @@ function allIncluded(outputTarget = 'email') {
 								});
 						}
 						// --- FIX END ---
+					} else {
+						if (outputTarget === 'popup') {
+							const generateBtn = document.getElementById('generateReport');
+							const ErrMessage =
+								chrome.i18n.getMessage('usernameRequiredError') || 'Please enter your username to generate a report.';
+							handleUsernameValidationError(ErrMessage);
+							if (generateBtn) {
+								generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
+								generateBtn.disabled = false;
+							}
+						}
+						scrumGenerationInProgress = false;
+					}
+				} else if (platform === 'gitea') {
+					if (!giteaHelper) giteaHelper = new window.GiteaHelper();
+					if (platformUsernameLocal) {
+						const generateBtn = document.getElementById('generateReport');
+						if (generateBtn && outputTarget === 'popup') {
+							generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
+							generateBtn.disabled = true;
+						}
+
+						if (outputTarget === 'email') {
+							(async () => {
+								try {
+									const data = await giteaHelper.fetchGiteaData(
+										platformUsernameLocal,
+										startingDate,
+										endingDate
+									);
+
+									const mappedData = mapGiteaReportData(data, giteaHelper.baseUrl);
+									githubUserData = mappedData.githubUserData;
+
+									const name =
+										githubUserData?.name || githubUserData?.username || platformUsernameLocal || platformUsername;
+									const project = projectName;
+									const curDate = new Date();
+									const year = curDate.getFullYear().toString();
+									let date = curDate.getDate();
+									let month = curDate.getMonth() + 1;
+									if (month < 10) month = '0' + month;
+									if (date < 10) date = '0' + date;
+									const dateCode = year.toString() + month.toString() + date.toString();
+									const subject = `[Scrum]${project ? ' - ' + project : ''} - ${dateCode}`;
+									subjectForEmail = subject;
+
+									await processGithubData(mappedData, true, subjectForEmail);
+									scrumGenerationInProgress = false;
+								} catch (err) {
+									console.error('Gitea fetch failed:', err);
+									if (outputTarget === 'popup') {
+										if (generateBtn) {
+											generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
+											generateBtn.disabled = false;
+										}
+										const ErrMessage = `${err.message || 'Error fetching Gitea data.'}`;
+										if (typeof ErrMessage === 'string' && ErrMessage.toLowerCase().includes('not found')) {
+											handleUsernameValidationError(ErrMessage);
+										} else {
+											showReportMessage(ErrMessage);
+										}
+									}
+									scrumGenerationInProgress = false;
+								}
+							})();
+						} else {
+							giteaHelper
+								.fetchGiteaData(platformUsernameLocal, startingDate, endingDate)
+								.then((data) => {
+									const mappedData = mapGiteaReportData(data, giteaHelper.baseUrl);
+									processGithubData(mappedData);
+									scrumGenerationInProgress = false;
+								})
+								.catch((err) => {
+									console.error('Gitea fetch failed:', err);
+									if (outputTarget === 'popup') {
+										if (generateBtn) {
+											generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
+											generateBtn.disabled = false;
+										}
+										const ErrMessage = `${err.message || 'Error fetching Gitea data.'}`;
+										if (typeof ErrMessage === 'string' && ErrMessage.toLowerCase().includes('not found')) {
+											handleUsernameValidationError(ErrMessage);
+										} else {
+											showReportMessage(ErrMessage);
+										}
+									}
+									scrumGenerationInProgress = false;
+								});
+						}
 					} else {
 						if (outputTarget === 'popup') {
 							const generateBtn = document.getElementById('generateReport');
@@ -1030,7 +1166,7 @@ function allIncluded(outputTarget = 'email') {
 		log('[SCRUM-DEBUG] Processing issues for main activity:', githubIssuesData?.items);
 		if (platform === 'github') {
 			await writeGithubIssuesPrs(githubIssuesData?.items || []);
-		} else if (platform === 'gitlab') {
+		} else if (platform === 'gitlab' || platform === 'gitea') {
 			await writeGithubIssuesPrs(githubIssuesData?.items || []);
 			await writeGithubIssuesPrs(githubPrsReviewData?.items || []);
 		}
@@ -1650,7 +1786,7 @@ ${blockerText}`;
 			const repository_url = item.repository_url;
 			// Use project name for GitLab, repo extraction for GitHub
 			const project =
-				platform === 'gitlab' && item.project
+				(platform === 'gitlab' || platform === 'gitea') && item.project && item.project !== 'unknown'
 					? item.project
 					: repository_url
 						? repository_url.substr(repository_url.lastIndexOf('/') + 1)
@@ -1702,7 +1838,7 @@ ${blockerText}`;
 				// Check if PR has commits in the date range
 				const hasCommitsInRange = item._allCommits && item._allCommits.length > 0;
 
-				if (platform === 'github') {
+				if (platform === 'github' || platform === 'gitea') {
 					// For existing PRs (not new), they must be open AND have commits in the date range
 					if (!isNewPR) {
 						if (item.state !== 'open') {
@@ -1728,6 +1864,13 @@ ${blockerText}`;
 						prAction = 'Made Merge Request';
 					} else {
 						prAction = 'Updated Merge Request';
+					}
+				} else if (platform === 'gitea') {
+					prAction = isNewPR ? 'Made PR' : 'Updated PR';
+					if (isCreatedToday && item.state === 'open') {
+						prAction = 'Made PR';
+					} else {
+						prAction = 'Updated PR';
 					}
 				}
 
@@ -1764,6 +1907,9 @@ ${blockerText}`;
 						const owner = repoParts[repoParts.length - 2];
 						const repo = repoParts[repoParts.length - 1];
 						merged = mergedStatusResults[`${owner}/${repo}#${number}`];
+					}
+					if (platform === 'gitea' && item.pull_request && item.pull_request.merged_at) {
+						merged = true;
 					}
 					if (merged === true) {
 						li = `<li><i>(${project})</i> - ${prAction} <a href='${html_url}' target='_blank' rel='noopener noreferrer' contenteditable='false'>(#${number})</a> - <a href='${html_url}' target='_blank' rel='noopener noreferrer' contenteditable='false'>${title}</a>${showOpenLabel ? ' ' + pr_merged_button : ''}</li>`;
@@ -1981,6 +2127,24 @@ async function forceGitlabDataRefresh() {
 	return { success: true };
 }
 
+async function forceGiteaDataRefresh() {
+	if (window.GiteaHelper && giteaHelper instanceof window.GiteaHelper) {
+		giteaHelper.cache.data = null;
+		giteaHelper.cache.cacheKey = null;
+		giteaHelper.cache.timestamp = 0;
+		giteaHelper.cache.fetching = false;
+		giteaHelper.cache.queue = [];
+	}
+	await new Promise((resolve) => {
+		chrome.storage.local.remove('giteaCache', resolve);
+	});
+	hasInjectedContent = false;
+	if (window.GiteaHelper) {
+		giteaHelper = new window.GiteaHelper();
+	}
+	return { success: true };
+}
+
 // Auto inject report on email client load
 // if (window.location.protocol.startsWith('http')) {
 // 	allIncluded('email');
@@ -2001,6 +2165,13 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 			const platform = result.platform || 'github';
 			if (platform === 'gitlab') {
 				forceGitlabDataRefresh()
+					.then((result) => sendResponse(result))
+					.catch((err) => {
+						console.error('Force refresh failed:', err);
+						sendResponse({ success: false, error: err.message });
+					});
+			} else if (platform === 'gitea') {
+				forceGiteaDataRefresh()
 					.then((result) => sendResponse(result))
 					.catch((err) => {
 						console.error('Force refresh failed:', err);
@@ -2070,12 +2241,12 @@ async function fetchPrsMergedStatusBatch(prs, headers) {
 	if (prs.length === 0) return results;
 	const query = `query {
 ${prs
-	.map(
-		(pr, i) => `	repo${i}: repository(owner: "${pr.owner}\", name: "${pr.repo}\") {
+			.map(
+				(pr, i) => `	repo${i}: repository(owner: "${pr.owner}\", name: "${pr.repo}\") {
 		pr${i}: pullRequest(number: ${pr.number}) { merged }
 	}`,
-	)
-	.join('\n')}
+			)
+			.join('\n')}
 }`;
 
 	try {
@@ -2257,8 +2428,8 @@ async function fetchUserRepositories(username, token, org = '') {
 				}));
 
 			return repos.sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
-		} catch (err) {}
-	} catch (err) {}
+		} catch (err) { }
+	} catch (err) { }
 }
 
 function filterDataByRepos(data, selectedRepos) {


### PR DESCRIPTION
Added giteaHelper.js to fetch PRs/issues, updated UI in popup.html/popup.js for Gitea platform selection, and modified scrumHelper.js to process and render Gitea API responses.

### 📌 Fixes

Resolves #652 

---

### 📝 Summary of Changes

Currently, Scrum Helper supports generating reports from GitHub and GitLab. This PR extends the platform support to include **Gitea**, allowing developers who use self-hosted Gitea instances or Gitea.com to generate their daily Scrum reports through the same extension.

- Added `giteaHelper.js` to handle API interactions, data fetching, and caching for the Gitea platform.
- Updated `popup.html` and `popup.js` to include the Gitea helper script, render Gitea as an option in the platform dropdown, and handle Gitea-specific cache clearing and UI state toggling.
- Updated `main.js` to properly persist the `giteaUsername` in local storage.
- Modified `scrumHelper.js` to orchestrate Gitea data fetching alongside GitHub and GitLab.
- Implemented `mapGiteaReportData` to safely parse repo names from Gitea's `html_url` and normalize the API responses.
- Adjusted rendering logic in `writeGithubIssuesPrs` to ensure Gitea PRs correctly show action labels ("Made PR" / "Updated PR") and accurately detect "Merged" statuses.

---

### 📸 Screenshots / Demo 


https://github.com/user-attachments/assets/317b7d84-34ec-41dd-8bc1-bedf0a1e4aa2


---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

The Gitea API does not expose the `repository` object in the standard `/repos/issues/search` response for pull requests. To work around this, I implemented logic in `mapGiteaReportItem` to parse the repository name cleanly from the `html_url`. The fallback logic ensures that the `(repo-name)` label displays correctly in the Scrum report.
