### PR TITLE
fix: handle rate limiting errors properly

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -440,5 +440,9 @@
   "insertedInEmailNotification": {
     "message": "Report inserted into email!",
     "description": "Notification shown when report is successfully inserted into email."
+  },
+  "rateLimitError": {
+    "message": "GitHub API rate limit exceeded. Please try again later or add/check your GitHub token in the Scrum Helper settings.",
+    "description": "Error shown when GitHub API rate limit is exceeded."
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -444,5 +444,9 @@
   "rateLimitError": {
     "message": "GitHub API rate limit exceeded. Please try again later or add/check your GitHub token in the Scrum Helper settings.",
     "description": "Error shown when GitHub API rate limit is exceeded."
+  },
+  "rateLimitWarningMessage": {
+    "message": "Some data may be missing due to GitHub rate limit. Please add or check your GitHub token in settings.",
+    "description": "Warning message shown below buttons when rate limit is exceeded."
   }
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -354,7 +354,10 @@
 							</div>
 						</div>
 
-
+						<div id="rateLimitWarning" class="hidden text-xs text-yellow-800 p-2 bg-yellow-50 border border-yellow-200 rounded-xl mt-2 flex items-center justify-between">
+							<span id="rateLimitWarningText" data-i18n="rateLimitWarningMessage">Some data may be missing due to GitHub rate limit. Please add or check your GitHub token in settings.</span>
+							<button id="closeRateLimitWarning" class="text-yellow-800 hover:text-yellow-900 font-bold ml-2" style="background: none; border: none; cursor: pointer; font-size: 14px;">&times;</button>
+						</div>
 					</div>
 					<div class="border-gray-100 border-2 bg-white rounded-3xl px-4 py-2 mx-2 my-2">
 						<div>

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -777,37 +777,38 @@ document.addEventListener('DOMContentLoaded', () => {
 			if (!generateBtn._triggeredByShortcut) {
 				showPopupMessage(browser.i18n.getMessage('generatingReportNotification'));
 			}
-			browser.storage.local.get(['platform']).then((result) => {
-				platformUsername.classList.remove('input-error');
-				usernameError.classList.remove('errorMessage');
-				usernameError.textContent = '';
-				const platform = result.platform || 'github';
-				const platformUsernameKey = `${platform}Username`;
+			browser.storage.local
+				.get(['platform'])
+				.then((result) => {
+					platformUsername.classList.remove('input-error');
+					usernameError.classList.remove('errorMessage');
+					usernameError.textContent = '';
+					const platform = result.platform || 'github';
+					const platformUsernameKey = `${platform}Username`;
 
-				return browser.storage.local
-					.set({
-						platform: platformSelect.value,
-						[platformUsernameKey]: platformUsername.value,
-					})
-					.then(() => {
-						// Reload platform from storage before generating report
-						return browser.storage.local.get(['platform']).then((res) => {
-							platformSelect.value = res.platform || 'github';
-							updatePlatformUI(platformSelect.value);
-							generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
-							generateBtn.disabled = true;
-							window.generateScrumReport && window.generateScrumReport();
-							generateBtn._triggeredByShortcut = false;
-
-
+					return browser.storage.local
+						.set({
+							platform: platformSelect.value,
+							[platformUsernameKey]: platformUsername.value,
+						})
+						.then(() => {
+							// Reload platform from storage before generating report
+							return browser.storage.local.get(['platform']).then((res) => {
+								platformSelect.value = res.platform || 'github';
+								updatePlatformUI(platformSelect.value);
+								generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
+								generateBtn.disabled = true;
+								window.generateScrumReport && window.generateScrumReport();
+								generateBtn._triggeredByShortcut = false;
+							});
 						});
-					});
-			}).finally(() => {
-				if (generateBtn._triggeredByShortcut) {
-					dismissShortcutTooltipFocus(generateBtn);
-					generateBtn._triggeredByShortcut = false;
-				}
-			});
+				})
+				.finally(() => {
+					if (generateBtn._triggeredByShortcut) {
+						dismissShortcutTooltipFocus(generateBtn);
+						generateBtn._triggeredByShortcut = false;
+					}
+				});
 		});
 
 		copyBtn.addEventListener('click', function () {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1300,10 +1300,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			const groups = new Map();
 
 			repos.forEach((repo) => {
-				const owner =
-					repo.fullName && repo.fullName.includes('/')
-						? repo.fullName.split('/')[0]
-						: 'Unknown';
+				const owner = repo.fullName && repo.fullName.includes('/') ? repo.fullName.split('/')[0] : 'Unknown';
 
 				if (!groups.has(owner)) {
 					groups.set(owner, []);
@@ -1315,9 +1312,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
 				.map((owner) => ({
 					owner,
-					repos: groups
-						.get(owner)
-						.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })),
+					repos: groups.get(owner).sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })),
 				}));
 		}
 
@@ -2073,3 +2068,32 @@ function validateOrgOnBlur(org) {
 		helper.validateOrgOnBlur(org);
 	}
 }
