### PR TITLE
feat: prompt users to add GitHub token on rate limit exceeded

### DIFF
--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -651,12 +651,26 @@ function allIncluded(outputTarget = 'email') {
 			log('Validating GitHub user existence for:', platformUsernameLocal);
 			const userCheckRes = await fetch(userUrl, { headers });
 
+			console.log('[SCRUM-HELPER] GitHub API Rate Limit:', userCheckRes.headers.get('x-ratelimit-limit'));
+			console.log('[SCRUM-HELPER] GitHub API Rate Limit Remaining:', userCheckRes.headers.get('x-ratelimit-remaining'));
+			const resetTime = userCheckRes.headers.get('x-ratelimit-reset');
+			if (resetTime) {
+				const resetDate = new Date(resetTime * 1000);
+				console.log('[SCRUM-HELPER] GitHub API Rate Limit Resets at:', resetDate.toLocaleString());
+			}
+
 			if (userCheckRes.status === 404) {
 				const errorMsg =
 					chrome?.i18n.getMessage('githubUserNotFoundError', [platformUsernameLocal]) ||
 					`GitHub user "${platformUsernameLocal}" not found.`;
 				logError(errorMsg);
 				throw new Error(errorMsg);
+			}
+
+			if (userCheckRes.status === 403 && userCheckRes.headers.get('x-ratelimit-remaining') === '0') {
+				showRateLimitMessage();
+				githubCache.fetching = false;
+				return;
 			}
 
 			if (userCheckRes.status === 401 || userCheckRes.status === 403) {
@@ -678,6 +692,14 @@ function allIncluded(outputTarget = 'email') {
 				fetch(prUrl, { headers }),
 				userCheckRes, // Reuse the already validated user response
 			]);
+
+			const isRateLimited = (res) => res.status === 403 && res.headers.get('x-ratelimit-remaining') === '0';
+
+			if (isRateLimited(issuesRes) || isRateLimited(prRes)) {
+				showRateLimitMessage();
+				githubCache.fetching = false;
+				return;
+			}
 
 			if (issuesRes.status === 401 || prRes.status === 401 || issuesRes.status === 403 || prRes.status === 403) {
 				showInvalidTokenMessage();
@@ -995,6 +1017,40 @@ function allIncluded(outputTarget = 'email') {
 				window.scrumHelperToast?.(errMsg, { duration: 4000, variant: 'error' });
 			}
 		}
+		scrumGenerationInProgress = false;
+	}
+
+	function showRateLimitMessage() {
+		const errMsg =
+			chrome?.i18n.getMessage('rateLimitExceededError') ||
+			'API rate limit exceeded. Please add a GitHub token in the Scrum Helper settings to increase your limit.';
+		if (outputTarget === 'popup') {
+			if (scrumReportEl) {
+				showReportMessage(errMsg);
+				const generateBtn = document.getElementById('generateReport');
+				if (generateBtn) {
+					generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
+					generateBtn.disabled = false;
+				}
+
+				// Automatically open settings so user can add token
+				const settingsToggle = document.getElementById('settingsToggle');
+				const settingsSection = document.getElementById('settingsSection');
+				if (settingsToggle && settingsSection && settingsSection.classList.contains('hidden')) {
+					settingsToggle.click();
+				}
+				const githubTokenInput = document.getElementById('githubToken');
+				if (githubTokenInput) {
+					setTimeout(() => {
+						githubTokenInput.scrollIntoView({ behavior: 'smooth', block: 'center' });
+						githubTokenInput.focus();
+					}, 100);
+				}
+			} else {
+				window.scrumHelperToast?.(errMsg, { duration: 4000, variant: 'error' });
+			}
+		}
+		scrumGenerationInProgress = false;
 	}
 
 	async function processGithubData(data) {


### PR DESCRIPTION
- Detect rate limit exhaustion explicitly by checking x-ratelimit-remaining headers.
- Automatically navigate the user to the token settings input when limit is reached.
- Fix UI state lock where 'scrumGenerationInProgress' was not reset on API errors.

### 📌 Fixes

Fixes #277 

---

### 📝 Summary of Changes

- **Added Specific Rate Limit Handling:** The extension now actively inspects the `x-ratelimit-remaining` headers. If an API request fails specifically due to the rate limit hitting `0`, users are presented with a tailored error prompt asking them to add a GitHub token rather than a generic 403 error.
- **Enhanced UX for Rate Limit Errors:** When the rate limit prompt is triggered, the settings menu automatically opens, scrolls to the GitHub Token input, and focuses the field so users can immediately paste their new token.
- **Improved API Logging:** Added un-suppressed console logs that print the current rate limit, remaining requests, and reset time during generation for easier developer debugging.
- **Fixed UI State Lock Bug:** Ensured `scrumGenerationInProgress` is properly reset to `false` when a rate limit or invalid token error is caught, preventing the "Generate" button from becoming permanently disabled.

---

### 📸 Screenshots / Demo (if UI-related)


https://github.com/user-attachments/assets/485cf600-9ab1-4873-92d5-0b2c3d7bbfd0


---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

- **UX Improvement:** To make adding the token as frictionless as possible, when the rate limit prompt is triggered, the code simulates a click on `settingsToggle` to automatically open the settings drawer, scrolls to the `githubToken` input field, and sets focus on it.
- **Bug Fix Note:** While testing the rate limits, I noticed that when the extension previously threw a `403` or `401` error inside `fetchGithubData` and returned early, it bypassed the catch block and failed to reset the `scrumGenerationInProgress` flag to `false`. This caused the UI to permanently lock up, disabling the "Generate" button until the extension was reloaded. I have fixed this by explicitly resetting the flag in both `showInvalidTokenMessage` and the new `showRateLimitMessage`.
- **Debugging Aid:** I added a few `console.log` statements in the fetch cycle to print the headers for the current rate limit usage and reset time. This will make debugging rate limit issues much easier for future contributors without needing to flip the `DEBUG` flag on.
