### PR TITLE
fix: timezone issues by compute local time

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -8,6 +8,13 @@ function debounce(func, wait) {
 	};
 }
 
+function formatLocalDate(date) {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const day = String(date.getDate()).padStart(2, '0');
+	return `${year}-${month}-${day}`;
+}
+
 // Utility: Detect if the current OS is macOS
 function isMacOS() {
 	if (typeof navigator === 'undefined') {
@@ -63,14 +70,14 @@ function setupButtonTooltips() {
 
 function getToday() {
 	const today = new Date();
-	return today.toISOString().split('T')[0];
+	return formatLocalDate(today);
 }
 
 function getYesterday() {
 	const today = new Date();
 	const yesterday = new Date(today);
 	yesterday.setDate(today.getDate() - 1);
-	return yesterday.toISOString().split('T')[0];
+	return formatLocalDate(yesterday);
 }
 
 function applyI18n() {
@@ -777,37 +784,38 @@ document.addEventListener('DOMContentLoaded', () => {
 			if (!generateBtn._triggeredByShortcut) {
 				showPopupMessage(browser.i18n.getMessage('generatingReportNotification'));
 			}
-			browser.storage.local.get(['platform']).then((result) => {
-				platformUsername.classList.remove('input-error');
-				usernameError.classList.remove('errorMessage');
-				usernameError.textContent = '';
-				const platform = result.platform || 'github';
-				const platformUsernameKey = `${platform}Username`;
+			browser.storage.local
+				.get(['platform'])
+				.then((result) => {
+					platformUsername.classList.remove('input-error');
+					usernameError.classList.remove('errorMessage');
+					usernameError.textContent = '';
+					const platform = result.platform || 'github';
+					const platformUsernameKey = `${platform}Username`;
 
-				return browser.storage.local
-					.set({
-						platform: platformSelect.value,
-						[platformUsernameKey]: platformUsername.value,
-					})
-					.then(() => {
-						// Reload platform from storage before generating report
-						return browser.storage.local.get(['platform']).then((res) => {
-							platformSelect.value = res.platform || 'github';
-							updatePlatformUI(platformSelect.value);
-							generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
-							generateBtn.disabled = true;
-							window.generateScrumReport && window.generateScrumReport();
-							generateBtn._triggeredByShortcut = false;
-
-
+					return browser.storage.local
+						.set({
+							platform: platformSelect.value,
+							[platformUsernameKey]: platformUsername.value,
+						})
+						.then(() => {
+							// Reload platform from storage before generating report
+							return browser.storage.local.get(['platform']).then((res) => {
+								platformSelect.value = res.platform || 'github';
+								updatePlatformUI(platformSelect.value);
+								generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
+								generateBtn.disabled = true;
+								window.generateScrumReport && window.generateScrumReport();
+								generateBtn._triggeredByShortcut = false;
+							});
 						});
-					});
-			}).finally(() => {
-				if (generateBtn._triggeredByShortcut) {
-					dismissShortcutTooltipFocus(generateBtn);
-					generateBtn._triggeredByShortcut = false;
-				}
-			});
+				})
+				.finally(() => {
+					if (generateBtn._triggeredByShortcut) {
+						dismissShortcutTooltipFocus(generateBtn);
+						generateBtn._triggeredByShortcut = false;
+					}
+				});
 		});
 
 		copyBtn.addEventListener('click', function () {
@@ -1622,10 +1630,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			const groups = new Map();
 
 			repos.forEach((repo) => {
-				const owner =
-					repo.fullName && repo.fullName.includes('/')
-						? repo.fullName.split('/')[0]
-						: 'Unknown';
+				const owner = repo.fullName && repo.fullName.includes('/') ? repo.fullName.split('/')[0] : 'Unknown';
 
 				if (!groups.has(owner)) {
 					groups.set(owner, []);
@@ -1637,9 +1642,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
 				.map((owner) => ({
 					owner,
-					repos: groups
-						.get(owner)
-						.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })),
+					repos: groups.get(owner).sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })),
 				}));
 		}
 

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -12,6 +12,13 @@ function logError(...args) {
 	}
 }
 
+function formatLocalDate(date) {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const day = String(date.getDate()).padStart(2, '0');
+	return `${year}-${month}-${day}`;
+}
+
 /**
  * Redact sensitive storage data for safe logging
  * Prevents exposure of authentication tokens and credentials in console logs
@@ -405,11 +412,11 @@ function allIncluded(outputTarget = 'email') {
 		const today = new Date();
 		const yesterday = new Date(today);
 		yesterday.setDate(today.getDate() - 1);
-		return yesterday.toISOString().split('T')[0];
+		return formatLocalDate(yesterday);
 	}
 	function getToday() {
 		const today = new Date();
-		return today.toISOString().split('T')[0];
+		return formatLocalDate(today);
 	}
 
 	// Global cache object
@@ -520,8 +527,8 @@ function allIncluded(outputTarget = 'email') {
 		if (yesterdayContribution) {
 			const today = new Date();
 			const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
-			startDateForCache = yesterday.toISOString().split('T')[0];
-			endDateForCache = today.toISOString().split('T')[0]; // Use yesterday for start and today for end
+			startDateForCache = formatLocalDate(yesterday);
+			endDateForCache = formatLocalDate(today); // Use yesterday for start and today for end
 		} else if (startingDate && endingDate) {
 			startDateForCache = startingDate;
 			endDateForCache = endingDate;
@@ -529,8 +536,8 @@ function allIncluded(outputTarget = 'email') {
 			// Default to last 7 days if no date range is set
 			const today = new Date();
 			const lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7);
-			startDateForCache = lastWeek.toISOString().split('T')[0];
-			endDateForCache = today.toISOString().split('T')[0];
+			startDateForCache = formatLocalDate(lastWeek);
+			endDateForCache = formatLocalDate(today);
 		}
 
 		const cacheKey = `${platformUsernameLocal}-${startDateForCache}-${endDateForCache}-${orgName || 'all'}`;
@@ -765,8 +772,8 @@ function allIncluded(outputTarget = 'email') {
 					if (yesterdayContribution) {
 						const today = new Date();
 						const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
-						startDateForCommits = yesterday.toISOString().split('T')[0];
-						endDateForCommits = today.toISOString().split('T')[0]; // Use yesterday for start and today for end
+						startDateForCommits = formatLocalDate(yesterday);
+						endDateForCommits = formatLocalDate(today); // Use yesterday for start and today for end
 					} else if (startingDate && endingDate) {
 						startDateForCommits = startingDate;
 						endDateForCommits = endingDate;
@@ -774,8 +781,8 @@ function allIncluded(outputTarget = 'email') {
 						// Default to last 7 days if no date range is set
 						const today = new Date();
 						const lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7);
-						startDateForCommits = lastWeek.toISOString().split('T')[0];
-						endDateForCommits = today.toISOString().split('T')[0];
+						startDateForCommits = formatLocalDate(lastWeek);
+						endDateForCommits = formatLocalDate(today);
 					}
 
 					const commitMap = await fetchCommitsForOpenPRs(openPRs, githubToken, startDateForCommits, endDateForCommits);
@@ -1299,8 +1306,8 @@ ${blockerText}`;
 		if (yesterdayContribution) {
 			const today = new Date();
 			const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
-			startDate = yesterday.toISOString().split('T')[0];
-			endDate = today.toISOString().split('T')[0]; // Use yesterday for start and today for end
+			startDate = formatLocalDate(yesterday);
+			endDate = formatLocalDate(today); // Use yesterday for start and today for end
 		} else if (startingDate && endingDate) {
 			startDate = startingDate;
 			endDate = endingDate;
@@ -1308,8 +1315,8 @@ ${blockerText}`;
 			// Default to last 7 days if no date range is set
 			const today = new Date();
 			const lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7);
-			startDate = lastWeek.toISOString().split('T')[0];
-			endDate = today.toISOString().split('T')[0];
+			startDate = formatLocalDate(lastWeek);
+			endDate = formatLocalDate(today);
 		}
 
 		const startDateTime = new Date(startDate + 'T00:00:00Z');
@@ -1518,8 +1525,8 @@ ${blockerText}`;
 		if (yesterdayContribution) {
 			const today = new Date();
 			const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
-			startDateForRange = yesterday.toISOString().split('T')[0];
-			endDateForRange = today.toISOString().split('T')[0]; // Use yesterday for start and today for end
+			startDateForRange = formatLocalDate(yesterday);
+			endDateForRange = formatLocalDate(today); // Use yesterday for start and today for end
 		} else if (startingDate && endingDate) {
 			startDateForRange = startingDate;
 			endDateForRange = endingDate;
@@ -1527,8 +1534,8 @@ ${blockerText}`;
 			// Default to last 7 days if no date range is set
 			const today = new Date();
 			const lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7);
-			startDateForRange = lastWeek.toISOString().split('T')[0];
-			endDateForRange = today.toISOString().split('T')[0];
+			startDateForRange = formatLocalDate(lastWeek);
+			endDateForRange = formatLocalDate(today);
 		}
 
 		const daysRange = getDaysBetween(startDateForRange, endDateForRange);
@@ -1689,8 +1696,8 @@ ${blockerText}`;
 				if (yesterdayContribution) {
 					const today = new Date();
 					const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
-					startDateFilter = new Date(yesterday.toISOString().split('T')[0] + 'T00:00:00Z');
-					endDateFilter = new Date(today.toISOString().split('T')[0] + 'T23:59:59Z'); // Use yesterday for start and today for end
+					startDateFilter = new Date(formatLocalDate(yesterday) + 'T00:00:00Z');
+					endDateFilter = new Date(formatLocalDate(today) + 'T23:59:59Z'); // Use yesterday for start and today for end
 				} else if (startingDate && endingDate) {
 					startDateFilter = new Date(startingDate + 'T00:00:00Z');
 					endDateFilter = new Date(endingDate + 'T23:59:59Z');
@@ -1698,8 +1705,8 @@ ${blockerText}`;
 					// Default to last 7 days if no date range is set
 					const today = new Date();
 					const lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7);
-					startDateFilter = new Date(lastWeek.toISOString().split('T')[0] + 'T00:00:00Z');
-					endDateFilter = new Date(today.toISOString().split('T')[0] + 'T23:59:59Z');
+					startDateFilter = new Date(formatLocalDate(lastWeek) + 'T00:00:00Z');
+					endDateFilter = new Date(formatLocalDate(today) + 'T23:59:59Z');
 				}
 
 				const today = new Date();
@@ -1811,16 +1818,16 @@ ${blockerText}`;
 				if (yesterdayContribution) {
 					const todayDate = new Date();
 					const yesterdayDate = new Date(todayDate.getTime() - 24 * 60 * 60 * 1000);
-					issueStartDateFilter = new Date(yesterdayDate.toISOString().split('T')[0] + 'T00:00:00Z');
-					issueEndDateFilter = new Date(yesterdayDate.toISOString().split('T')[0] + 'T23:59:59Z');
+					issueStartDateFilter = new Date(formatLocalDate(yesterdayDate) + 'T00:00:00Z');
+					issueEndDateFilter = new Date(formatLocalDate(yesterdayDate) + 'T23:59:59Z');
 				} else if (startingDate && endingDate) {
 					issueStartDateFilter = new Date(startingDate + 'T00:00:00Z');
 					issueEndDateFilter = new Date(endingDate + 'T23:59:59Z');
 				} else {
 					const todayDate = new Date();
 					const lastWeek = new Date(todayDate.getFullYear(), todayDate.getMonth(), todayDate.getDate() - 7);
-					issueStartDateFilter = new Date(lastWeek.toISOString().split('T')[0] + 'T00:00:00Z');
-					issueEndDateFilter = new Date(todayDate.toISOString().split('T')[0] + 'T23:59:59Z');
+					issueStartDateFilter = new Date(formatLocalDate(lastWeek) + 'T00:00:00Z');
+					issueEndDateFilter = new Date(formatLocalDate(todayDate) + 'T23:59:59Z');
 				}
 
 				const issueCreatedDate = new Date(item.created_at);
@@ -2142,16 +2149,16 @@ async function fetchUserRepositories(username, token, org = '') {
 			if (storageData.yesterdayContribution) {
 				const today = new Date();
 				const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
-				startDate = yesterday.toISOString().split('T')[0];
-				endDate = today.toISOString().split('T')[0];
+				startDate = formatLocalDate(yesterday);
+				endDate = formatLocalDate(today);
 			} else if (storageData.startingDate && storageData.endingDate) {
 				startDate = storageData.startingDate;
 				endDate = storageData.endingDate;
 			} else {
 				const today = new Date();
 				const lastWeek = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7);
-				startDate = lastWeek.toISOString().split('T')[0];
-				endDate = today.toISOString().split('T')[0];
+				startDate = formatLocalDate(lastWeek);
+				endDate = formatLocalDate(today);
 			}
 
 			dateRange = `+created:${startDate}..${endDate}`;
@@ -2160,8 +2167,8 @@ async function fetchUserRepositories(username, token, org = '') {
 			console.warn('Could not determine date range, using last 30 days:', err);
 			const today = new Date();
 			const thirtyDaysAgo = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 30);
-			const startDate = thirtyDaysAgo.toISOString().split('T')[0];
-			const endDate = today.toISOString().split('T')[0];
+			const startDate = formatLocalDate(thirtyDaysAgo);
+			const endDate = formatLocalDate(today);
 		}
 		const orgPart = org && org !== 'all' ? `+org:${org}` : '';
 		const issuesUrl = `https://api.github.com/search/issues?q=author:${username}${orgPart}${dateRange}&per_page=100`;

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -12,6 +12,18 @@ function logError(...args) {
 	}
 }
 
+
+function getLocalISOString(dateStr, time) {
+	const offsetMinutes = new Date().getTimezoneOffset();
+	const absOffset = Math.abs(offsetMinutes);
+	const hours = Math.floor(absOffset / 60);
+	const minutes = absOffset % 60;
+	const sign = offsetMinutes <= 0 ? '+' : '-';
+	const pad = (num) => String(num).padStart(2, '0');
+	const offsetStr = `${sign}${pad(hours)}:${pad(minutes)}`;
+	return `${dateStr}T${time}${offsetStr}`;
+}
+
 function formatLocalDate(date) {
 	const year = date.getFullYear();
 	const month = String(date.getMonth() + 1).padStart(2, '0');
@@ -860,8 +872,8 @@ function allIncluded(outputTarget = 'email') {
 			endDate,
 		);
 		if (!prs.length) return {};
-		const since = new Date(startDate + 'T00:00:00Z').toISOString();
-		const until = new Date(endDate + 'T23:59:59Z').toISOString();
+	const since = getLocalISOString(startDate, '00:00:00');
+	const until = getLocalISOString(endDate, '23:59:59');
 		const queries = prs
 			.map((pr, idx) => {
 				const repoParts = pr.repository_url.split('/');


### PR DESCRIPTION
### 📌 Fixes

Closes #398 

---

### 📝 Summary of Changes


Follow-up PR to #399 , #503 

- **Resolved UTC Mismatch in Date Calculations**: Replaced all occurrences of `date.toISOString().split('T')[0]` with a local date formatting helper function (`formatLocalDate`) across `src/scripts/popup.js` and `src/scripts/scrumHelper.js`.
- **System Timezone Independence**: Using `date.getFullYear()`, `date.getMonth()`, and `date.getDate()` ensures that "today" and "yesterday" calculations are determined by the user's local system clock/timezone settings instead of forcing UTC-relative boundaries.
- **Accurate API Date Filtering**: Prevents off-by-one errors when querying commit/issue/PR lists from GitHub and GitLab APIs, ensuring that users in timezones far from UTC (e.g., Japan/Australia or US West Coast) request the correct local 24-hour periods.

---

### 📸 Screenshots / Demo (if UI-related)

_N/A (Underlying date logic and API query parameters correction)_

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

- The code has been formatted and linted (`npm run format && npm run lint`) with no issues.
- The build targets build successfully for Chrome, Firefox, and Opera (`npm run build`).
