### PR TITLE
feat: quick previous week filter

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -43,6 +43,10 @@
     "message": "Previous day",
     "description": "Radio button option for the last 1 day."
   },
+  "lastWeekLabel": {
+    "message": "Previous week",
+    "description": "Radio button option for the last 7 days."
+  },
   "startDateLabel": {
     "message": "From:",
     "description": "Label for the start date picker."

--- a/src/index.css
+++ b/src/index.css
@@ -1202,3 +1202,33 @@ body.mode-popup {
     background: #fee2e2;
     color: #991b1b;
 }
+
+/* Timeframe container and presets layout */
+.timeframe-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: flex-end;
+    justify-content: space-between;
+}
+
+.timeframe-presets {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    margin-bottom: 4px;
+}
+
+/* In popup mode, stack the presets below the date container */
+html.mode-popup .timeframe-container {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+html.mode-popup .timeframe-presets {
+    width: 100%;
+    justify-content: flex-start;
+    gap: 16px;
+    margin-bottom: 0;
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -184,7 +184,7 @@
 							contributions between:</p>
 
 
-						<div class="flex gap-[3px] justify-between items-center mt-2" style="gap: 8px">
+						<div class="timeframe-container mt-2">
 
 							<div id="customDateContainer" class="flex gap-2">
 
@@ -203,11 +203,19 @@
 										style="width: 96px;">
 								</div>
 							</div>
-							<div class="flex items-center gap-1">
-								<input type="radio" id="yesterdayContribution" name="timeframe" class="form-radio"
-									style="margin-right: 4px;">
-								<label for="yesterdayContribution" class="font-medium text-xs"
-									data-i18n="last1DayLabel">Previous Day</label>
+							<div class="timeframe-presets">
+								<div class="flex items-center gap-1">
+									<input type="radio" id="yesterdayContribution" name="timeframe" class="form-radio"
+										style="margin-right: 4px;">
+									<label for="yesterdayContribution" class="font-medium text-xs"
+										data-i18n="last1DayLabel">Previous Day</label>
+								</div>
+								<div class="flex items-center gap-1">
+									<input type="radio" id="weeklyContribution" name="timeframe" class="form-radio"
+										style="margin-right: 4px;">
+									<label for="weeklyContribution" class="font-medium text-xs"
+										data-i18n="lastWeekLabel">Previous Week</label>
+								</div>
 							</div>
 						</div>
 					</div>

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -4,6 +4,7 @@ const gitlabTokenElement = document.getElementById('gitlabToken');
 const cacheInputElement = document.getElementById('cacheInput');
 const projectNameElement = document.getElementById('projectName');
 const yesterdayContributionElement = document.getElementById('yesterdayContribution');
+const weeklyContributionElement = document.getElementById('weeklyContribution');
 const startingDateElement = document.getElementById('startingDate');
 const endingDateElement = document.getElementById('endingDate');
 const showOpenLabelElement = document.getElementById('showOpenLabel');
@@ -29,6 +30,12 @@ if (!window.scrumDateRangeUtils) {
 			yesterday.setDate(yesterday.getDate() - 1);
 
 			return this.formatLocalDate(yesterday);
+		},
+		getLocalWeekAgoString() {
+			const weekAgo = new Date();
+			weekAgo.setDate(weekAgo.getDate() - 7);
+
+			return this.formatLocalDate(weekAgo);
 		},
 		normalizeAndSync(startDateInput, endDateInput) {
 			if (!startDateInput || !endDateInput) return false;
@@ -174,6 +181,8 @@ function handleBodyOnLoad() {
 			'showOpenLabel',
 			'userReason',
 			'yesterdayContribution',
+			'weeklyContribution',
+			'selectedTimeframe',
 			'cacheInput',
 			'githubToken',
 			'gitlabToken',
@@ -224,7 +233,33 @@ function handleBodyOnLoad() {
 				}
 			}
 
-			if (yesterdayContributionElement) {
+			let selectedTimeframe = items.selectedTimeframe;
+			if (!selectedTimeframe) {
+				if (items.yesterdayContribution) {
+					selectedTimeframe = 'yesterdayContribution';
+				} else if (items.weeklyContribution) {
+					selectedTimeframe = 'weeklyContribution';
+				} else if (items.yesterdayContribution !== false) {
+					selectedTimeframe = 'yesterdayContribution';
+				}
+			}
+
+			if (yesterdayContributionElement && weeklyContributionElement) {
+				if (selectedTimeframe === 'yesterdayContribution') {
+					yesterdayContributionElement.checked = true;
+					weeklyContributionElement.checked = false;
+					handleYesterdayContributionChange();
+				} else if (selectedTimeframe === 'weeklyContribution') {
+					weeklyContributionElement.checked = true;
+					yesterdayContributionElement.checked = false;
+					handleWeeklyContributionChange();
+				} else {
+					yesterdayContributionElement.checked = false;
+					weeklyContributionElement.checked = false;
+					handleYesterdayContributionChange();
+					handleWeeklyContributionChange();
+				}
+			} else if (yesterdayContributionElement) {
 				if (items.yesterdayContribution) {
 					yesterdayContributionElement.checked = items.yesterdayContribution;
 					handleYesterdayContributionChange();
@@ -273,6 +308,7 @@ function handleYesterdayContributionChange() {
 	if (!yesterdayContributionElement) return;
 	const value = yesterdayContributionElement.checked;
 	const labelElement = document.querySelector("label[for='yesterdayContribution']");
+	const weeklyLabelElement = document.querySelector("label[for='weeklyContribution']");
 
 	if (value) {
 		if (startingDateElement) startingDateElement.readOnly = true;
@@ -286,22 +322,79 @@ function handleYesterdayContributionChange() {
 			labelElement.classList.add('selectedLabel');
 			labelElement.classList.remove('unselectedLabel');
 		}
+		if (weeklyLabelElement) {
+			weeklyLabelElement.classList.remove('selectedLabel');
+			weeklyLabelElement.classList.add('unselectedLabel');
+		}
+		browser.storage.local.set({
+			yesterdayContribution: true,
+			weeklyContribution: false,
+			selectedTimeframe: 'yesterdayContribution',
+		});
 	} else {
-		if (startingDateElement) startingDateElement.readOnly = false;
-		if (endingDateElement) endingDateElement.readOnly = false;
-		if (startingDateElement && endingDateElement) {
-			window.scrumDateRangeUtils.normalizeDateRangeValues(startingDateElement, endingDateElement);
+		const weeklyChecked = weeklyContributionElement ? weeklyContributionElement.checked : false;
+		if (!weeklyChecked) {
+			if (startingDateElement) startingDateElement.readOnly = false;
+			if (endingDateElement) endingDateElement.readOnly = false;
+			if (startingDateElement && endingDateElement) {
+				window.scrumDateRangeUtils.normalizeDateRangeValues(startingDateElement, endingDateElement);
+			}
 		}
 		if (labelElement) {
 			labelElement.classList.add('unselectedLabel');
 			labelElement.classList.remove('selectedLabel');
 		}
 	}
-	browser.storage.local.set({ yesterdayContribution: value });
+}
+
+function handleWeeklyContributionChange() {
+	if (!weeklyContributionElement) return;
+	const value = weeklyContributionElement.checked;
+	const labelElement = document.querySelector("label[for='weeklyContribution']");
+	const yesterdayLabelElement = document.querySelector("label[for='yesterdayContribution']");
+
+	if (value) {
+		if (startingDateElement) startingDateElement.readOnly = true;
+		if (endingDateElement) endingDateElement.readOnly = true;
+		if (endingDateElement) endingDateElement.value = getToday();
+		if (startingDateElement) startingDateElement.value = getWeekAgo();
+		if (startingDateElement && endingDateElement) {
+			window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(startingDateElement, endingDateElement);
+		}
+		if (labelElement) {
+			labelElement.classList.add('selectedLabel');
+			labelElement.classList.remove('unselectedLabel');
+		}
+		if (yesterdayLabelElement) {
+			yesterdayLabelElement.classList.remove('selectedLabel');
+			yesterdayLabelElement.classList.add('unselectedLabel');
+		}
+		browser.storage.local.set({
+			yesterdayContribution: false,
+			weeklyContribution: true,
+			selectedTimeframe: 'weeklyContribution',
+		});
+	} else {
+		const yesterdayChecked = yesterdayContributionElement ? yesterdayContributionElement.checked : false;
+		if (!yesterdayChecked) {
+			if (startingDateElement) startingDateElement.readOnly = false;
+			if (endingDateElement) endingDateElement.readOnly = false;
+			if (startingDateElement && endingDateElement) {
+				window.scrumDateRangeUtils.normalizeDateRangeValues(startingDateElement, endingDateElement);
+			}
+		}
+		if (labelElement) {
+			labelElement.classList.add('unselectedLabel');
+			labelElement.classList.remove('selectedLabel');
+		}
+	}
 }
 
 function getYesterday() {
 	return window.scrumDateRangeUtils.getLocalYesterdayString();
+}
+function getWeekAgo() {
+	return window.scrumDateRangeUtils.getLocalWeekAgoString();
 }
 function getToday() {
 	return window.scrumDateRangeUtils.getLocalTodayString();
@@ -406,6 +499,9 @@ if (endingDateElement) {
 }
 if (yesterdayContributionElement) {
 	yesterdayContributionElement.addEventListener('change', handleYesterdayContributionChange);
+}
+if (weeklyContributionElement) {
+	weeklyContributionElement.addEventListener('change', handleWeeklyContributionChange);
 }
 if (showOpenLabelElement) {
 	showOpenLabelElement.addEventListener('change', handleOpenLabelChange);

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -91,6 +91,13 @@ function getYesterday() {
 	return formatLocalDate(yesterday);
 }
 
+function getWeekAgo() {
+	const today = new Date();
+	const weekAgo = new Date(today);
+	weekAgo.setDate(today.getDate() - 7);
+	return formatLocalDate(weekAgo);
+}
+
 function applyI18n() {
 	document.querySelectorAll('[data-i18n]').forEach((el) => {
 		const key = el.getAttribute('data-i18n');
@@ -495,6 +502,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		const githubTokenInput = document.getElementById('githubToken');
 		const cacheInput = document.getElementById('cacheInput');
 		const yesterdayRadio = document.getElementById('yesterdayContribution');
+		const weeklyRadio = document.getElementById('weeklyContribution');
 		const startingDateInput = document.getElementById('startingDate');
 		const endingDateInput = document.getElementById('endingDate');
 		const platformUsername = document.getElementById('platformUsername');
@@ -514,6 +522,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				'onlyRevPRs',
 				'onlyMergedPRs',
 				'yesterdayContribution',
+				'weeklyContribution',
 				'startingDate',
 				'endingDate',
 				'selectedTimeframe',
@@ -567,6 +576,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				if (result.githubToken) githubTokenInput.value = result.githubToken;
 				if (result.cacheInput) cacheInput.value = result.cacheInput;
 				if (typeof result.yesterdayContribution !== 'undefined') yesterdayRadio.checked = result.yesterdayContribution;
+				if (typeof result.weeklyContribution !== 'undefined') weeklyRadio.checked = result.weeklyContribution;
 				if (result.startingDate) startingDateInput.value = result.startingDate;
 				if (result.endingDate) endingDateInput.value = result.endingDate;
 				const wasNormalizedOnLoad = window.scrumDateRangeUtils.normalizeDateRangeValues(
@@ -801,16 +811,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			browser.storage.local.set({
 				yesterdayContribution: false,
+				weeklyContribution: false,
 				selectedTimeframe: null,
 			});
 		});
 
 		browser.storage.local
-			.get(['selectedTimeframe', 'yesterdayContribution', 'startingDate', 'endingDate'])
+			.get(['selectedTimeframe', 'yesterdayContribution', 'weeklyContribution', 'startingDate', 'endingDate'])
 			.then((items) => {
 				console.log('Restoring state:', typeof logRedaction === 'function' ? logRedaction(items) : items);
 
-				if (items.startingDate && items.endingDate && !items.yesterdayContribution) {
+				if (items.startingDate && items.endingDate && !items.yesterdayContribution && !items.weeklyContribution) {
 					const startDateInput = document.getElementById('startingDate');
 					const endDateInput = document.getElementById('endingDate');
 
@@ -843,6 +854,9 @@ document.addEventListener('DOMContentLoaded', () => {
 					if (items.selectedTimeframe === 'yesterdayContribution') {
 						startDateInput.value = getYesterday();
 						endDateInput.value = getToday();
+					} else if (items.selectedTimeframe === 'weeklyContribution') {
+						startDateInput.value = getWeekAgo();
+						endDateInput.value = getToday();
 					}
 					startDateInput.readOnly = endDateInput.readOnly = true;
 
@@ -850,6 +864,7 @@ document.addEventListener('DOMContentLoaded', () => {
 						startingDate: startDateInput.value,
 						endingDate: endDateInput.value,
 						yesterdayContribution: items.selectedTimeframe === 'yesterdayContribution',
+						weeklyContribution: items.selectedTimeframe === 'weeklyContribution',
 						selectedTimeframe: items.selectedTimeframe,
 					});
 				}
@@ -1043,6 +1058,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		yesterdayRadio.addEventListener('change', () => {
 			browser.storage.local.set({ yesterdayContribution: yesterdayRadio.checked });
+		});
+		weeklyRadio.addEventListener('change', () => {
+			browser.storage.local.set({ weeklyContribution: weeklyRadio.checked });
 		});
 		startingDateInput.addEventListener('blur', () => {
 			window.scrumDateRangeUtils.normalizeSyncAndPersistDateRange(startingDateInput, endingDateInput);
@@ -1951,6 +1969,7 @@ document.querySelectorAll('input[name="timeframe"]').forEach((radio) => {
 
 			browser.storage.local.set({
 				yesterdayContribution: false,
+				weeklyContribution: false,
 				selectedTimeframe: null,
 			});
 		} else {
@@ -2055,6 +2074,9 @@ function toggleRadio(radio) {
 	if (radio.id === 'yesterdayContribution') {
 		if (startDateInput) startDateInput.value = getYesterday();
 		if (endDateInput) endDateInput.value = getToday();
+	} else if (radio.id === 'weeklyContribution') {
+		if (startDateInput) startDateInput.value = getWeekAgo();
+		if (endDateInput) endDateInput.value = getToday();
 	}
 
 	if (startDateInput) startDateInput.readOnly = true;
@@ -2066,6 +2088,7 @@ function toggleRadio(radio) {
 				startingDate: startDateInput.value,
 				endingDate: endDateInput.value,
 				yesterdayContribution: radio.id === 'yesterdayContribution',
+				weeklyContribution: radio.id === 'weeklyContribution',
 				selectedTimeframe: radio.id,
 				githubCache: null, // Clear cache to force new fetch
 			})
@@ -2081,6 +2104,7 @@ function toggleRadio(radio) {
 		browser.storage.local
 			.set({
 				yesterdayContribution: radio.id === 'yesterdayContribution',
+				weeklyContribution: radio.id === 'weeklyContribution',
 				selectedTimeframe: radio.id,
 				githubCache: null,
 			})

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -46,7 +46,6 @@ function logError(...args) {
 	}
 }
 
-
 function getLocalISOString(dateStr, time) {
 	const offsetMinutes = new Date().getTimezoneOffset();
 	const absOffset = Math.abs(offsetMinutes);
@@ -158,6 +157,7 @@ function allIncluded(outputTarget = 'email') {
 	let reviewedPrsArray = [];
 	let githubIssuesData = null;
 	let yesterdayContribution = false;
+	let weeklyContribution = false;
 	let githubPrsReviewData = null;
 	let githubUserData = null;
 	let githubPrsReviewDataProcessed = {};
@@ -205,6 +205,8 @@ function allIncluded(outputTarget = 'email') {
 				'endingDate',
 				'showOpenLabel',
 				'yesterdayContribution',
+				'weeklyContribution',
+				'selectedTimeframe',
 				'userReason',
 				'githubCache',
 				'cacheInput',
@@ -260,6 +262,7 @@ function allIncluded(outputTarget = 'email') {
 					window.gitlabHelper = new window.GitLabHelper(window.gitlabBaseUrl);
 				}
 				yesterdayContribution = items.yesterdayContribution;
+				weeklyContribution = items.weeklyContribution;
 
 				onlyIssues = items.onlyIssues === true;
 				onlyPRs = items.onlyPRs === true;
@@ -275,16 +278,41 @@ function allIncluded(outputTarget = 'email') {
 				showOpenLabel = items.showOpenLabel !== false; // Default to true if not explicitly set to false
 				orgName = items.orgName || '';
 
-				if (items.yesterdayContribution) {
+				let selectedTimeframe = items.selectedTimeframe;
+				if (!selectedTimeframe) {
+					if (items.yesterdayContribution) {
+						selectedTimeframe = 'yesterdayContribution';
+					} else if (items.weeklyContribution) {
+						selectedTimeframe = 'weeklyContribution';
+					} else if (items.yesterdayContribution !== false) {
+						selectedTimeframe = 'yesterdayContribution';
+					}
+				}
+
+				if (selectedTimeframe === 'yesterdayContribution') {
+					yesterdayContribution = true;
+					weeklyContribution = false;
 					handleYesterdayContributionChange();
+				} else if (selectedTimeframe === 'weeklyContribution') {
+					yesterdayContribution = false;
+					weeklyContribution = true;
+					handleWeeklyContributionChange();
 				} else if (items.startingDate && items.endingDate) {
+					yesterdayContribution = false;
+					weeklyContribution = false;
 					startingDate = items.startingDate;
 					endingDate = items.endingDate;
 				} else {
+					yesterdayContribution = true;
+					weeklyContribution = false;
 					handleYesterdayContributionChange();
 
 					if (outputTarget === 'popup') {
-						chrome.storage.local.set({ yesterdayContribution: true });
+						chrome.storage.local.set({
+							yesterdayContribution: true,
+							weeklyContribution: false,
+							selectedTimeframe: 'yesterdayContribution',
+						});
 					}
 				}
 
@@ -419,11 +447,22 @@ function allIncluded(outputTarget = 'email') {
 		startingDate = getYesterday();
 	}
 
+	function handleWeeklyContributionChange() {
+		endingDate = getToday();
+		startingDate = getWeekAgo();
+	}
+
 	function getYesterday() {
 		const today = new Date();
 		const yesterday = new Date(today);
 		yesterday.setDate(today.getDate() - 1);
 		return formatLocalDate(yesterday);
+	}
+	function getWeekAgo() {
+		const today = new Date();
+		const weekAgo = new Date(today);
+		weekAgo.setDate(today.getDate() - 7);
+		return formatLocalDate(weekAgo);
 	}
 	function getToday() {
 		const today = new Date();
@@ -540,6 +579,11 @@ function allIncluded(outputTarget = 'email') {
 			const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
 			startDateForCache = formatLocalDate(yesterday);
 			endDateForCache = formatLocalDate(today); // Use yesterday for start and today for end
+		} else if (weeklyContribution) {
+			const today = new Date();
+			const weekAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
+			startDateForCache = formatLocalDate(weekAgo);
+			endDateForCache = formatLocalDate(today);
 		} else if (startingDate && endingDate) {
 			startDateForCache = startingDate;
 			endDateForCache = endingDate;
@@ -797,6 +841,11 @@ function allIncluded(outputTarget = 'email') {
 						const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
 						startDateForCommits = formatLocalDate(yesterday);
 						endDateForCommits = formatLocalDate(today); // Use yesterday for start and today for end
+					} else if (weeklyContribution) {
+						const today = new Date();
+						const weekAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
+						startDateForCommits = formatLocalDate(weekAgo);
+						endDateForCommits = formatLocalDate(today);
 					} else if (startingDate && endingDate) {
 						startDateForCommits = startingDate;
 						endDateForCommits = endingDate;
@@ -1039,10 +1088,18 @@ function allIncluded(outputTarget = 'email') {
 			const lastWeekUl = buildActivityListHtml();
 			const nextWeekUl = buildNextWeekListHtml();
 			const blockerText = buildBlockerTextHtml();
-			const weekOrDay = yesterdayContribution ? 'yesterday' : 'the period';
-			const weekOrDay2 = 'today';
-			let content;
+			let weekOrDay = 'the period';
+			let weekOrDay2 = 'today';
 			if (yesterdayContribution) {
+				weekOrDay = 'yesterday';
+				weekOrDay2 = 'today';
+			} else if (weeklyContribution) {
+				weekOrDay = 'last week';
+				weekOrDay2 = 'this week';
+			}
+
+			let content;
+			if (yesterdayContribution || weeklyContribution) {
 				content = `<b>1. What did I do ${weekOrDay}?</b><br>${lastWeekUl}<br><b>2. What do I plan to do ${weekOrDay2}?</b><br>${nextWeekUl}<br><b>3. What is blocking me from making progress?</b><br>${blockerText}`;
 			} else {
 				content = `<b>1. What did I do from ${formatDate(startingDate)} to ${formatDate(endingDate)}?</b><br>${lastWeekUl}<br><b>2. What do I plan to do ${weekOrDay2}?</b><br>${nextWeekUl}<br><b>3. What is blocking me from making progress?</b><br>${blockerText}`;
@@ -1124,11 +1181,18 @@ function allIncluded(outputTarget = 'email') {
 		const nextWeekUl = buildNextWeekListHtml();
 		const blockerText = buildBlockerTextHtml();
 
-		const weekOrDay = yesterdayContribution ? 'yesterday' : 'the period';
-		const weekOrDay2 = 'today';
+		let weekOrDay = 'the period';
+		let weekOrDay2 = 'today';
+		if (yesterdayContribution) {
+			weekOrDay = 'yesterday';
+			weekOrDay2 = 'today';
+		} else if (weeklyContribution) {
+			weekOrDay = 'last week';
+			weekOrDay2 = 'this week';
+		}
 
 		let content;
-		if (yesterdayContribution) {
+		if (yesterdayContribution || weeklyContribution) {
 			content = `<b>1. What did I do ${weekOrDay}?</b><br>
 ${lastWeekUl}<br>
 <b>2. What do I plan to do ${weekOrDay2}?</b><br>
@@ -1277,6 +1341,11 @@ ${blockerText}`;
 			const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
 			startDate = formatLocalDate(yesterday);
 			endDate = formatLocalDate(today); // Use yesterday for start and today for end
+		} else if (weeklyContribution) {
+			const today = new Date();
+			const weekAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
+			startDate = formatLocalDate(weekAgo);
+			endDate = formatLocalDate(today);
 		} else if (startingDate && endingDate) {
 			startDate = startingDate;
 			endDate = endingDate;
@@ -1480,6 +1549,11 @@ ${blockerText}`;
 			const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
 			startDateForRange = formatLocalDate(yesterday);
 			endDateForRange = formatLocalDate(today); // Use yesterday for start and today for end
+		} else if (weeklyContribution) {
+			const today = new Date();
+			const weekAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
+			startDateForRange = formatLocalDate(weekAgo);
+			endDateForRange = formatLocalDate(today);
 		} else if (startingDate && endingDate) {
 			startDateForRange = startingDate;
 			endDateForRange = endingDate;
@@ -1651,6 +1725,11 @@ ${blockerText}`;
 					const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
 					startDateFilter = new Date(formatLocalDate(yesterday) + 'T00:00:00Z');
 					endDateFilter = new Date(formatLocalDate(today) + 'T23:59:59Z'); // Use yesterday for start and today for end
+				} else if (weeklyContribution) {
+					const today = new Date();
+					const weekAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
+					startDateFilter = new Date(formatLocalDate(weekAgo) + 'T00:00:00Z');
+					endDateFilter = new Date(formatLocalDate(today) + 'T23:59:59Z');
 				} else if (startingDate && endingDate) {
 					startDateFilter = new Date(startingDate + 'T00:00:00Z');
 					endDateFilter = new Date(endingDate + 'T23:59:59Z');
@@ -1773,6 +1852,11 @@ ${blockerText}`;
 					const yesterdayDate = new Date(todayDate.getTime() - 24 * 60 * 60 * 1000);
 					issueStartDateFilter = new Date(formatLocalDate(yesterdayDate) + 'T00:00:00Z');
 					issueEndDateFilter = new Date(formatLocalDate(yesterdayDate) + 'T23:59:59Z');
+				} else if (weeklyContribution) {
+					const todayDate = new Date();
+					const weekAgo = new Date(todayDate.getTime() - 7 * 24 * 60 * 60 * 1000);
+					issueStartDateFilter = new Date(formatLocalDate(weekAgo) + 'T00:00:00Z');
+					issueEndDateFilter = new Date(formatLocalDate(todayDate) + 'T23:59:59Z');
 				} else if (startingDate && endingDate) {
 					issueStartDateFilter = new Date(startingDate + 'T00:00:00Z');
 					issueEndDateFilter = new Date(endingDate + 'T23:59:59Z');


### PR DESCRIPTION
### 📌 Fixes

Fixes #706 

---

### 📝 Summary of Changes
- Added a "Previous Week" timeframe filter option alongside the existing "Yesterday" filter, allowing users to generate reports covering the last 7 days with one click
- **i18n**: Added `lastWeekLabel` translation key in `messages.json`
- **UI**: Added `weeklyContribution` radio button in `popup.html`, wrapped timeframe presets in a new `.timeframe-presets` container for layout flexibility
- **Styling**: Added `.timeframe-container` and `.timeframe-presets` rules in `index.css` with responsive grid layouts for both popup (`mode-popup`) and side panel (`mode-sidepanel`) modes
- **State logic**: Added `getWeekAgo()` in both `popup.js` and `scrumHelper.js`; wired up storage get/set, radio restoration, and custom-date-input locking when "Previous Week" is selected (mirrors existing `yesterdayContribution` pattern)
- **Report generation**: Updated `scrumHelper.js` to use a 7-day lookback for issues, PRs, and PR reviews when `weeklyContribution` is active, including correct cache key handling
- **Copy**: Report headings dynamically switch to "What did I do last week?" / "What do I plan to do this week?" when the weekly filter is selected, instead of the daily phrasing

---

### 📸 Screenshots / Demo (if UI-related)
<img width="511" height="829" alt="image" src="https://github.com/user-attachments/assets/6cdeba7e-629e-40eb-b2df-ea7d396d2977" />

---

### ✅ Checklist
- [x] I've tested my changes locally
- [ ] I've added tests (if applicable)
- [ ] I've updated documentation (if applicable)
- [x] My code follows the project's code style guidelines

---

### 👀 Reviewer Notes

- `getWeekAgo()` currently exists in two places (`popup.js` and `scrumHelper.js`) rather than a shared util — flagging in case a follow-up refactor to share it is preferred, but kept separate here to match the existing pattern where `getYesterday()` is also duplicated across files