### PR TITLE
fix: replace unsafe innerHTML in domSanitizer with regex text extraction

### DIFF
--- a/src/scripts/domSanitizer.js
+++ b/src/scripts/domSanitizer.js
@@ -10,6 +10,17 @@ function sanitizeHtml(html) {
 		return DOMPurify.sanitize(html, SCRUM_SANITIZER_CONFIG);
 	}
 	console.warn('[scrum_helper] DOMPurify unavailable, falling back to basic text extraction');
-	// Safely strip HTML tags without touching the DOM to completely bypass Trusted Types crashes
-	return typeof html === 'string' ? html.replace(/<[^>]*>?/gm, '') : '';
+	
+	if (typeof html !== 'string') return '';
+	
+	//Step 1: Strip tags so the user doesn't see raw HTML on the screen
+	const stripped = html.replace(/<[^>]*>?/gm, '');
+	
+	//Step 2: Escape any remaining characters to guarantee safety in .innerHTML
+	return stripped
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#039;');
 }

--- a/src/scripts/domSanitizer.js
+++ b/src/scripts/domSanitizer.js
@@ -9,8 +9,7 @@ function sanitizeHtml(html) {
 	if (typeof DOMPurify !== 'undefined') {
 		return DOMPurify.sanitize(html, SCRUM_SANITIZER_CONFIG);
 	}
-	console.warn('[scrum_helper] DOMPurify unavailable, falling back to Text');
-	const div = document.createElement('div');
-	div.innerHTML = html;
-	return div.textContent || div.innerText || '';
+	console.warn('[scrum_helper] DOMPurify unavailable, falling back to basic text extraction');
+	// Safely strip HTML tags without touching the DOM to completely bypass Trusted Types crashes
+	return typeof html === 'string' ? html.replace(/<[^>]*>?/gm, '') : '';
 }

--- a/src/scripts/domSanitizer.js
+++ b/src/scripts/domSanitizer.js
@@ -10,12 +10,12 @@ function sanitizeHtml(html) {
 		return DOMPurify.sanitize(html, SCRUM_SANITIZER_CONFIG);
 	}
 	console.warn('[scrum_helper] DOMPurify unavailable, falling back to basic text extraction');
-	
+
 	if (typeof html !== 'string') return '';
-	
+
 	//Step 1: Strip tags so the user doesn't see raw HTML on the screen
 	const stripped = html.replace(/<[^>]*>?/gm, '');
-	
+
 	//Step 2: Escape any remaining characters to guarantee safety in .innerHTML
 	return stripped
 		.replace(/&/g, '&amp;')

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -663,37 +663,38 @@ document.addEventListener('DOMContentLoaded', () => {
 			if (!generateBtn._triggeredByShortcut) {
 				showPopupMessage(browser.i18n.getMessage('generatingReportNotification'));
 			}
-			browser.storage.local.get(['platform']).then((result) => {
-				platformUsername.classList.remove('input-error');
-				usernameError.classList.remove('errorMessage');
-				usernameError.textContent = '';
-				const platform = result.platform || 'github';
-				const platformUsernameKey = `${platform}Username`;
+			browser.storage.local
+				.get(['platform'])
+				.then((result) => {
+					platformUsername.classList.remove('input-error');
+					usernameError.classList.remove('errorMessage');
+					usernameError.textContent = '';
+					const platform = result.platform || 'github';
+					const platformUsernameKey = `${platform}Username`;
 
-				return browser.storage.local
-					.set({
-						platform: platformSelect.value,
-						[platformUsernameKey]: platformUsername.value,
-					})
-					.then(() => {
-						// Reload platform from storage before generating report
-						return browser.storage.local.get(['platform']).then((res) => {
-							platformSelect.value = res.platform || 'github';
-							updatePlatformUI(platformSelect.value);
-							generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
-							generateBtn.disabled = true;
-							window.generateScrumReport && window.generateScrumReport();
-							generateBtn._triggeredByShortcut = false;
-
-
+					return browser.storage.local
+						.set({
+							platform: platformSelect.value,
+							[platformUsernameKey]: platformUsername.value,
+						})
+						.then(() => {
+							// Reload platform from storage before generating report
+							return browser.storage.local.get(['platform']).then((res) => {
+								platformSelect.value = res.platform || 'github';
+								updatePlatformUI(platformSelect.value);
+								generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
+								generateBtn.disabled = true;
+								window.generateScrumReport && window.generateScrumReport();
+								generateBtn._triggeredByShortcut = false;
+							});
 						});
-					});
-			}).finally(() => {
-				if (generateBtn._triggeredByShortcut) {
-					dismissShortcutTooltipFocus(generateBtn);
-					generateBtn._triggeredByShortcut = false;
-				}
-			});
+				})
+				.finally(() => {
+					if (generateBtn._triggeredByShortcut) {
+						dismissShortcutTooltipFocus(generateBtn);
+						generateBtn._triggeredByShortcut = false;
+					}
+				});
 		});
 
 		copyBtn.addEventListener('click', function () {
@@ -1299,10 +1300,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			const groups = new Map();
 
 			repos.forEach((repo) => {
-				const owner =
-					repo.fullName && repo.fullName.includes('/')
-						? repo.fullName.split('/')[0]
-						: 'Unknown';
+				const owner = repo.fullName && repo.fullName.includes('/') ? repo.fullName.split('/')[0] : 'Unknown';
 
 				if (!groups.has(owner)) {
 					groups.set(owner, []);
@@ -1314,9 +1312,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
 				.map((owner) => ({
 					owner,
-					repos: groups
-						.get(owner)
-						.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })),
+					repos: groups.get(owner).sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })),
 				}));
 		}
 


### PR DESCRIPTION
### 📌 Fixes

Fixes #694

---

### 📝 Summary of Changes

Replaced the unsafe innerHTML fallback inside domSanitizer.js with a pure regex string replacement (html.replace(/<[^>]*>?/gm, '')).
Why: The previous fallback created an XSS vulnerability when DOMPurify was unavailable. Furthermore, any DOM-based fallback (even DOMParser) causes a TypeError and crashes the extension completely on secure sites enforcing strict TrustedHTML policies (like GitHub). By using regex, we safely extract text without invoking DOM-creation APIs, completely bypassing both XSS and Trusted Types CSP crashes.

---

### 📸 Screenshots / Demo (if UI-related)

Please see the linked issue for console screenshots proving the Trusted Types crash and the XSS vulnerability.
<img width="801" height="456" alt="Screenshot 2026-06-20 121141" src="https://github.com/user-attachments/assets/c0945c73-05ea-4e1a-ab2d-724579387883" />

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

I specifically opted for regex string replacement rather than DOMParser because local testing revealed that new DOMParser().parseFromString(html, 'text/html') also triggers a Trusted Types violation on GitHub, which completely crashes the extension. The regex approach gracefully strips HTML without ever touching the DOM.



