### PR TITLE
fix: keep copy button disabled for empty reports

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -346,7 +346,7 @@
 							</div>
 
 							<div class="tooltip-container">
-								<button id="copyReport"
+								<button id="copyReport" disabled
 									class="flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded">
 									<i class="fa fa-copy"></i> <span data-i18n="copyReportButton">Copy</span>
 								</button>

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -444,6 +444,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 
 	window.updateGenerateButtonState = updateGenerateButtonState;
+	window.updateCopyButtonState = updateCopyButtonState;
 
 	function updateCopyButtonState() {
 		const copyBtn = document.getElementById('copyReport');
@@ -547,6 +548,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				if (reportEmpty && lastScrumReportHtml && matches) {
 					scrumReport.innerHTML = sanitizeHtml(lastScrumReportHtml);
 					delete scrumReport.dataset.copyPlaceholder;
+					updateCopyButtonState();
 					if (generateBtn) generateBtn.disabled = false;
 					return;
 				}
@@ -560,6 +562,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			if ((!scrumReport.innerHTML || !scrumReport.innerHTML.trim()) && lastScrumReportHtml && isUsernameMatch) {
 				scrumReport.innerHTML = sanitizeHtml(lastScrumReportHtml);
 				delete scrumReport.dataset.copyPlaceholder;
+				updateCopyButtonState();
 			}
 
 			if (generateBtn) generateBtn.disabled = false;
@@ -699,13 +702,6 @@ document.addEventListener('DOMContentLoaded', () => {
 					delete scrumReportEl.dataset.copyPlaceholder;
 				}
 				updateCopyButtonState();
-			});
-
-			const copyBtnObserver = new MutationObserver(updateCopyButtonState);
-			copyBtnObserver.observe(scrumReportEl, {
-				childList: true,
-				subtree: true,
-				characterData: true,
 			});
 		}
 
