### PR TITLE
fix: tooltip apearance issues after clicking copy & insert btns

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -751,6 +751,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			}).finally(() => {
 				if (generateBtn._triggeredByShortcut) {
 					dismissShortcutTooltipFocus(generateBtn);
+					generateBtn._triggeredByShortcut = false;
 				}
 			});
 		});

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -749,7 +749,9 @@ document.addEventListener('DOMContentLoaded', () => {
 						});
 					});
 			}).finally(() => {
-				dismissShortcutTooltipFocus(generateBtn);
+				if (generateBtn._triggeredByShortcut) {
+					dismissShortcutTooltipFocus(generateBtn);
+				}
 			});
 		});
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -745,7 +745,7 @@ document.addEventListener('DOMContentLoaded', () => {
 							updatePlatformUI(platformSelect.value);
 							generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
 							generateBtn.disabled = true;
-							window.generateScrumReport && window.generateScrumReport();
+							return window.generateScrumReport && window.generateScrumReport();
 						});
 					});
 			}).finally(() => {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -663,6 +663,12 @@ document.addEventListener('DOMContentLoaded', () => {
 				checkTokenForMergedPRs();
 			});
 
+			function dismissShortcutTooltipFocus(el) {
+			try {
+				el?.blur?.();
+			} catch {}
+		}
+
 		// Button setup
 		const generateBtn = document.getElementById('generateReport');
 		const copyBtn = document.getElementById('copyReport');
@@ -714,6 +720,7 @@ document.addEventListener('DOMContentLoaded', () => {
 					})
 					.finally(() => {
 						insertBtn._triggeredByShortcut = false;
+						dismissShortcutTooltipFocus(insertBtn);
 					});
 			});
 		}
@@ -739,6 +746,7 @@ document.addEventListener('DOMContentLoaded', () => {
 							generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
 							generateBtn.disabled = true;
 							window.generateScrumReport && window.generateScrumReport();
+							dismissShortcutTooltipFocus(generateBtn);
 						});
 					});
 			});
@@ -803,6 +811,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				console.error('Failed to copy: ', err);
 			} finally {
 				this._triggeredByShortcut = false;
+				dismissShortcutTooltipFocus(this);
 				selection.removeAllRanges();
 				document.body.removeChild(tempDiv);
 			}

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -681,6 +681,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 				if (!content) {
 					insertBtn._triggeredByShortcut = false;
+					dismissShortcutTooltipFocus(insertBtn);
 					return;
 				}
 
@@ -732,22 +733,23 @@ document.addEventListener('DOMContentLoaded', () => {
 				const platform = result.platform || 'github';
 				const platformUsernameKey = `${platform}Username`;
 
-				browser.storage.local
+				return browser.storage.local
 					.set({
 						platform: platformSelect.value,
 						[platformUsernameKey]: platformUsername.value,
 					})
 					.then(() => {
 						// Reload platform from storage before generating report
-						browser.storage.local.get(['platform']).then((res) => {
+						return browser.storage.local.get(['platform']).then((res) => {
 							platformSelect.value = res.platform || 'github';
 							updatePlatformUI(platformSelect.value);
 							generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
 							generateBtn.disabled = true;
 							window.generateScrumReport && window.generateScrumReport();
-							dismissShortcutTooltipFocus(generateBtn);
 						});
 					});
+			}).finally(() => {
+				dismissShortcutTooltipFocus(generateBtn);
 			});
 		});
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -663,7 +663,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				checkTokenForMergedPRs();
 			});
 
-			function dismissShortcutTooltipFocus(el) {
+		function dismissShortcutTooltipFocus(el) {
 			try {
 				el?.blur?.();
 			} catch {}

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -664,9 +664,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			});
 
 		function dismissShortcutTooltipFocus(el) {
-			try {
-				el?.blur?.();
-			} catch {}
+			el?.blur?.();
 		}
 
 		// Button setup


### PR DESCRIPTION
### 📌 Fixes

Closes #568 

---

### 📝 Summary of Changes

- Fixed issue where the tooltip (Ctrl + Shift + Y) + (Ctrl + Shift + M) remained visible after clicking the copy button
- Added proper handling to hide the tooltip when cursour moves away



---

### 📸 Screenshots / Demo (if UI-related)

_Add screenshots, video, or link to deployed preview if applicable_

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

Write a small function inside that function call blur JS build in function that remove the focus
Call the function where all the buttons trigred

## Summary by Sourcery

Bug Fixes:
- Hide the keyboard shortcut tooltip after copy, generate, and insert actions so it no longer remains visible after clicking the related buttons.