+
+// Rate Limit Warning banner management
+(function () {
+	let rateLimitTimeout;
+	const rateLimitWarning = document.getElementById('rateLimitWarning');
+	const closeRateLimitWarning = document.getElementById('closeRateLimitWarning');
+
+	if (rateLimitWarning && closeRateLimitWarning) {
+		closeRateLimitWarning.addEventListener('click', () => {
+			rateLimitWarning.classList.add('hidden');
+			if (rateLimitTimeout) {
+				clearTimeout(rateLimitTimeout);
+			}
+		});
+	}
+
+	window.showRateLimitWarning = function () {
+		const banner = document.getElementById('rateLimitWarning');
+		if (banner) {
+			banner.classList.remove('hidden');
+			if (rateLimitTimeout) {
+				clearTimeout(rateLimitTimeout);
+			}
+			rateLimitTimeout = setTimeout(() => {
+				banner.classList.add('hidden');
+			}, 6000); // 6 seconds
+		}
+	};
+})();

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1,3 +1,35 @@
+let rateLimitWarningShown = false;
+const originalFetch = window.fetch;
+window.fetch = async function (...args) {
+	const res = await originalFetch(...args);
+	const url = typeof args[0] === 'string' ? args[0] : args[0]?.url || '';
+	if (url.includes('api.github.com')) {
+		const remaining = res.headers.get('x-ratelimit-remaining');
+		if (res.status === 403 || res.status === 429 || remaining === '0') {
+			try {
+				const clone = res.clone();
+				const data = await clone.json();
+				if (data && data.message && data.message.toLowerCase().includes('rate limit exceeded')) {
+					window.githubRateLimitExceeded = true;
+					if (!rateLimitWarningShown) {
+						rateLimitWarningShown = true;
+						const msg =
+							chrome?.i18n.getMessage('rateLimitError') ||
+							'Some data may be missing due to GitHub rate limit. Please add or check your GitHub token in settings.';
+						window.scrumHelperToast?.(msg, { duration: 5000, variant: 'error' });
+						setTimeout(() => {
+							rateLimitWarningShown = false;
+						}, 5000);
+					}
+				}
+			} catch (e) {
+				// Ignore clone/json parsing issues
+			}
+		}
+	}
+	return res;
+};
+
 const DEBUG = false;
 
 function log(...args) {
@@ -126,6 +158,7 @@ function allIncluded(outputTarget = 'email') {
 		return;
 	}
 	scrumGenerationInProgress = true;
+	window.githubRateLimitExceeded = false;
 	console.log('allIncluded called with outputTarget:', outputTarget);
 
 	let scrumBody = null;
@@ -682,17 +715,21 @@ function allIncluded(outputTarget = 'email') {
 			}
 
 			if (userCheckRes.status === 401 || userCheckRes.status === 403) {
-				showInvalidTokenMessage();
-				githubCache.fetching = false;
-				return;
+				if (!window.githubRateLimitExceeded) {
+					showInvalidTokenMessage();
+					githubCache.fetching = false;
+					return;
+				}
 			}
 
 			if (!userCheckRes.ok) {
-				const errorMsg =
-					chrome?.i18n.getMessage('githubUserValidationError', [userCheckRes.status, userCheckRes.statusText]) ||
-					`Error validating GitHub user: ${userCheckRes.status} ${userCheckRes.statusText}`;
-				logError(errorMsg);
-				throw new Error(errorMsg);
+				if (!window.githubRateLimitExceeded) {
+					const errorMsg =
+						chrome?.i18n.getMessage('githubUserValidationError', [userCheckRes.status, userCheckRes.statusText]) ||
+						`Error validating GitHub user: ${userCheckRes.status} ${userCheckRes.statusText}`;
+					logError(errorMsg);
+					throw new Error(errorMsg);
+				}
 			}
 
 			const [issuesRes, prRes, userRes] = await Promise.all([
@@ -702,9 +739,11 @@ function allIncluded(outputTarget = 'email') {
 			]);
 
 			if (issuesRes.status === 401 || prRes.status === 401 || issuesRes.status === 403 || prRes.status === 403) {
-				showInvalidTokenMessage();
-				githubCache.fetching = false;
-				return;
+				if (!window.githubRateLimitExceeded) {
+					showInvalidTokenMessage();
+					githubCache.fetching = false;
+					return;
+				}
 			}
 
 			if (issuesRes.status === 422 || prRes.status === 422) {
@@ -718,7 +757,7 @@ function allIncluded(outputTarget = 'email') {
 				throw new Error(errorMsg);
 			}
 
-			if (!issuesRes.ok) {
+			if (!issuesRes.ok && !window.githubRateLimitExceeded) {
 				const errorMsg =
 					chrome?.i18n.getMessage('githubIssuesFetchError', [issuesRes.status, issuesRes.statusText]) ||
 					`Error fetching GitHub issues: ${issuesRes.status} ${issuesRes.statusText}`;
@@ -728,7 +767,7 @@ function allIncluded(outputTarget = 'email') {
 				}
 				throw new Error(errorMsg);
 			}
-			if (!prRes.ok) {
+			if (!prRes.ok && !window.githubRateLimitExceeded) {
 				const errorMsg =
 					chrome?.i18n.getMessage('githubPRReviewFetchError', [prRes.status, prRes.statusText]) ||
 					`Error fetching GitHub PR review data: ${prRes.status} ${prRes.statusText}`;
@@ -738,7 +777,7 @@ function allIncluded(outputTarget = 'email') {
 				}
 				throw new Error(errorMsg);
 			}
-			if (!userRes.ok) {
+			if (!userRes.ok && !window.githubRateLimitExceeded) {
 				const errorMsg =
 					chrome?.i18n.getMessage('githubUserFetchError', [userRes.status, userRes.statusText]) ||
 					`Error fetching GitHub user data: ${userRes.status} ${userRes.statusText}`;
@@ -746,9 +785,21 @@ function allIncluded(outputTarget = 'email') {
 				throw new Error(errorMsg);
 			}
 
-			githubIssuesData = await issuesRes.json();
-			githubPrsReviewData = await prRes.json();
-			githubUserData = await userRes.json();
+			try {
+				githubIssuesData = issuesRes.ok ? await issuesRes.json() : { items: [] };
+			} catch (e) {
+				githubIssuesData = { items: [] };
+			}
+			try {
+				githubPrsReviewData = prRes.ok ? await prRes.json() : { items: [] };
+			} catch (e) {
+				githubPrsReviewData = { items: [] };
+			}
+			try {
+				githubUserData = userRes.ok ? await userRes.json() : {};
+			} catch (e) {
+				githubUserData = {};
+			}
 
 			if (githubIssuesData && githubIssuesData.items) {
 				log('Fetched githubIssuesData:', githubIssuesData.items.length, 'items');
@@ -1019,6 +1070,22 @@ function allIncluded(outputTarget = 'email') {
 		}
 	}
 
+	function showRateLimitMessage() {
+		const errMsg =
+			chrome?.i18n.getMessage('rateLimitError') ||
+			'GitHub API rate limit exceeded. Please try again later or add/check your GitHub token in the Scrum Helper settings.';
+		if (outputTarget === 'popup') {
+			if (scrumReportEl) {
+				showReportMessage(errMsg);
+				const generateBtn = document.getElementById('generateReport');
+				if (generateBtn) {
+					generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
+					generateBtn.disabled = false;
+				}
+			}
+		}
+	}
+
 	async function processGithubData(data) {
 		log('Processing Github data');
 
@@ -1166,6 +1233,10 @@ ${lastWeekUl}<br>
 ${nextWeekUl}<br>
 <b>3. What is blocking me from making progress?</b><br>
 ${blockerText}`;
+		}
+
+		if (window.githubRateLimitExceeded) {
+			content += `<br><br><span style="color: #d32f2f; font-weight: bold;">⚠️ Note: Some data may be missing from this report due to GitHub API rate limits. Please check your GitHub token in the settings.</span>`;
 		}
 
 		if (outputTarget === 'popup') {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1,7 +1,12 @@
 let rateLimitWarningShown = false;
 const originalFetch = window.fetch;
 window.fetch = async function (...args) {
-	const res = await originalFetch(...args);
+	let res;
+	try {
+		res = await originalFetch(...args);
+	} catch (err) {
+		throw err;
+	}
 	const url = typeof args[0] === 'string' ? args[0] : args[0]?.url || '';
 	if (url.includes('api.github.com')) {
 		const remaining = res.headers.get('x-ratelimit-remaining');

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -18,13 +18,10 @@ window.fetch = async function (...args) {
 					window.githubRateLimitExceeded = true;
 					if (!rateLimitWarningShown) {
 						rateLimitWarningShown = true;
-						const msg =
-							chrome?.i18n.getMessage('rateLimitError') ||
-							'Some data may be missing due to GitHub rate limit. Please add or check your GitHub token in settings.';
-						window.scrumHelperToast?.(msg, { duration: 5000, variant: 'error' });
+						window.showRateLimitWarning?.();
 						setTimeout(() => {
 							rateLimitWarningShown = false;
-						}, 5000);
+						}, 6000);
 					}
 				}
 			} catch (e) {
@@ -1238,10 +1235,6 @@ ${lastWeekUl}<br>
 ${nextWeekUl}<br>
 <b>3. What is blocking me from making progress?</b><br>
 ${blockerText}`;
-		}
-
-		if (window.githubRateLimitExceeded) {
-			content += `<br><br><span style="color: #d32f2f; font-weight: bold;">⚠️ Note: Some data may be missing from this report due to GitHub API rate limits. Please check your GitHub token in the settings.</span>`;
 		}
 
 		if (outputTarget === 'popup') {


### PR DESCRIPTION
### 📌 Fixes

Closes #277

---

### 📝 Summary of Changes

- **Global Fetch Interception**: Added a global `window.fetch` wrapper in `scrumHelper.js` to automatically intercept GitHub API rate-limiting errors (responses with `403` or `429` status, or when the `x-ratelimit-remaining` header is `"0"`).
- **Graceful Degradation**: Updated the validation checks in `scrumHelper.js` to prevent report generation from aborting when a rate limit error occurs. It now falls back to empty datasets for the failed API calls so that the remaining parts of the Scrum report (e.g. plans, blockers, and successfully loaded cached data) still load.
- **Visual Alert**: Triggers a toast notification alert upon hitting the rate limit, and appends a warning note to the bottom of the generated Scrum report notifying the user that some data may be missing.

---

### 📸 Screenshots / Demo (if UI-related)

<img width="466" height="821" alt="image" src="https://github.com/user-attachments/assets/a5e8655b-e89c-4364-bdca-ec1785bf2825" />

<img width="367" height="427" alt="image" src="https://github.com/user-attachments/assets/1aee04ac-f158-4b14-a45a-5c30379ed699" />

<img width="453" height="675" alt="image" src="https://github.com/user-attachments/assets/9dc5360a-1c40-4782-9e38-8a05a2bbbf6d" />


---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

The fetch interceptor is implemented as a lightweight, global wrapper. It resolves the JSON clone asynchronously without race conditions, safely flagging `window.githubRateLimitExceeded` before downstream checks execute.