@@ -1801,6 +1797,7 @@ platformSelect.addEventListener('change', () => {
 		const scrumReport = document.getElementById('scrumReport');
 		if (scrumReport) {
 			scrumReport.innerHTML = '';
+			window.updateCopyButtonState?.();
 		}
 		const generateBtn = document.getElementById('generateReport');
 		if (typeof bootstrapScrumReportOnPopupLoad === 'function') {
@@ -1861,6 +1858,7 @@ function setPlatformDropdown(value) {
 	browser.storage.local.set({ platform: value }).then(() => {
 		const scrumReport = document.getElementById('scrumReport');
 		if (scrumReport) scrumReport.innerHTML = '';
+		window.updateCopyButtonState?.();
 
 		const generateBtn = document.getElementById('generateReport');
 		if (typeof bootstrapScrumReportOnPopupLoad === 'function') {
@@ -2083,6 +2081,7 @@ document.getElementById('refreshCache').addEventListener('click', async function
 		if (scrumReport) {
 			scrumReport.dataset.copyPlaceholder = 'true';
 			scrumReport.innerHTML = `<p style="text-align: center; color: #666; padding: 20px;">${browser.i18n.getMessage('cacheClearedMessage')}</p>`;
+			window.updateCopyButtonState?.();
 		}
 
 		if (typeof availableRepos !== 'undefined') {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -452,6 +452,16 @@ document.addEventListener('DOMContentLoaded', () => {
 			return;
 		}
 
+		const textContent = scrumReport.textContent;
+		const cacheClearedText =
+			(typeof browser !== 'undefined' && browser.i18n ? browser.i18n.getMessage('cacheClearedMessage') : null) ||
+			(typeof chrome !== 'undefined' && chrome.i18n ? chrome.i18n.getMessage('cacheClearedMessage') : null) ||
+			'Cache cleared successfully. Click "Generate" to fetch fresh data.';
+
+		if (textContent === cacheClearedText) {
+			scrumReport.dataset.copyPlaceholder = 'true';
+		}
+
 		copyBtn.disabled = scrumReport.dataset.copyPlaceholder === 'true' || !scrumReport.textContent.trim();
 	}
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -445,6 +445,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	window.updateGenerateButtonState = updateGenerateButtonState;
 
+	function updateCopyButtonState() {
+		const copyBtn = document.getElementById('copyReport');
+		const scrumReport = document.getElementById('scrumReport');
+		if (!copyBtn || !scrumReport) {
+			return;
+		}
+
+		copyBtn.disabled = scrumReport.dataset.copyPlaceholder === 'true' || !scrumReport.textContent.trim();
+	}
+
 	async function bootstrapScrumReportOnPopupLoad(generateBtn) {
 		console.log('[BOOTSTRAP] bootstrapScrumReportOnPopupLoad called');
 
@@ -526,6 +536,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 				if (reportEmpty && lastScrumReportHtml && matches) {
 					scrumReport.innerHTML = sanitizeHtml(lastScrumReportHtml);
+					delete scrumReport.dataset.copyPlaceholder;
 					if (generateBtn) generateBtn.disabled = false;
 					return;
 				}
@@ -538,6 +549,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			// If cache is expired, still only show the old HTML if it was for the current username
 			if ((!scrumReport.innerHTML || !scrumReport.innerHTML.trim()) && lastScrumReportHtml && isUsernameMatch) {
 				scrumReport.innerHTML = sanitizeHtml(lastScrumReportHtml);
+				delete scrumReport.dataset.copyPlaceholder;
 			}
 
 			if (generateBtn) generateBtn.disabled = false;
@@ -668,6 +680,25 @@ document.addEventListener('DOMContentLoaded', () => {
 		const copyBtn = document.getElementById('copyReport');
 		const insertBtn = document.getElementById('insertInEmail');
 
+		updateCopyButtonState();
+
+		const scrumReportEl = document.getElementById('scrumReport');
+		if (scrumReportEl) {
+			scrumReportEl.addEventListener('input', () => {
+				if (scrumReportEl.dataset.copyPlaceholder === 'true') {
+					delete scrumReportEl.dataset.copyPlaceholder;
+				}
+				updateCopyButtonState();
+			});
+
+			const copyBtnObserver = new MutationObserver(updateCopyButtonState);
+			copyBtnObserver.observe(scrumReportEl, {
+				childList: true,
+				subtree: true,
+				characterData: true,
+			});
+		}
+
 		if (insertBtn) {
 			insertBtn.addEventListener('click', () => {
 				const scrumReport = document.getElementById('scrumReport');
@@ -746,8 +777,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		copyBtn.addEventListener('click', function () {
 			const scrumReport = document.getElementById('scrumReport');
+			if (scrumReport?.dataset.copyPlaceholder === 'true') {
+				this._triggeredByShortcut = false;
+				return;
+			}
+			const reportHtml = scrumReport ? sanitizeHtml(scrumReport.innerHTML) : '';
 			const tempDiv = document.createElement('div');
 			tempDiv.innerHTML = sanitizeHtml(scrumReport.innerHTML);
+			if (!tempDiv.textContent.trim()) {
+				this._triggeredByShortcut = false;
+				return;
+			}
 
 			const darkMode = document.body.classList.contains('dark-mode');
 
@@ -2031,6 +2071,7 @@ document.getElementById('refreshCache').addEventListener('click', async function
 		// Clear the scrum report
 		const scrumReport = document.getElementById('scrumReport');
 		if (scrumReport) {
+			scrumReport.dataset.copyPlaceholder = 'true';
 			scrumReport.innerHTML = `<p style="text-align: center; color: #666; padding: 20px;">${browser.i18n.getMessage('cacheClearedMessage')}</p>`;
 		}
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -787,14 +787,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		copyBtn.addEventListener('click', function () {
 			const scrumReport = document.getElementById('scrumReport');
-			if (scrumReport?.dataset.copyPlaceholder === 'true') {
+			if (!scrumReport) {
 				this._triggeredByShortcut = false;
 				return;
 			}
-			const reportHtml = scrumReport ? sanitizeHtml(scrumReport.innerHTML) : '';
+			if (scrumReport.dataset.copyPlaceholder === 'true') {
+				this._triggeredByShortcut = false;
+				return;
+			}
+			const reportHtml = sanitizeHtml(scrumReport.innerHTML);
 			const tempDiv = document.createElement('div');
-			tempDiv.innerHTML = sanitizeHtml(scrumReport.innerHTML);
-			if (!tempDiv.textContent.trim()) {
+			tempDiv.innerHTML = reportHtml;
+			if (!(tempDiv.textContent || '').trim()) {
 				this._triggeredByShortcut = false;
 				return;
 			}

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1151,6 +1151,7 @@ ${blockerText}`;
 			if (scrumReport) {
 				log('Found popup div, updating content');
 				scrumReport.innerHTML = sanitizeHtml(content);
+				delete scrumReport.dataset.copyPlaceholder;
 				try {
 					const cacheKey =
 						platform === 'gitlab' ? (gitlabHelper?.cache?.cacheKey ?? null) : (githubCache?.cacheKey ?? null);

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -43,6 +43,7 @@ function showReportMessage(message) {
 	if (!message) return;
 	if (scrumReportEl) {
 		scrumReportEl.innerHTML = '';
+		window.updateCopyButtonState?.();
 	}
 	window.scrumHelperToast?.(message, { duration: 4000, variant: 'error' });
 }
@@ -56,6 +57,7 @@ function handleUsernameValidationError(errMessage) {
 
 	if (scrumReportEl) {
 		scrumReportEl.innerHTML = '';
+		window.updateCopyButtonState?.();
 	}
 }
 
@@ -1151,6 +1153,7 @@ ${blockerText}`;
 			if (scrumReport) {
 				log('Found popup div, updating content');
 				scrumReport.innerHTML = sanitizeHtml(content);
+				window.updateCopyButtonState?.();
 				delete scrumReport.dataset.copyPlaceholder;
 				try {
 					const cacheKey =


### PR DESCRIPTION
### 📌 Fixes

Fixes #497 

---

### 📝 Summary of Changes

- Disabled the Copy button by default when no Scrum report content is available.
- Added Copy button state updates based on the Scrum report content.
- Prevented empty report content from being copied and falsely showing the copied state.

---

### 📸 Screenshots / Demo (if UI-related)

[Demo.webm](https://github.com/user-attachments/assets/05e444f3-8a5c-40b3-a8bd-a73134b673c7)

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

- Disable the Scrum report Copy button when no report content is available and update its enabled state as the report changes.
- Prevent copying and indicating success when the Scrum report content is empty or only whitespace.
