### PR TITLE
fix: trigger fresh data fetch when cache is expired on popup load

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -530,8 +530,8 @@ document.addEventListener('DOMContentLoaded', () => {
 					return;
 				}
 
-				setGenerateButtonLoading(generateBtn, true);
-				window.generateScrumReport();
+				if (generateBtn) setGenerateButtonLoading(generateBtn, true);
+				if (typeof window.generateScrumReport === 'function') window.generateScrumReport();
 				return;
 			}
 
@@ -540,13 +540,13 @@ document.addEventListener('DOMContentLoaded', () => {
 				scrumReport.innerHTML = sanitizeHtml(lastScrumReportHtml);
 			}
 
-			setGenerateButtonLoading(generateBtn, true);
-			window.generateScrumReport();
+			if (generateBtn) setGenerateButtonLoading(generateBtn, true);
+			if (typeof window.generateScrumReport === 'function') window.generateScrumReport();
 			return;
 		}
 
-		setGenerateButtonLoading(generateBtn, true);
-		window.generateScrumReport();
+		if (generateBtn) setGenerateButtonLoading(generateBtn, true);
+		if (typeof window.generateScrumReport === 'function') window.generateScrumReport();
 	}
 
 	function initializePopup() {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -540,7 +540,8 @@ document.addEventListener('DOMContentLoaded', () => {
 				scrumReport.innerHTML = sanitizeHtml(lastScrumReportHtml);
 			}
 
-			if (generateBtn) generateBtn.disabled = false;
+			setGenerateButtonLoading(generateBtn, true);
+			window.generateScrumReport();
 			return;
 		}
 


### PR DESCRIPTION
### 📌 Fixes

Fixes #651 

---

### 📝 Summary of Changes

**The Bug:**
The Scrum Helper extension was serving stale report data from the cache instead of fetching fresh data upon launch. When a user opened the extension after the cache had expired (e.g., the next day), the extension would correctly calculate that the cache was expired, display the stale HTML as a temporary placeholder, but then incorrectly execute an early `return;` without ever triggering a fresh fetch in the background. This forced users to manually click "Generate Report" to get accurate data.

**The Fix:**

I updated the cache loading logic in `popup.js` (around line 543). Now, if the cache is expired, the extension still briefly displays the stale HTML so the UI doesn't look empty, but it immediately puts the "Generate" button into a loading state and automatically triggers `window.generateScrumReport()` in the background to fetch fresh data.

---

### 📸 Screenshots / Demo 

https://github.com/user-attachments/assets/76bd6808-0e87-4c1a-be08-1d828c83ad9b

*As we can see in the video above, we set the cache TTL to 1 minute, and after waiting for it to expire and relaunching the extension, the generating button is automatically refreshed to fetch the fresh data.*

---

### ✅ Checklist
- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes
This fix ensures that the "Cache TTL" setting is strictly respected on extension launch, improving trust in the generated report's accuracy without degrading the perceived load time of the extension.

## Summary by Sourcery

Bug Fixes:
- Trigger an automatic report regeneration and loading state when opening the popup with an expired cached scrum report instead of leaving stale data and requiring manual user action.