### PR TITLE
fix: prevent Generate button from staying stuck when cached data exists

### DIFF
--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -513,8 +513,8 @@ function allIncluded(outputTarget = 'email') {
 
 		const cacheKey = `${platformUsernameLocal}-${startDateForCache}-${endDateForCache}-${orgName || 'all'}`;
 
-		if (githubCache.fetching || (githubCache.cacheKey === cacheKey && githubCache.data)) {
-			log('Fetch already in progress or data already fetched. Skipping fetch.');
+		if (githubCache.fetching) {
+			log('Fetch already in progress. Skipping fetch.');
 			return;
 		}
 


### PR DESCRIPTION
## Summary
Fixes #660

When a report has already been generated, clicking Generate again
with the same settings causes the Generate button to stay
permanently stuck in the disabled "Generating..." state.

## Root Cause
In `fetchGithubData()` in `src/scripts/scrumHelper.js`,
the early return condition checks both whether a fetch is
in progress AND whether cached data already exists.
The cached data check causes an early return before
`processGithubData()` renders the report and before
the button state is reset to enabled.

## Fix
Removed the cached data check from the early return.
Now only returns early if a fetch is actively in progress.

Before:
if (githubCache.fetching || (githubCache.cacheKey === cacheKey && githubCache.data)) {
  log('Fetch already in progress or data already fetched. Skipping fetch.');
  return;
}

After:
if (githubCache.fetching) {
  log('Fetch already in progress. Skipping fetch.');
  return;
}

## How to Test
1. Load extension from dist/chrome as unpacked in Chrome
2. Enter any valid GitHub username and date range
3. Click Generate and wait for report to appear
4. Click Generate again without changing any settings
5. Verify button returns to normal enabled state
6. Verify report is rendered correctly

## Type of Change
- [x] Bug fix (non-breaking — restores intended behavior)

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My change is limited to 3 lines in 1 file
- [x] npm run build succeeds
- [x] npm run check passes
- [x] Linked to issue #660

## Summary by Sourcery

Bug Fixes:
- Prevent the Generate button from remaining disabled when regenerating a report with existing cached data by only skipping fetches that are actively in progress.