### PR TITLE
chore: add null check to prevent dom issues

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -31,6 +31,7 @@ if (!window.scrumDateRangeUtils) {
 			return this.formatLocalDate(yesterday);
 		},
 		normalizeAndSync(startDateInput, endDateInput) {
+			if (!startDateInput || !endDateInput) return false;
 			const today = this.getLocalTodayString();
 			const originalStartDate = startDateInput.value;
 			const originalEndDate = endDateInput.value;
@@ -63,6 +64,7 @@ if (!window.scrumDateRangeUtils) {
 			return didChange;
 		},
 		normalizeDateRangeValues(startDateInput, endDateInput) {
+			if (!startDateInput || !endDateInput) return false;
 			const originalStartDate = startDateInput.value;
 			const originalEndDate = endDateInput.value;
 
@@ -71,12 +73,14 @@ if (!window.scrumDateRangeUtils) {
 			return startDateInput.value !== originalStartDate || endDateInput.value !== originalEndDate;
 		},
 		persistDateRange(startDateInput, endDateInput) {
+			if (!startDateInput || !endDateInput) return;
 			browser.storage.local.set({
 				startingDate: startDateInput.value,
 				endingDate: endDateInput.value,
 			});
 		},
 		normalizeSyncAndPersistDateRange(startDateInput, endDateInput) {
+			if (!startDateInput || !endDateInput) return;
 			this.normalizeDateRangeValues(startDateInput, endDateInput);
 			this.persistDateRange(startDateInput, endDateInput);
 		},
@@ -179,7 +183,7 @@ function handleBodyOnLoad() {
 			// Load platform-specific username
 			const platform = items.platform || 'github';
 			const platformUsernameKey = `${platform}Username`;
-			if (items[platformUsernameKey]) {
+			if (items[platformUsernameKey] && platformUsernameElement) {
 				platformUsernameElement.value = items[platformUsernameKey];
 			}
 
@@ -189,85 +193,109 @@ function handleBodyOnLoad() {
 			if (items.gitlabToken && gitlabTokenElement) {
 				gitlabTokenElement.value = items.gitlabToken;
 			}
-			if (items.projectName) {
+			if (items.projectName && projectNameElement) {
 				projectNameElement.value = items.projectName;
 			}
-			if (items.cacheInput) {
+			if (items.cacheInput && cacheInputElement) {
 				cacheInputElement.value = items.cacheInput;
 			}
-			if (items.endingDate) {
+			if (items.endingDate && endingDateElement) {
 				endingDateElement.value = items.endingDate;
 			}
-			if (items.startingDate) {
+			if (items.startingDate && startingDateElement) {
 				startingDateElement.value = items.startingDate;
 			}
-			const wasNormalizedOnLoad = window.scrumDateRangeUtils.normalizeDateRangeValues(
-				startingDateElement,
-				endingDateElement,
-			);
-			if (wasNormalizedOnLoad) {
-				window.scrumDateRangeUtils.persistDateRange(startingDateElement, endingDateElement);
+			if (startingDateElement && endingDateElement) {
+				const wasNormalizedOnLoad = window.scrumDateRangeUtils.normalizeDateRangeValues(
+					startingDateElement,
+					endingDateElement,
+				);
+				if (wasNormalizedOnLoad) {
+					window.scrumDateRangeUtils.persistDateRange(startingDateElement, endingDateElement);
+				}
 			}
-			if (items.showOpenLabel) {
-				showOpenLabelElement.checked = items.showOpenLabel;
-			} else if (items.showOpenLabel !== false) {
-				// undefined
-				showOpenLabelElement.checked = true;
-				handleOpenLabelChange();
+			if (showOpenLabelElement) {
+				if (items.showOpenLabel) {
+					showOpenLabelElement.checked = items.showOpenLabel;
+				} else if (items.showOpenLabel !== false) {
+					// undefined
+					showOpenLabelElement.checked = true;
+					handleOpenLabelChange();
+				}
 			}
 
-			if (items.yesterdayContribution) {
-				yesterdayContributionElement.checked = items.yesterdayContribution;
-				handleYesterdayContributionChange();
-			} else if (items.yesterdayContribution !== false) {
-				yesterdayContributionElement.checked = true;
-				handleYesterdayContributionChange();
+			if (yesterdayContributionElement) {
+				if (items.yesterdayContribution) {
+					yesterdayContributionElement.checked = items.yesterdayContribution;
+					handleYesterdayContributionChange();
+				} else if (items.yesterdayContribution !== false) {
+					yesterdayContributionElement.checked = true;
+					handleYesterdayContributionChange();
+				}
 			}
-			if (items.showCommits) {
-				showCommitsElement.checked = items.showCommits;
-			} else {
-				showCommitsElement.checked = false;
-				handleShowCommitsChange();
+			if (showCommitsElement) {
+				if (items.showCommits) {
+					showCommitsElement.checked = items.showCommits;
+				} else {
+					showCommitsElement.checked = false;
+					handleShowCommitsChange();
+				}
 			}
 		});
 }
 
-document.getElementById('refreshCache').addEventListener('click', async (e) => {
-	const button = e.currentTarget;
-	button.classList.add('loading');
-	button.disabled = true;
+const refreshCacheBtn = document.getElementById('refreshCache');
+if (refreshCacheBtn) {
+	refreshCacheBtn.addEventListener('click', async (e) => {
+		const button = e.currentTarget;
+		button.classList.add('loading');
+		button.disabled = true;
 
-	setTimeout(() => {
-		button.classList.remove('loading');
-		button.disabled = false;
-	}, 500);
-});
+		setTimeout(() => {
+			button.classList.remove('loading');
+			button.disabled = false;
+		}, 500);
+	});
+}
 
 function handleStartingDateChange() {
-	window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(startingDateElement, endingDateElement);
+	if (startingDateElement && endingDateElement) {
+		window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(startingDateElement, endingDateElement);
+	}
 }
 function handleEndingDateChange() {
-	window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(startingDateElement, endingDateElement);
+	if (startingDateElement && endingDateElement) {
+		window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(startingDateElement, endingDateElement);
+	}
 }
 
 function handleYesterdayContributionChange() {
+	if (!yesterdayContributionElement) return;
 	const value = yesterdayContributionElement.checked;
 	const labelElement = document.querySelector("label[for='yesterdayContribution']");
 
 	if (value) {
-		startingDateElement.readOnly = true;
-		endingDateElement.readOnly = true;
-		endingDateElement.value = getToday();
-		startingDateElement.value = getYesterday();
-		window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(startingDateElement, endingDateElement);
-		labelElement.classList.add('selectedLabel');
-		labelElement.classList.remove('unselectedLabel');
+		if (startingDateElement) startingDateElement.readOnly = true;
+		if (endingDateElement) endingDateElement.readOnly = true;
+		if (endingDateElement) endingDateElement.value = getToday();
+		if (startingDateElement) startingDateElement.value = getYesterday();
+		if (startingDateElement && endingDateElement) {
+			window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(startingDateElement, endingDateElement);
+		}
+		if (labelElement) {
+			labelElement.classList.add('selectedLabel');
+			labelElement.classList.remove('unselectedLabel');
+		}
 	} else {
-		startingDateElement.readOnly = false;
-		endingDateElement.readOnly = false;
-		window.scrumDateRangeUtils.normalizeDateRangeValues(startingDateElement, endingDateElement);
-		labelElement.classList.add('unselectedLabel');
-		labelElement.classList.remove('selectedLabel');
+		if (startingDateElement) startingDateElement.readOnly = false;
+		if (endingDateElement) endingDateElement.readOnly = false;
+		if (startingDateElement && endingDateElement) {
+			window.scrumDateRangeUtils.normalizeDateRangeValues(startingDateElement, endingDateElement);
+		}
+		if (labelElement) {
+			labelElement.classList.add('unselectedLabel');
+			labelElement.classList.remove('selectedLabel');
+		}
 	}
 	browser.storage.local.set({ yesterdayContribution: value });
 }
@@ -280,6 +308,7 @@ function getToday() {
 }
 
 function handlePlatformUsernameChange() {
+	if (!platformUsernameElement) return;
 	const value = platformUsernameElement.value;
 	browser.storage.local.get(['platform']).then((result) => {
 		const platform = result.platform || 'github';
@@ -288,54 +317,78 @@ function handlePlatformUsernameChange() {
 	});
 }
 function handleGithubTokenChange() {
+	if (!githubTokenElement) return;
 	const value = githubTokenElement.value;
 	browser.storage.local.set({ githubToken: value });
 }
 function handleGitlabTokenChange() {
+	if (!gitlabTokenElement) return;
 	const value = gitlabTokenElement.value;
 	browser.storage.local.set({ gitlabToken: value });
 }
 function handleProjectNameChange() {
+	if (!projectNameElement) return;
 	const value = projectNameElement.value;
 	browser.storage.local.set({ projectName: value });
 }
 function handleCacheInputChange() {
+	if (!cacheInputElement) return;
 	const value = cacheInputElement.value;
 	browser.storage.local.set({ cacheInput: value });
 }
 function handleOpenLabelChange() {
+	if (!showOpenLabelElement) return;
 	const value = showOpenLabelElement.checked;
 	const labelElement = document.querySelector("label[for='showOpenLabel']");
 
-	if (value) {
-		labelElement.classList.add('selectedLabel');
-		labelElement.classList.remove('unselectedLabel');
-	} else {
-		labelElement.classList.add('unselectedLabel');
-		labelElement.classList.remove('selectedLabel');
+	if (labelElement) {
+		if (value) {
+			labelElement.classList.add('selectedLabel');
+			labelElement.classList.remove('unselectedLabel');
+		} else {
+			labelElement.classList.add('unselectedLabel');
+			labelElement.classList.remove('selectedLabel');
+		}
 	}
 
 	browser.storage.local.set({ showOpenLabel: value });
 }
 
 function handleShowCommitsChange() {
+	if (!showCommitsElement) return;
 	const value = showCommitsElement.checked;
 	browser.storage.local.set({ showCommits: value });
 }
 
-platformUsernameElement.addEventListener('keyup', handlePlatformUsernameChange);
+if (platformUsernameElement) {
+	platformUsernameElement.addEventListener('keyup', handlePlatformUsernameChange);
+}
 if (githubTokenElement) {
 	githubTokenElement.addEventListener('keyup', handleGithubTokenChange);
 }
 if (gitlabTokenElement) {
 	gitlabTokenElement.addEventListener('keyup', handleGitlabTokenChange);
 }
-cacheInputElement.addEventListener('keyup', handleCacheInputChange);
-projectNameElement.addEventListener('keyup', handleProjectNameChange);
-startingDateElement.addEventListener('change', handleStartingDateChange);
-showCommitsElement.addEventListener('change', handleShowCommitsChange);
-endingDateElement.addEventListener('change', handleEndingDateChange);
-yesterdayContributionElement.addEventListener('change', handleYesterdayContributionChange);
-showOpenLabelElement.addEventListener('change', handleOpenLabelChange);
+if (cacheInputElement) {
+	cacheInputElement.addEventListener('keyup', handleCacheInputChange);
+}
+if (projectNameElement) {
+	projectNameElement.addEventListener('keyup', handleProjectNameChange);
+}
+if (startingDateElement) {
+	startingDateElement.addEventListener('change', handleStartingDateChange);
+}
+if (showCommitsElement) {
+	showCommitsElement.addEventListener('change', handleShowCommitsChange);
+}
+if (endingDateElement) {
+	endingDateElement.addEventListener('change', handleEndingDateChange);
+}
+if (yesterdayContributionElement) {
+	yesterdayContributionElement.addEventListener('change', handleYesterdayContributionChange);
+}
+if (showOpenLabelElement) {
+	showOpenLabelElement.addEventListener('change', handleOpenLabelChange);
+}
 
 document.addEventListener('DOMContentLoaded', handleBodyOnLoad);

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -777,37 +777,38 @@ document.addEventListener('DOMContentLoaded', () => {
 			if (!generateBtn._triggeredByShortcut) {
 				showPopupMessage(browser.i18n.getMessage('generatingReportNotification'));
 			}
-			browser.storage.local.get(['platform']).then((result) => {
-				platformUsername.classList.remove('input-error');
-				usernameError.classList.remove('errorMessage');
-				usernameError.textContent = '';
-				const platform = result.platform || 'github';
-				const platformUsernameKey = `${platform}Username`;
+			browser.storage.local
+				.get(['platform'])
+				.then((result) => {
+					platformUsername.classList.remove('input-error');
+					usernameError.classList.remove('errorMessage');
+					usernameError.textContent = '';
+					const platform = result.platform || 'github';
+					const platformUsernameKey = `${platform}Username`;
 
-				return browser.storage.local
-					.set({
-						platform: platformSelect.value,
-						[platformUsernameKey]: platformUsername.value,
-					})
-					.then(() => {
-						// Reload platform from storage before generating report
-						return browser.storage.local.get(['platform']).then((res) => {
-							platformSelect.value = res.platform || 'github';
-							updatePlatformUI(platformSelect.value);
-							generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
-							generateBtn.disabled = true;
-							window.generateScrumReport && window.generateScrumReport();
-							generateBtn._triggeredByShortcut = false;
-
-
+					return browser.storage.local
+						.set({
+							platform: platformSelect.value,
+							[platformUsernameKey]: platformUsername.value,
+						})
+						.then(() => {
+							// Reload platform from storage before generating report
+							return browser.storage.local.get(['platform']).then((res) => {
+								platformSelect.value = res.platform || 'github';
+								updatePlatformUI(platformSelect.value);
+								generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
+								generateBtn.disabled = true;
+								window.generateScrumReport && window.generateScrumReport();
+								generateBtn._triggeredByShortcut = false;
+							});
 						});
-					});
-			}).finally(() => {
-				if (generateBtn._triggeredByShortcut) {
-					dismissShortcutTooltipFocus(generateBtn);
-					generateBtn._triggeredByShortcut = false;
-				}
-			});
+				})
+				.finally(() => {
+					if (generateBtn._triggeredByShortcut) {
+						dismissShortcutTooltipFocus(generateBtn);
+						generateBtn._triggeredByShortcut = false;
+					}
+				});
 		});
 
 		copyBtn.addEventListener('click', function () {
@@ -962,30 +963,36 @@ document.addEventListener('DOMContentLoaded', () => {
 			});
 
 		// Save all fields to storage on input/change
-		projectNameInput.addEventListener('input', () => {
-			browser.storage.local.set({ projectName: projectNameInput.value });
-		});
+		if (projectNameInput) {
+			projectNameInput.addEventListener('input', () => {
+				browser.storage.local.set({ projectName: projectNameInput.value });
+			});
+		}
 
 		// Save to storage and validate ONLY when user clicks out (blur event)
-		orgInput.addEventListener('blur', () => {
-			const org = orgInput.value.trim().toLowerCase();
-			browser.storage.local.set({ orgName: org });
+		if (orgInput) {
+			orgInput.addEventListener('blur', () => {
+				const org = orgInput.value.trim().toLowerCase();
+				browser.storage.local.set({ orgName: org });
 
-			// Only validate if org name is not empty
-			if (org) {
-				validateOrgOnBlur(org);
-			} else {
-				window.clearScrumHelperToast?.();
-			}
-		});
+				// Only validate if org name is not empty
+				if (org) {
+					validateOrgOnBlur(org);
+				} else {
+					window.clearScrumHelperToast?.();
+				}
+			});
+		}
 		if (userReasonInput) {
 			userReasonInput.addEventListener('input', () => {
 				browser.storage.local.set({ userReason: userReasonInput.value });
 			});
 		}
-		showOpenLabelCheckbox.addEventListener('change', () => {
-			browser.storage.local.set({ showOpenLabel: showOpenLabelCheckbox.checked });
-		});
+		if (showOpenLabelCheckbox) {
+			showOpenLabelCheckbox.addEventListener('change', () => {
+				browser.storage.local.set({ showOpenLabel: showOpenLabelCheckbox.checked });
+			});
+		}
 		if (onlyIssuesCheckbox && onlyPRsCheckbox) {
 			onlyIssuesCheckbox.addEventListener('change', () => {
 				const checked = onlyIssuesCheckbox.checked;
@@ -1055,20 +1062,26 @@ document.addEventListener('DOMContentLoaded', () => {
 				});
 			}
 		}
-		showCommitsCheckbox.addEventListener('change', () => {
-			checkTokenForShowCommits({
-				showWarning: true,
-				animateWarning: true,
-				warningDurationMs: 3000,
-				persistState: true,
+		if (showCommitsCheckbox) {
+			showCommitsCheckbox.addEventListener('change', () => {
+				checkTokenForShowCommits({
+					showWarning: true,
+					animateWarning: true,
+					warningDurationMs: 3000,
+					persistState: true,
+				});
 			});
-		});
-		githubTokenInput.addEventListener('input', () => {
-			browser.storage.local.set({ githubToken: githubTokenInput.value });
-		});
-		cacheInput.addEventListener('input', () => {
-			browser.storage.local.set({ cacheInput: cacheInput.value });
-		});
+		}
+		if (githubTokenInput) {
+			githubTokenInput.addEventListener('input', () => {
+				browser.storage.local.set({ githubToken: githubTokenInput.value });
+			});
+		}
+		if (cacheInput) {
+			cacheInput.addEventListener('input', () => {
+				browser.storage.local.set({ cacheInput: cacheInput.value });
+			});
+		}
 
 		// Display mode (popup / sidepanel)
 		// Apply the stored display mode class on next launch
@@ -1622,10 +1635,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			const groups = new Map();
 
 			repos.forEach((repo) => {
-				const owner =
-					repo.fullName && repo.fullName.includes('/')
-						? repo.fullName.split('/')[0]
-						: 'Unknown';
+				const owner = repo.fullName && repo.fullName.includes('/') ? repo.fullName.split('/')[0] : 'Unknown';
 
 				if (!groups.has(owner)) {
 					groups.set(owner, []);
@@ -1637,9 +1647,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
 				.map((owner) => ({
 					owner,
-					repos: groups
-						.get(owner)
-						.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })),
+					repos: groups.get(owner).sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })),
 				}));
 		}
 
@@ -1932,7 +1940,10 @@ if (cacheInput) {
 
 browser.storage.local.get(['platform']).then((result) => {
 	const platform = result.platform || 'github';
-	platformSelect.value = platform;
+	const platformSelect = document.getElementById('platformSelect');
+	if (platformSelect) {
+		platformSelect.value = platform;
+	}
 	updatePlatformUI(platform);
 });
 
@@ -1978,37 +1989,41 @@ function updatePlatformUI(platform) {
 	});
 }
 
-platformSelect.addEventListener('change', () => {
-	const platform = platformSelect.value;
-	browser.storage.local.set({ platform }).then(() => {
-		const scrumReport = document.getElementById('scrumReport');
-		if (scrumReport) {
-			scrumReport.innerHTML = '';
-			window.updateCopyButtonState?.();
-		}
-		const generateBtn = document.getElementById('generateReport');
-		if (typeof bootstrapScrumReportOnPopupLoad === 'function') {
-			bootstrapScrumReportOnPopupLoad(generateBtn);
-		}
-	});
-	const platformUsername = document.getElementById('platformUsername');
-	if (platformUsername) {
-		const currentPlatform = platformSelect.value === 'github' ? 'gitlab' : 'github'; // Get the platform we're switching from
-		const currentUsername = platformUsername.value;
-		if (currentUsername.trim()) {
-			browser.storage.local.set({ [`${currentPlatform}Username`]: currentUsername });
-		}
-	}
-
-	browser.storage.local.get([`${platform}Username`]).then((result) => {
+const platformSelectEl = document.getElementById('platformSelect');
+if (platformSelectEl) {
+	platformSelectEl.addEventListener('change', () => {
+		const platform = platformSelectEl.value;
+		browser.storage.local.set({ platform }).then(() => {
+			const scrumReport = document.getElementById('scrumReport');
+			if (scrumReport) {
+				scrumReport.innerHTML = '';
+				window.updateCopyButtonState?.();
+			}
+			const generateBtn = document.getElementById('generateReport');
+			if (typeof bootstrapScrumReportOnPopupLoad === 'function') {
+				bootstrapScrumReportOnPopupLoad(generateBtn);
+			}
+		});
+		const platformUsername = document.getElementById('platformUsername');
 		if (platformUsername) {
-			platformUsername.value = result[`${platform}Username`] || '';
-			window.updateGenerateButtonState && window.updateGenerateButtonState();
+			const currentPlatform = platformSelectEl.value === 'github' ? 'gitlab' : 'github'; // Get the platform we're switching from
+			const currentUsername = platformUsername.value;
+			if (currentUsername.trim()) {
+				browser.storage.local.set({ [`${currentPlatform}Username`]: currentUsername });
+			}
 		}
-	});
 
-	updatePlatformUI(platform);
-});
+		browser.storage.local.get([`${platform}Username`]).then((result) => {
+			const platformUsername = document.getElementById('platformUsername');
+			if (platformUsername) {
+				platformUsername.value = result[`${platform}Username`] || '';
+				window.updateGenerateButtonState && window.updateGenerateButtonState();
+			}
+		});
+
+		updatePlatformUI(platform);
+	});
+}
 
 const customDropdown = document.getElementById('customPlatformDropdown');
 const dropdownBtn = document.getElementById('platformDropdownBtn');
@@ -2026,14 +2041,16 @@ function buildScrumSubjectFromPopup() {
 }
 
 function setPlatformDropdown(value) {
-	if (value === 'gitlab') {
-		dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
-	} else {
-		dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
+	if (dropdownSelected) {
+		if (value === 'gitlab') {
+			dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
+		} else {
+			dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
+		}
 	}
 
 	const platformUsername = document.getElementById('platformUsername');
-	if (platformUsername) {
+	if (platformUsername && platformSelectHidden) {
 		const currentPlatform = platformSelectHidden.value;
 		const currentUsername = platformUsername.value;
 		if (currentUsername.trim()) {
@@ -2041,7 +2058,9 @@ function setPlatformDropdown(value) {
 		}
 	}
 
-	platformSelectHidden.value = value;
+	if (platformSelectHidden) {
+		platformSelectHidden.value = value;
+	}
 	browser.storage.local.set({ platform: value }).then(() => {
 		const scrumReport = document.getElementById('scrumReport');
 		if (scrumReport) scrumReport.innerHTML = '';
@@ -2063,69 +2082,27 @@ function setPlatformDropdown(value) {
 	updatePlatformUI(value);
 }
 
-dropdownBtn.addEventListener('click', (e) => {
-	e.stopPropagation();
-	customDropdown.classList.toggle('open');
-	dropdownList.classList.toggle('hidden');
-});
-
-dropdownList.querySelectorAll('li').forEach((item) => {
-	item.addEventListener('click', function (e) {
-		const newPlatform = this.getAttribute('data-value');
-		const currentPlatform = platformSelectHidden.value;
-		const platformUsername = document.getElementById('platformUsername');
-		const usernameError = document.getElementById('usernameError');
-		platformUsername.classList.remove('input-error');
-		usernameError.classList.remove('errorMessage');
-		usernameError.textContent = '';
-
-		if (newPlatform !== currentPlatform) {
-			const platformUsername = document.getElementById('platformUsername');
-			if (platformUsername) {
-				const currentUsername = platformUsername.value;
-				if (currentUsername.trim()) {
-					browser.storage.local.set({ [`${currentPlatform}Username`]: currentUsername });
-				}
-			}
-		}
-
-		setPlatformDropdown(newPlatform);
-		customDropdown.classList.remove('open');
-		dropdownList.classList.add('hidden');
+if (dropdownBtn && customDropdown && dropdownList) {
+	dropdownBtn.addEventListener('click', (e) => {
+		e.stopPropagation();
+		customDropdown.classList.toggle('open');
+		dropdownList.classList.toggle('hidden');
 	});
-});
+}
 
-document.addEventListener('click', (e) => {
-	if (!customDropdown.contains(e.target)) {
-		customDropdown.classList.remove('open');
-		dropdownList.classList.add('hidden');
-	}
-});
-
-// Keyboard navigation
-platformDropdownBtn.addEventListener('keydown', (e) => {
-	if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
-		e.preventDefault();
-		customDropdown.classList.add('open');
-		dropdownList.classList.remove('hidden');
-		dropdownList.querySelector('li').focus();
-	}
-});
-dropdownList.querySelectorAll('li').forEach((item, idx, arr) => {
-	item.setAttribute('tabindex', '0');
-	item.addEventListener('keydown', function (e) {
-		if (e.key === 'ArrowDown') {
-			e.preventDefault();
-			(arr[idx + 1] || arr[0]).focus();
-		} else if (e.key === 'ArrowUp') {
-			e.preventDefault();
-			(arr[idx - 1] || arr[arr.length - 1]).focus();
-		} else if (e.key === 'Enter' || e.key === ' ') {
-			e.preventDefault();
+if (dropdownList) {
+	dropdownList.querySelectorAll('li').forEach((item) => {
+		item.addEventListener('click', function (e) {
 			const newPlatform = this.getAttribute('data-value');
-			const currentPlatform = platformSelectHidden.value;
+			const currentPlatform = platformSelectHidden ? platformSelectHidden.value : 'github';
+			const platformUsername = document.getElementById('platformUsername');
+			const usernameError = document.getElementById('usernameError');
+			if (platformUsername) platformUsername.classList.remove('input-error');
+			if (usernameError) {
+				usernameError.classList.remove('errorMessage');
+				usernameError.textContent = '';
+			}
 
-			// Save current username for current platform before switching
 			if (newPlatform !== currentPlatform) {
 				const platformUsername = document.getElementById('platformUsername');
 				if (platformUsername) {
@@ -2137,23 +2114,81 @@ dropdownList.querySelectorAll('li').forEach((item, idx, arr) => {
 			}
 
 			setPlatformDropdown(newPlatform);
-			customDropdown.classList.remove('open');
+			if (customDropdown) customDropdown.classList.remove('open');
 			dropdownList.classList.add('hidden');
-			dropdownBtn.focus();
+		});
+	});
+}
+
+document.addEventListener('click', (e) => {
+	if (customDropdown && dropdownList && !customDropdown.contains(e.target)) {
+		customDropdown.classList.remove('open');
+		dropdownList.classList.add('hidden');
+	}
+});
+
+// Keyboard navigation
+const platformDropdownBtn = document.getElementById('platformDropdownBtn');
+if (platformDropdownBtn && customDropdown && dropdownList) {
+	platformDropdownBtn.addEventListener('keydown', (e) => {
+		if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			customDropdown.classList.add('open');
+			dropdownList.classList.remove('hidden');
+			const firstLi = dropdownList.querySelector('li');
+			if (firstLi) firstLi.focus();
 		}
 	});
-});
+}
+if (dropdownList && customDropdown && dropdownBtn) {
+	dropdownList.querySelectorAll('li').forEach((item, idx, arr) => {
+		item.setAttribute('tabindex', '0');
+		item.addEventListener('keydown', function (e) {
+			if (e.key === 'ArrowDown') {
+				e.preventDefault();
+				(arr[idx + 1] || arr[0]).focus();
+			} else if (e.key === 'ArrowUp') {
+				e.preventDefault();
+				(arr[idx - 1] || arr[arr.length - 1]).focus();
+			} else if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				const newPlatform = this.getAttribute('data-value');
+				const currentPlatform = platformSelectHidden ? platformSelectHidden.value : 'github';
+
+				// Save current username for current platform before switching
+				if (newPlatform !== currentPlatform) {
+					const platformUsername = document.getElementById('platformUsername');
+					if (platformUsername) {
+						const currentUsername = platformUsername.value;
+						if (currentUsername.trim()) {
+							browser.storage.local.set({ [`${currentPlatform}Username`]: currentUsername });
+						}
+					}
+				}
+
+				setPlatformDropdown(newPlatform);
+				customDropdown.classList.remove('open');
+				dropdownList.classList.add('hidden');
+				dropdownBtn.focus();
+			}
+		});
+	});
+}
 
 // On load, restore platform from storage
 browser.storage.local.get(['platform']).then((result) => {
 	const platform = result.platform || 'github';
 	// Just update the UI without clearing username when restoring from storage
-	if (platform === 'gitlab') {
-		dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
-	} else {
-		dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
+	if (dropdownSelected) {
+		if (platform === 'gitlab') {
+			dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
+		} else {
+			dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
+		}
 	}
-	platformSelectHidden.value = platform;
+	if (platformSelectHidden) {
+		platformSelectHidden.value = platform;
+	}
 	updatePlatformUI(platform);
 });
 
@@ -2206,8 +2241,8 @@ document.querySelectorAll('input[name="timeframe"]').forEach((radio) => {
 
 			const startDateInput = document.getElementById('startingDate');
 			const endDateInput = document.getElementById('endingDate');
-			startDateInput.readOnly = false;
-			endDateInput.readOnly = false;
+			if (startDateInput) startDateInput.readOnly = false;
+			if (endDateInput) endDateInput.readOnly = false;
 
 			browser.storage.local.set({
 				yesterdayContribution: false,
@@ -2244,62 +2279,67 @@ document.querySelectorAll('input[name="timeframe"]').forEach((radio) => {
 
 // refresh cache button
 
-document.getElementById('refreshCache').addEventListener('click', async function () {
-	const originalText = this.innerHTML;
+{
+	const localRefreshCacheBtn = document.getElementById('refreshCache');
+	if (localRefreshCacheBtn) {
+		localRefreshCacheBtn.addEventListener('click', async function () {
+			const originalText = this.innerHTML;
 
-	this.classList.add('loading');
-	this.innerHTML = `<i class="fa fa-refresh fa-spin"></i><span>${browser.i18n.getMessage('refreshingButton')}</span>`;
-	this.disabled = true;
+			this.classList.add('loading');
+			this.innerHTML = `<i class="fa fa-refresh fa-spin"></i><span>${browser.i18n.getMessage('refreshingButton')}</span>`;
+			this.disabled = true;
 
-	try {
-		// Determine platform
-		let platform = 'github';
-		try {
-			const items = await browser.storage.local.get(['platform']);
-			platform = items.platform || 'github';
-		} catch (e) {}
+			try {
+				// Determine platform
+				let platform = 'github';
+				try {
+					const items = await browser.storage.local.get(['platform']);
+					platform = items.platform || 'github';
+				} catch (e) {}
 
-		// Clear all caches
-		const keysToRemove = ['githubCache', 'repoCache', 'gitlabCache'];
-		await browser.storage.local.remove(keysToRemove);
+				// Clear all caches
+				const keysToRemove = ['githubCache', 'repoCache', 'gitlabCache'];
+				await browser.storage.local.remove(keysToRemove);
 
-		// Clear the scrum report
-		const scrumReport = document.getElementById('scrumReport');
-		if (scrumReport) {
-			scrumReport.dataset.copyPlaceholder = 'true';
-			scrumReport.innerHTML = `<p style="text-align: center; color: #666; padding: 20px;">${browser.i18n.getMessage('cacheClearedMessage')}</p>`;
-			window.updateCopyButtonState?.();
-		}
+				// Clear the scrum report
+				const scrumReport = document.getElementById('scrumReport');
+				if (scrumReport) {
+					scrumReport.dataset.copyPlaceholder = 'true';
+					scrumReport.innerHTML = `<p style="text-align: center; color: #666; padding: 20px;">${browser.i18n.getMessage('cacheClearedMessage')}</p>`;
+					window.updateCopyButtonState?.();
+				}
 
-		if (typeof availableRepos !== 'undefined') {
-			availableRepos = [];
-		}
+				if (typeof availableRepos !== 'undefined') {
+					availableRepos = [];
+				}
 
-		const repoStatus = document.getElementById('repoStatus');
-		if (repoStatus) {
-			repoStatus.textContent = '';
-		}
+				const repoStatus = document.getElementById('repoStatus');
+				if (repoStatus) {
+					repoStatus.textContent = '';
+				}
 
-		this.innerHTML = `<i class="fa fa-check"></i><span>${browser.i18n.getMessage('cacheClearedButton')}</span>`;
-		this.classList.remove('loading');
+				this.innerHTML = `<i class="fa fa-check"></i><span>${browser.i18n.getMessage('cacheClearedButton')}</span>`;
+				this.classList.remove('loading');
 
-		// Do NOT trigger report generation automatically
+				// Do NOT trigger report generation automatically
 
-		setTimeout(() => {
-			this.innerHTML = originalText;
-			this.disabled = false;
-		}, 2000);
-	} catch (error) {
-		console.error('Cache clear failed:', error);
-		this.innerHTML = `<i class="fa fa-exclamation-triangle"></i><span>${browser.i18n.getMessage('cacheClearFailed')}</span>`;
-		this.classList.remove('loading');
+				setTimeout(() => {
+					this.innerHTML = originalText;
+					this.disabled = false;
+				}, 2000);
+			} catch (error) {
+				console.error('Cache clear failed:', error);
+				this.innerHTML = `<i class="fa fa-exclamation-triangle"></i><span>${browser.i18n.getMessage('cacheClearFailed')}</span>`;
+				this.classList.remove('loading');
 
-		setTimeout(() => {
-			this.innerHTML = originalText;
-			this.disabled = false;
-		}, 3000);
+				setTimeout(() => {
+					this.innerHTML = originalText;
+					this.disabled = false;
+				}, 3000);
+			}
+		});
 	}
-});
+}
 
 function toggleRadio(radio) {
 	const startDateInput = document.getElementById('startingDate');
@@ -2308,28 +2348,41 @@ function toggleRadio(radio) {
 	console.log('Toggling radio:', radio.id);
 
 	if (radio.id === 'yesterdayContribution') {
-		startDateInput.value = getYesterday();
-		endDateInput.value = getToday();
+		if (startDateInput) startDateInput.value = getYesterday();
+		if (endDateInput) endDateInput.value = getToday();
 	}
 
-	startDateInput.readOnly = endDateInput.readOnly = true;
+	if (startDateInput) startDateInput.readOnly = true;
+	if (endDateInput) endDateInput.readOnly = true;
 
-	browser.storage.local
-		.set({
-			startingDate: startDateInput.value,
-			endingDate: endDateInput.value,
-			yesterdayContribution: radio.id === 'yesterdayContribution',
-			selectedTimeframe: radio.id,
-			githubCache: null, // Clear cache to force new fetch
-		})
-		.then(() => {
-			console.log('State saved, dates:', {
-				start: startDateInput.value,
-				end: endDateInput.value,
+	if (startDateInput && endDateInput) {
+		browser.storage.local
+			.set({
+				startingDate: startDateInput.value,
+				endingDate: endDateInput.value,
+				yesterdayContribution: radio.id === 'yesterdayContribution',
+				selectedTimeframe: radio.id,
+				githubCache: null, // Clear cache to force new fetch
+			})
+			.then(() => {
+				console.log('State saved, dates:', {
+					start: startDateInput.value,
+					end: endDateInput.value,
+				});
+
+				triggerRepoFetchIfEnabled();
 			});
-
-			triggerRepoFetchIfEnabled();
-		});
+	} else {
+		browser.storage.local
+			.set({
+				yesterdayContribution: radio.id === 'yesterdayContribution',
+				selectedTimeframe: radio.id,
+				githubCache: null,
+			})
+			.then(() => {
+				triggerRepoFetchIfEnabled();
+			});
+	}
 }
 
 async function triggerRepoFetchIfEnabled() {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -960,36 +960,35 @@ document.addEventListener('DOMContentLoaded', () => {
 		}
 		if (githubTokenInput) {
 			githubTokenInput.addEventListener('input', () => {
-				browser.storage.local.set({ githubToken: githubTokenInput.value });
+				const trimmed = githubTokenInput.value.trim();
+				browser.storage.local.get(['githubToken']).then((items) => {
+					const currentStored = items.githubToken || '';
+					if (trimmed !== currentStored) {
+						browser.storage.local.set({ githubToken: trimmed });
+					}
+				});
 			});
-		});
-		githubTokenInput.addEventListener('input', () => {
-			const trimmed = githubTokenInput.value.trim();
-			browser.storage.local.get(['githubToken']).then((items) => {
-				const currentStored = items.githubToken || '';
-				if (trimmed !== currentStored) {
-					browser.storage.local.set({ githubToken: trimmed });
-				}
+			githubTokenInput.addEventListener('change', () => {
+				const trimmed = githubTokenInput.value.trim();
+				githubTokenInput.value = trimmed;
+				browser.storage.local.get(['githubToken']).then((items) => {
+					const currentStored = items.githubToken || '';
+					if (trimmed !== currentStored) {
+						browser.storage.local.set({ githubToken: trimmed }).then(() => {
+							triggerRepoFetchIfEnabled();
+						});
+					}
+				});
 			});
-		});
-		githubTokenInput.addEventListener('change', () => {
-			const trimmed = githubTokenInput.value.trim();
-			githubTokenInput.value = trimmed;
-			browser.storage.local.get(['githubToken']).then((items) => {
-				const currentStored = items.githubToken || '';
-				if (trimmed !== currentStored) {
-					browser.storage.local.set({ githubToken: trimmed }).then(() => {
-						triggerRepoFetchIfEnabled();
-					});
-				}
+			githubTokenInput.addEventListener('blur', () => {
+				githubTokenInput.value = githubTokenInput.value.trim();
 			});
-		});
-		githubTokenInput.addEventListener('blur', () => {
-			githubTokenInput.value = githubTokenInput.value.trim();
-		});
-		cacheInput.addEventListener('input', () => {
-			browser.storage.local.set({ cacheInput: cacheInput.value });
-		});
+		}
+		if (cacheInput) {
+			cacheInput.addEventListener('input', () => {
+				browser.storage.local.set({ cacheInput: cacheInput.value });
+			});
+		}
 
 		// Display mode (popup / sidepanel)
 		// Apply the stored display mode class on next launch


### PR DESCRIPTION
### 📌 Fixes

Closes #575 

---

### 📝 Summary of Changes

- Added defensive null checks for DOM element references in both Options page logic (`src/scripts/main.js`) and Popup settings logic (`src/scripts/popup.js`) to prevent runtime errors (`TypeError`) when elements are missing, renamed, or not yet loaded in the DOM.
- Guarded element property updates (`value`, `checked`, `readOnly`) and event listener attachments (`addEventListener`) with element existence checks.
- Handled global namespace variable conflicts between `main.js` and `popup.js` (e.g. block-scoping the refresh cache button handler as `localRefreshCacheBtn`) since both scripts share the popup execution context.
- Ensured a clean, crash-resistant extension interface that degrades gracefully without throwing JavaScript errors if specific HTML components are absent.

---

### 📸 Screenshots / Demo (if UI-related)

N/A (This is a technical stability improvement with no visual UI/UX layout modifications.)

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

- The project formatter and linter (`npm run format && npm run lint`) pass with no errors or fixes needed.
