### PR TITLE
chore: UX enhancements for report notifications

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -79,8 +79,8 @@
     "description": "Text for the 'Insert to Email' button."
   },
   "insertToEmailFailedError": {
-    "message": "Open an email tab to insert report",
-    "description": "Error message shown when no active email tab can receive insert action."
+    "message": "Open an email tab (or reload the existing mail tab) to insert the report",
+    "description": "Error message shown when no active email tab can receive insert action or when the mail tab needs reload."
   },
   "settingsOrgNameLabel": {
     "message": "Organization Name",

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -88,7 +88,7 @@ if (!window.scrumHelperToast) {
 	window.scrumHelperToast = function scrumHelperToast(message, options = {}) {
 		if (!message || typeof document === 'undefined') return null;
 
-		const { duration = 4000, variant = 'info' } = options;
+		const { duration = 2000, variant = 'info' } = options;
 
 		const toastId = 'scrum-helper-toast';
 		const existingToast = document.getElementById(toastId);
@@ -141,7 +141,7 @@ if (!window.clearScrumHelperToast) {
 // Backwards-compatible wrapper used across the codebase
 if (!window.showPopupMessage) {
 	window.showPopupMessage = function showPopupMessage(message, options = {}) {
-		const opts = Object.assign({ duration: 4000, variant: 'info' }, options || {});
+		const opts = Object.assign({ duration: 2000, variant: 'info' }, options || {});
 		return window.scrumHelperToast?.(message, opts);
 	};
 }

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -708,6 +708,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		if (insertBtn) {
 			insertBtn.addEventListener('click', () => {
+				if (!insertBtn._triggeredByShortcut) {
+					showPopupMessage(browser.i18n.getMessage('insertingInEmailNotification'));
+				}
 				const scrumReport = document.getElementById('scrumReport');
 				const content = scrumReport ? sanitizeHtml(scrumReport.innerHTML) : '';
 				const subject = buildScrumSubjectFromPopup();
@@ -722,7 +725,7 @@ document.addEventListener('DOMContentLoaded', () => {
 					console.warn('Insert to Email failed:', errorMsg);
 					const failureMessage =
 						browser.i18n.getMessage('insertToEmailFailedError') || 'open an email tab to insert report';
-					showPopupMessage(failureMessage);
+					showPopupMessage(failureMessage, { variant: 'error' });
 				};
 
 				browser.tabs
@@ -739,8 +742,12 @@ document.addEventListener('DOMContentLoaded', () => {
 							.then((response) => {
 								if (!response?.success) {
 									handleInsertFailure(response?.error);
-								} else if (insertBtn._triggeredByShortcut) {
-									showShortcutNotification('insertedInEmailNotification');
+								} else {
+									if (insertBtn._triggeredByShortcut) {
+										showShortcutNotification('insertedInEmailNotification');
+									} else {
+										showPopupMessage(browser.i18n.getMessage('insertedInEmailNotification'), { variant: 'success' });
+									}
 								}
 							})
 							.catch((error) => {
@@ -757,6 +764,9 @@ document.addEventListener('DOMContentLoaded', () => {
 		}
 
 		generateBtn.addEventListener('click', () => {
+			if (!generateBtn._triggeredByShortcut) {
+				showPopupMessage(browser.i18n.getMessage('generatingReportNotification'));
+			}
 			browser.storage.local.get(['platform']).then((result) => {
 				platformUsername.classList.remove('input-error');
 				usernameError.classList.remove('errorMessage');
@@ -777,12 +787,17 @@ document.addEventListener('DOMContentLoaded', () => {
 							generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
 							generateBtn.disabled = true;
 							window.generateScrumReport && window.generateScrumReport();
+
+							generateBtn._triggeredByShortcut = false;
 						});
 					});
 			});
 		});
 
 		copyBtn.addEventListener('click', function () {
+			if (!this._triggeredByShortcut) {
+				showPopupMessage(browser.i18n.getMessage('copyingReportNotification'));
+			}
 			const scrumReport = document.getElementById('scrumReport');
 			if (!scrumReport) {
 				this._triggeredByShortcut = false;
@@ -845,6 +860,8 @@ document.addEventListener('DOMContentLoaded', () => {
 							? 'copiedReportNotification'
 							: 'copiedButton';
 					showShortcutNotification(notificationKey);
+				} else {
+					showPopupMessage(browser.i18n.getMessage('copiedReportNotification'), { variant: 'success' });
 				}
 				this.innerHTML = `<i class="fa fa-check"></i> ${browser?.i18n.getMessage('copiedButton')}`;
 				setTimeout(() => {
@@ -2247,6 +2264,7 @@ document.addEventListener('keydown', (e) => {
 	if (modifier && !e.shiftKey && !e.altKey && key === 'g' && !e.repeat && generateBtn && !generateBtn.disabled) {
 		e.preventDefault();
 		showShortcutNotification('generatingReportNotification');
+		generateBtn._triggeredByShortcut = true;
 		generateBtn.click();
 	}
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -26,7 +26,7 @@ function isMacOS() {
 	return /Mac/.test(platform);
 }
 
-function showShortcutNotification(messageKey) {
+function showShortcutNotification(messageKey, variant = 'info') {
 	if (typeof chrome === 'undefined' || !chrome.i18n) {
 		return;
 	}
@@ -36,7 +36,7 @@ function showShortcutNotification(messageKey) {
 		return;
 	}
 
-	window.scrumHelperToast?.(message, { duration: 2200, variant: 'info' });
+	window.scrumHelperToast?.(message, { duration: 2200, variant });
 }
 
 function setupButtonTooltips() {
@@ -859,7 +859,7 @@ document.addEventListener('DOMContentLoaded', () => {
 						browser?.i18n && browser.i18n.getMessage('copiedReportNotification')
 							? 'copiedReportNotification'
 							: 'copiedButton';
-					showShortcutNotification(notificationKey);
+					showShortcutNotification(notificationKey, 'success');
 				} else {
 					showPopupMessage(browser.i18n.getMessage('copiedReportNotification'), { variant: 'success' });
 				}

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -45,7 +45,7 @@ function showReportMessage(message) {
 		scrumReportEl.innerHTML = '';
 		window.updateCopyButtonState?.();
 	}
-	window.scrumHelperToast?.(message, { duration: 4000, variant: 'error' });
+	window.scrumHelperToast?.(message, { duration: 2000, variant: 'error' });
 }
 
 function handleUsernameValidationError(errMessage) {
@@ -994,7 +994,7 @@ function allIncluded(outputTarget = 'email') {
 					generateBtn.disabled = false;
 				}
 			} else {
-				window.scrumHelperToast?.(errMsg, { duration: 4000, variant: 'error' });
+				window.scrumHelperToast?.(errMsg, { duration: 2000, variant: 'error' });
 			}
 		}
 	}


### PR DESCRIPTION
📌 Fixes

Fixes: #599

### Summary of Changes

- Improved popup UX feedback so button clicks now show action notifications (not only keyboard shortcuts):
- Generate → shows Generating report…
- Copy → shows Copying report… and success feedback
- Insert in Email → shows Inserting report into email… and success feedback
- Added shortcut-trigger guards to prevent duplicate notifications when the same actions are triggered via keyboard.
- Improved insert-email failure handling by showing a clearer error flow and using error-style toast feedback.

- This PR is take over of #600 

📸 Screenshots / Demo
<img width="335" height="479" alt="image" src="https://github.com/user-attachments/assets/2c1372b6-87f5-4900-b9aa-9383ce764526" /><img width="335" height="479" alt="image" src="https://github.com/user-attachments/assets/e610a987-dfab-4e46-bac7-0e3126c0441e" />



✅ Checklist
 - [X] I’ve tested my changes locally
 - [ ] I’ve added tests (if applicable)
 - [ ] I’ve updated documentation (if applicable)
 - [X] My code follows the project’s code style guidelines

### Reviewer Notes

Focus is strictly UX feedback consistency + notification timing reduction.
No feature scope expansion; changes are limited to notification behavior and related messaging.