### PR TITLE
chore: token type define for github

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ This document provides guidelines for contributing to the project. Please feel f
 
 5.  **Get a GitHub Personal Access Token (Recommended)**
 
-    To use Scrum Helper with authenticated requests (for higher rate limits and private repositories), you need a GitHub personal access token.
+    To use Scrum Helper with authenticated requests (for higher rate limits and private repositories), you need a GitHub personal access token (classic).
 
     -   **Go to GitHub Developer Settings:** Visit [https://github.com/settings/tokens](https://github.com/settings/tokens).
     -   **Choose Token Type:** Select "Personal access tokens (classic)".

--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ $ npm install
    * For Firefox: Reload the temporary add-on by going to `about:debugging` → "This Firefox" → Click "Reload" next to your extension.
    * For Opera: Reload the extension in your browser (`opera://extensions` → Click the reload/refresh icon next to the extension).
    
-3. **How to Obtain a GitHub Personal Access Token**
+3. **How to Obtain a GitHub Personal Access Token (Classic)**
 
-- To use Scrum Helper with authenticated requests (for higher rate limits and private repositories), you need a GitHub personal access token.
+- To use Scrum Helper with authenticated requests (for higher rate limits and private repositories), you need a GitHub personal access token (classic).
 
   #### Steps to Generate a Token
 

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -103,7 +103,7 @@
     "description": "Placeholder for the GitHub token input."
   },
   "githubTokenTooltip": {
-    "message": "Why is it recommended to add a GitHub token? Scrum Helper works without a GitHub token, but adding a personal access token is recommended for a better experience.",
+    "message": "Why is it recommended to add a GitHub token? Scrum Helper works without a GitHub token, but adding a personal access token (classic) is recommended for a better experience.",
     "description": "Tooltip for GitHub token explaining why it's needed."
   },
   "gitlabTokenLabel": {

--- a/src/popup.html
+++ b/src/popup.html
@@ -379,7 +379,7 @@
 										<span class="tooltip-bubble" data-i18n="githubTokenTooltip">
 											<b>Why is it recommended to add a GitHub token?</b><br>
 											Scrum Helper works without a GitHub token, but adding a personal access
-											token is recommended for a
+											token (classic) is recommended for a
 											better experience. It raises your API limits, allows access to private
 											repos
 											(if permitted), and


### PR DESCRIPTION
### 📌 Fixes

Fixes #N/A

---

### 📝 Summary of Changes

- Mention the classic token in docs


---

### 📸 Screenshots / Demo (if UI-related)

_Add screenshots, video, or link to deployed preview if applicable_

---

### ✅ Checklist

- [ ] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [ ] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_

## Summary by Sourcery

Clarify references to GitHub authentication tokens to explicitly refer to classic personal access tokens across docs and UI copy.

Enhancements:
- Adjust extension tooltip text to clarify that a GitHub personal access token (classic) is recommended for improved API limits and private repo access.

Documentation:
- Update README and CONTRIBUTING guidance to specify the need for a GitHub personal access token (classic) and align terminology with GitHub’s token types.