### PR TITLE
chore: saprate the report pipeline

### DIFF
--- a/src/scripts/githubHelper.js
+++ b/src/scripts/githubHelper.js
@@ -665,6 +665,162 @@ async function forceGithubDataRefresh() {
 
 window['forceGithubDataRefresh'] = forceGithubDataRefresh;
 
+// Global fetch helpers
+const GITHUB_DEBUG = false;
+function log(...args) {
+	if (GITHUB_DEBUG) {
+		console.log(`[GITHUB-HELPER]:`, ...args);
+	}
+}
+
+async function githubFetchUser(username, token) {
+	const url = `https://api.github.com/users/${username}`;
+	const headers = { Accept: 'application/vnd.github.v3+json' };
+	if (token) {
+		headers.Authorization = `token ${token}`;
+	}
+	return fetch(url, { headers });
+}
+
+async function githubFetchIssues(username, token, startDate, endDate, orgName, repoQueries) {
+	const headers = { Accept: 'application/vnd.github.v3+json' };
+	if (token) {
+		headers.Authorization = `token ${token}`;
+	}
+	const orgPart = orgName ? `org:${orgName}` : '';
+	const orgQuery = orgPart ? `+${orgPart}` : '';
+	let url;
+	if (repoQueries) {
+		url = `https://api.github.com/search/issues?q=author%3A${username}+${repoQueries}${orgQuery}+updated%3A${startDate}..${endDate}&per_page=100`;
+	} else {
+		url = `https://api.github.com/search/issues?q=author%3A${username}${orgQuery}+updated%3A${startDate}..${endDate}&per_page=100`;
+	}
+	return fetch(url, { headers });
+}
+
+async function githubFetchReviews(username, token, startDate, endDate, orgName, repoQueries) {
+	const headers = { Accept: 'application/vnd.github.v3+json' };
+	if (token) {
+		headers.Authorization = `token ${token}`;
+	}
+	const orgPart = orgName ? `org:${orgName}` : '';
+	const orgQuery = orgPart ? `+${orgPart}` : '';
+	let url;
+	if (repoQueries) {
+		url = `https://api.github.com/search/issues?q=commenter%3A${username}+${repoQueries}${orgQuery}+updated%3A${startDate}..${endDate}&per_page=100`;
+	} else {
+		url = `https://api.github.com/search/issues?q=commenter%3A${username}${orgQuery}+updated%3A${startDate}..${endDate}&per_page=100`;
+	}
+	return fetch(url, { headers });
+}
+
+async function githubFetchPullRequests(username, token, startDate, endDate, orgName, repoQueries) {
+	return githubFetchReviews(username, token, startDate, endDate, orgName, repoQueries);
+}
+
+async function githubFetchCommits(prs, githubToken, startDate, endDate) {
+	log(
+		'githubFetchCommits called with PRs:',
+		prs.map((pr) => pr.number),
+		'startDate:',
+		startDate,
+		'endDate:',
+		endDate,
+	);
+	if (!prs.length) return {};
+	const since = new Date(startDate + 'T00:00:00Z').toISOString();
+	const until = new Date(endDate + 'T23:59:59Z').toISOString();
+	const queries = prs
+		.map((pr, idx) => {
+			const repoParts = pr.repository_url.split('/');
+			const owner = repoParts[repoParts.length - 2];
+			const repo = repoParts[repoParts.length - 1];
+			return `
+		pr${idx}: repository(owner: "${owner}", name: "${repo}") {
+			pullRequest(number: ${pr.number}) {
+				commits(first: 100) {
+					nodes {
+						commit {
+							messageHeadline
+							committedDate
+							url
+							author {
+								name
+								user { login }
+							}
+						}
+					}
+				}
+			}
+		}`;
+		})
+		.join('\n');
+	const query = `query { ${queries} }`;
+	log('GraphQL query for commits:', query);
+	const res = await fetch('https://api.github.com/graphql', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...(githubToken ? { Authorization: `bearer ${githubToken}` } : {}),
+		},
+		body: JSON.stringify({ query }),
+	});
+	log('githubFetchCommits response status:', res.status);
+	const data = await res.json();
+	log('githubFetchCommits response data:', data);
+	const commitMap = {};
+	prs.forEach((pr, idx) => {
+		const prData = data.data && data.data[`pr${idx}`] && data.data[`pr${idx}`].pullRequest;
+		if (prData && prData.commits && prData.commits.nodes) {
+			const allCommits = prData.commits.nodes.map((n) => n.commit);
+			log(`PR #${pr.number} allCommits:`, allCommits);
+			const filteredCommits = allCommits.filter((commit) => {
+				const commitDate = new Date(commit.committedDate);
+				const sinceDate = new Date(since);
+				const untilDate = new Date(until);
+				const isInRange = commitDate >= sinceDate && commitDate <= untilDate;
+				log(`PR #${pr.number} commit "${commit.messageHeadline}" (${commit.committedDate}) - in range: ${isInRange}`);
+				return isInRange;
+			});
+			commitMap[pr.number] = filteredCommits;
+		} else {
+			commitMap[pr.number] = [];
+		}
+	});
+	return commitMap;
+}
+
+const sessionMergedStatusCache = {};
+
+async function githubFetchPrMergedStatusREST(owner, repo, number, token) {
+	const cacheKey = `${owner}/${repo}#${number}`;
+	if (sessionMergedStatusCache[cacheKey] !== undefined) {
+		return sessionMergedStatusCache[cacheKey];
+	}
+	const url = `https://api.github.com/repos/${owner}/${repo}/pulls/${number}`;
+	const headers = { Accept: 'application/vnd.github.v3+json' };
+	if (token) {
+		headers.Authorization = `token ${token}`;
+	}
+	try {
+		const res = await fetch(url, { headers });
+		if (!res.ok) return null;
+		const data = await res.json();
+		const merged = !!data.merged_at;
+		sessionMergedStatusCache[cacheKey] = merged;
+		return merged;
+	} catch (e) {
+		return null;
+	}
+}
+
+window.githubFetchUser = githubFetchUser;
+window.githubFetchIssues = githubFetchIssues;
+window.githubFetchReviews = githubFetchReviews;
+window.githubFetchPullRequests = githubFetchPullRequests;
+window.githubFetchCommits = githubFetchCommits;
+window.githubFetchPrMergedStatusREST = githubFetchPrMergedStatusREST;
+
 if (window.PlatformRegistry) {
 	window.PlatformRegistry.register('github', {
 		hasRepoFilter: true,

--- a/src/scripts/gitlabHelper.js
+++ b/src/scripts/gitlabHelper.js
@@ -286,6 +286,40 @@ class GitLabHelper {
 
 		return processed;
 	}
+
+	mapGitLabReportItem(item, projectById, type) {
+		const project = projectById.get(item.project_id);
+		const repoName = project ? project.name : 'unknown';
+
+		return {
+			...item,
+			repository_url: `${this.baseUrl}/projects/${item.project_id}`,
+			html_url:
+				type === 'issue'
+					? item.web_url || (project ? `${project.web_url}/-/issues/${item.iid}` : '')
+					: item.web_url || (project ? `${project.web_url}/-/merge_requests/${item.iid}` : ''),
+			number: item.iid,
+			title: item.title,
+			state: type === 'issue' && item.state === 'opened' ? 'open' : item.state,
+			project: repoName,
+			pull_request: type === 'mr',
+		};
+	}
+
+	mapGitLabReportData(data) {
+		const projects = Array.isArray(data.projects) ? data.projects : [];
+		const projectById = new Map(projects.map((project) => [project.id, project]));
+		const mappedIssues = (data.issues || []).map((issue) => this.mapGitLabReportItem(issue, projectById, 'issue'));
+		const mappedMRs = (data.mergeRequests || data.mrs || []).map((mr) =>
+			this.mapGitLabReportItem(mr, projectById, 'mr'),
+		);
+
+		return {
+			githubIssuesData: { items: mappedIssues },
+			githubPrsReviewData: { items: mappedMRs },
+			githubUserData: data.user || {},
+		};
+	}
 }
 
 // Export for use in other scripts

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -663,37 +663,38 @@ document.addEventListener('DOMContentLoaded', () => {
 			if (!generateBtn._triggeredByShortcut) {
 				showPopupMessage(browser.i18n.getMessage('generatingReportNotification'));
 			}
-			browser.storage.local.get(['platform']).then((result) => {
-				platformUsername.classList.remove('input-error');
-				usernameError.classList.remove('errorMessage');
-				usernameError.textContent = '';
-				const platform = result.platform || 'github';
-				const platformUsernameKey = `${platform}Username`;
+			browser.storage.local
+				.get(['platform'])
+				.then((result) => {
+					platformUsername.classList.remove('input-error');
+					usernameError.classList.remove('errorMessage');
+					usernameError.textContent = '';
+					const platform = result.platform || 'github';
+					const platformUsernameKey = `${platform}Username`;
 
-				return browser.storage.local
-					.set({
-						platform: platformSelect.value,
-						[platformUsernameKey]: platformUsername.value,
-					})
-					.then(() => {
-						// Reload platform from storage before generating report
-						return browser.storage.local.get(['platform']).then((res) => {
-							platformSelect.value = res.platform || 'github';
-							updatePlatformUI(platformSelect.value);
-							generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
-							generateBtn.disabled = true;
-							window.generateScrumReport && window.generateScrumReport();
-							generateBtn._triggeredByShortcut = false;
-
-
+					return browser.storage.local
+						.set({
+							platform: platformSelect.value,
+							[platformUsernameKey]: platformUsername.value,
+						})
+						.then(() => {
+							// Reload platform from storage before generating report
+							return browser.storage.local.get(['platform']).then((res) => {
+								platformSelect.value = res.platform || 'github';
+								updatePlatformUI(platformSelect.value);
+								generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
+								generateBtn.disabled = true;
+								window.generateScrumReport && window.generateScrumReport();
+								generateBtn._triggeredByShortcut = false;
+							});
 						});
-					});
-			}).finally(() => {
-				if (generateBtn._triggeredByShortcut) {
-					dismissShortcutTooltipFocus(generateBtn);
-					generateBtn._triggeredByShortcut = false;
-				}
-			});
+				})
+				.finally(() => {
+					if (generateBtn._triggeredByShortcut) {
+						dismissShortcutTooltipFocus(generateBtn);
+						generateBtn._triggeredByShortcut = false;
+					}
+				});
 		});
 
 		copyBtn.addEventListener('click', function () {
@@ -1299,10 +1300,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			const groups = new Map();
 
 			repos.forEach((repo) => {
-				const owner =
-					repo.fullName && repo.fullName.includes('/')
-						? repo.fullName.split('/')[0]
-						: 'Unknown';
+				const owner = repo.fullName && repo.fullName.includes('/') ? repo.fullName.split('/')[0] : 'Unknown';
 
 				if (!groups.has(owner)) {
 					groups.set(owner, []);
@@ -1314,9 +1312,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
 				.map((owner) => ({
 					owner,
-					repos: groups
-						.get(owner)
-						.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })),
+					repos: groups.get(owner).sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })),
 				}));
 		}
 

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -612,9 +612,7 @@ function allIncluded(outputTarget = 'email') {
 		console.log('[SCRUM-HELPER] orgPart for API:', orgPart);
 		console.log('[SCRUM-HELPER] orgPart length:', orgPart.length);
 
-		let issueUrl;
-		let prUrl;
-		let userUrl;
+		let repoQueries = '';
 
 		if (useRepoFilter && selectedRepos && selectedRepos.length > 0) {
 			log('Using repo filter for api calls:', selectedRepos);
@@ -625,7 +623,7 @@ function allIncluded(outputTarget = 'email') {
 				logError('Failed to fetch repo data for filtering:', err);
 			}
 
-			const repoQueries = selectedRepos
+			repoQueries = selectedRepos
 				.filter((repo) => repo !== null)
 				.map((repo) => {
 					if (typeof repo === 'object' && repo.fullName) {
@@ -647,31 +645,20 @@ function allIncluded(outputTarget = 'email') {
 				})
 				.join('+');
 
-			const orgQuery = orgPart ? `+${orgPart}` : '';
 			if (!repoQueries) {
 				loadFromStorage('Repo filter empty, using org wide search');
-				issueUrl = `https://api.github.com/search/issues?q=author%3A${platformUsernameLocal}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
-				prUrl = `https://api.github.com/search/issues?q=commenter%3A${platformUsernameLocal}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
-				userUrl = `https://api.github.com/users/${platformUsernameLocal}`;
 			} else {
-				issueUrl = `https://api.github.com/search/issues?q=author%3A${platformUsernameLocal}+${repoQueries}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
-				prUrl = `https://api.github.com/search/issues?q=commenter%3A${platformUsernameLocal}+${repoQueries}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
-				userUrl = `https://api.github.com/users/${platformUsernameLocal}`;
-				log('Repository-filtered URLs:', { issueUrl, prUrl });
+				loadFromStorage('Using repository filter');
 			}
 		} else {
 			loadFromStorage('Using org wide search');
-			const orgQuery = orgPart ? `+${orgPart}` : '';
-			issueUrl = `https://api.github.com/search/issues?q=author%3A${platformUsernameLocal}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
-			prUrl = `https://api.github.com/search/issues?q=commenter%3A${platformUsernameLocal}${orgQuery}+updated%3A${startDateForCache}..${endDateForCache}&per_page=100`;
-			userUrl = `https://api.github.com/users/${platformUsernameLocal}`;
 		}
 
 		try {
 			await new Promise((res) => setTimeout(res, 500));
 
 			log('Validating GitHub user existence for:', platformUsernameLocal);
-			const userCheckRes = await fetch(userUrl, { headers });
+			const userCheckRes = await githubFetchUser(platformUsernameLocal, githubToken);
 
 			if (userCheckRes.status === 404) {
 				const errorMsg =
@@ -696,8 +683,15 @@ function allIncluded(outputTarget = 'email') {
 			}
 
 			const [issuesRes, prRes, userRes] = await Promise.all([
-				fetch(issueUrl, { headers }),
-				fetch(prUrl, { headers }),
+				githubFetchIssues(platformUsernameLocal, githubToken, startDateForCache, endDateForCache, orgName, repoQueries),
+				githubFetchReviews(
+					platformUsernameLocal,
+					githubToken,
+					startDateForCache,
+					endDateForCache,
+					orgName,
+					repoQueries,
+				),
 				userCheckRes, // Reuse the already validated user response
 			]);
 
@@ -844,77 +838,7 @@ function allIncluded(outputTarget = 'email') {
 	}
 
 	async function fetchCommitsForOpenPRs(prs, githubToken, startDate, endDate) {
-		log(
-			'fetchCommitsForOpenPRs called with PRs:',
-			prs.map((pr) => pr.number),
-			'startDate:',
-			startDate,
-			'endDate:',
-			endDate,
-		);
-		if (!prs.length) return {};
-		const since = new Date(startDate + 'T00:00:00Z').toISOString();
-		const until = new Date(endDate + 'T23:59:59Z').toISOString();
-		const queries = prs
-			.map((pr, idx) => {
-				const repoParts = pr.repository_url.split('/');
-				const owner = repoParts[repoParts.length - 2];
-				const repo = repoParts[repoParts.length - 1];
-				return `
-			pr${idx}: repository(owner: "${owner}", name: "${repo}") {
-				pullRequest(number: ${pr.number}) {
-					commits(first: 100) {
-						nodes {
-							commit {
-								messageHeadline
-								committedDate
-								url
-								author {
-									name
-									user { login }
-								}
-							}
-						}
-					}
-				}
-
-			}`;
-			})
-			.join('\n');
-		const query = `query { ${queries} }`;
-		log('GraphQL query for commits:', query);
-		const res = await fetch('https://api.github.com/graphql', {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				...(githubToken ? { Authorization: `bearer ${githubToken}` } : {}),
-			},
-			body: JSON.stringify({ query }),
-		});
-		log('fetchCommitsForOpenPRs response status:', res.status);
-		const data = await res.json();
-		log('fetchCommitsForOpenPRs response data:', data);
-		const commitMap = {};
-		prs.forEach((pr, idx) => {
-			const prData = data.data && data.data[`pr${idx}`] && data.data[`pr${idx}`].pullRequest;
-			if (prData && prData.commits && prData.commits.nodes) {
-				const allCommits = prData.commits.nodes.map((n) => n.commit);
-				log(`PR #${pr.number} allCommits:`, allCommits);
-				const filteredCommits = allCommits.filter((commit) => {
-					const commitDate = new Date(commit.committedDate);
-					const sinceDate = new Date(since);
-					const untilDate = new Date(until);
-					const isInRange = commitDate >= sinceDate && commitDate <= untilDate;
-					log(`PR #${pr.number} commit "${commit.messageHeadline}" (${commit.committedDate}) - in range: ${isInRange}`);
-					return isInRange;
-				});
-				log(`PR #${pr.number} filteredCommits:`, filteredCommits);
-				commitMap[pr.number] = filteredCommits;
-			} else {
-				log(`No commits found for PR #${pr.number}`);
-			}
-		});
-		return commitMap;
+		return githubFetchCommits(prs, githubToken, startDate, endDate);
 	}
 
 	async function fetchReposIfNeeded() {
@@ -1479,24 +1403,8 @@ ${blockerText}`;
 		return Math.ceil((d2 - d1) / (1000 * 60 * 60 * 24));
 	}
 
-	const sessionMergedStatusCache = {};
-
 	async function fetchPrMergedStatusREST(owner, repo, number, headers) {
-		const cacheKey = `${owner}/${repo}#${number}`;
-		if (sessionMergedStatusCache[cacheKey] !== undefined) {
-			return sessionMergedStatusCache[cacheKey];
-		}
-		const url = `https://api.github.com/repos/${owner}/${repo}/pulls/${number}`;
-		try {
-			const res = await fetch(url, { headers });
-			if (!res.ok) return null;
-			const data = await res.json();
-			const merged = !!data.merged_at;
-			sessionMergedStatusCache[cacheKey] = merged;
-			return merged;
-		} catch (e) {
-			return null;
-		}
+		return githubFetchPrMergedStatusREST(owner, repo, number, githubToken);
 	}
 
 	async function writeGithubIssuesPrs(items) {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -81,42 +81,6 @@ function handleUsernameValidationError(errMessage) {
 	}
 }
 
-function mapGitLabReportItem(item, projectById, type, gitlabApiBaseUrl) {
-	const project = projectById.get(item.project_id);
-	const repoName = project ? project.name : 'unknown';
-
-	return {
-		...item,
-		repository_url: `${gitlabApiBaseUrl}/projects/${item.project_id}`,
-		html_url:
-			type === 'issue'
-				? item.web_url || (project ? `${project.web_url}/-/issues/${item.iid}` : '')
-				: item.web_url || (project ? `${project.web_url}/-/merge_requests/${item.iid}` : ''),
-		number: item.iid,
-		title: item.title,
-		state: type === 'issue' && item.state === 'opened' ? 'open' : item.state,
-		project: repoName,
-		pull_request: type === 'mr',
-	};
-}
-
-function mapGitLabReportData(data, gitlabApiBaseUrl) {
-	const projects = Array.isArray(data.projects) ? data.projects : [];
-	const projectById = new Map(projects.map((project) => [project.id, project]));
-	const mappedIssues = (data.issues || []).map((issue) =>
-		mapGitLabReportItem(issue, projectById, 'issue', gitlabApiBaseUrl),
-	);
-	const mappedMRs = (data.mergeRequests || data.mrs || []).map((mr) =>
-		mapGitLabReportItem(mr, projectById, 'mr', gitlabApiBaseUrl),
-	);
-
-	return {
-		githubIssuesData: { items: mappedIssues },
-		githubPrsReviewData: { items: mappedMRs },
-		githubUserData: data.user || {},
-	};
-}
-
 function allIncluded(outputTarget = 'email') {
 	// Always re-instantiate gitlabHelper for gitlab platform to ensure fresh cache after refresh
 	if (platform === 'gitlab' || (typeof platform === 'undefined' && window.GitLabHelper)) {
@@ -310,7 +274,7 @@ function allIncluded(outputTarget = 'email') {
 										gitlabToken,
 									);
 
-									const mappedData = mapGitLabReportData(data, window.gitlabHelper.baseUrl);
+									const mappedData = window.gitlabHelper.mapGitLabReportData(data);
 									githubUserData = mappedData.githubUserData;
 
 									const name =
@@ -349,7 +313,7 @@ function allIncluded(outputTarget = 'email') {
 							window.gitlabHelper
 								.fetchGitLabData(platformUsernameLocal, startingDate, endingDate, gitlabToken)
 								.then((data) => {
-									const mappedData = mapGitLabReportData(data, window.gitlabHelper.baseUrl);
+									const mappedData = window.gitlabHelper.mapGitLabReportData(data);
 									processGithubData(mappedData);
 									scrumGenerationInProgress = false;
 								})


### PR DESCRIPTION

### 📌 Fixes

follow-up #507 


---

### 📝 Summary of Changes

- **GitHub API Decoupling:** Moved all direct `fetch()` calls and URL construction logic out of `src/scripts/scrumHelper.js` to make it a clean report builder and orchestrator.
- **Dedicated Helper Functions:** Created self-contained, globally accessible functions in `src/scripts/githubHelper.js`:
  - `githubFetchUser` (Checks user existence)
  - `githubFetchIssues` (Fetches authored issues/PRs)
  - `githubFetchReviews` / `githubFetchPullRequests` (Fetches reviewer PRs)
  - `githubFetchCommits` (GraphQL query batching for open PR commits)
  - `githubFetchPrMergedStatusREST` (REST check with preserved session caching)


---

### 📸 Screenshots / Demo (if UI-related)

N/A (Pure codebase refactoring with no UI or functional behavior changes)

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

This is a non-breaking codebase reorganization to separate network/API details from core report generation logic. 
All reporting formats, caching mechanics, date math, and authentication error handling pathways remain unchanged.