### PR TITLE
fix: Use reviewed-by instead of commenter for accurate PR review filtering

### DIFF
--- a/src/scripts/githubHelper.js
+++ b/src/scripts/githubHelper.js
@@ -726,9 +726,9 @@ async function githubFetchReviews(username, token, startDate, endDate, orgName, 
 	const orgQuery = orgPart ? `+${orgPart}` : '';
 	let url;
 	if (repoQueries) {
-		url = `https://api.github.com/search/issues?q=commenter%3A${username}+${repoQueries}${orgQuery}+updated%3A${startDate}..${endDate}&per_page=100`;
+		url = `https://api.github.com/search/issues?q=reviewed-by%3A${username}+${repoQueries}${orgQuery}+updated%3A${startDate}..${endDate}&per_page=100`;
 	} else {
-		url = `https://api.github.com/search/issues?q=commenter%3A${username}${orgQuery}+updated%3A${startDate}..${endDate}&per_page=100`;
+		url = `https://api.github.com/search/issues?q=reviewed-by%3A${username}${orgQuery}+updated%3A${startDate}..${endDate}&per_page=100`;
 	}
 	return fetch(url, { headers });
 }

--- a/src/scripts/githubHelper.js
+++ b/src/scripts/githubHelper.js
@@ -726,9 +726,9 @@ async function githubFetchReviews(username, token, startDate, endDate, orgName, 
 	const orgQuery = orgPart ? `+${orgPart}` : '';
 	let url;
 	if (repoQueries) {
-		url = `https://api.github.com/search/issues?q=reviewed-by%3A${username}+${repoQueries}${orgQuery}+updated%3A${startDate}..${endDate}&per_page=100`;
+		url = `https://api.github.com/search/issues?q=reviewed-by%3A${username}+${repoQueries}${orgQuery}+type%3Apr+updated%3A${startDate}..${endDate}&per_page=100`;
 	} else {
-		url = `https://api.github.com/search/issues?q=reviewed-by%3A${username}${orgQuery}+updated%3A${startDate}..${endDate}&per_page=100`;
+		url = `https://api.github.com/search/issues?q=reviewed-by%3A${username}${orgQuery}+type%3Apr+updated%3A${startDate}..${endDate}&per_page=100`;
 	}
 	return fetch(url, { headers });
 }


### PR DESCRIPTION
### 📌 Fixes
Fixes #711 <issue-number> 

---

### 📝 Summary of Changes

**Problem:**
The "PR reviews" section was fetching PRs using the `commenter:` search qualifier, which matches **any PR where the user left a comment** not PRs they actually formally reviewed. A user could leave a single passing comment on a PR without ever formally reviewing it, and it would still appear in their "reviewed" section.

**Solution:**
Replaced `commenter:` with `reviewed-by:` search qualifier in the GitHub API query to accurately fetch only PRs that the user has formally reviewed (approved, requested changes, or left a review comment).

**Changes Made:**
- **File:** `src/scripts/githubHelper.js`
- **New Query:** `reviewed-by:${username}+type:pr`
- **Added:** `type:pr` filter to ensure only pull requests are returned


**Why This Matters:**
-  More accurate filtering of actual PR reviews
-  Distinguishes between casual comments and formal code reviews
-  Better aligns with user expectations of what "reviewed PRs" means
-  Respects GitHub's review semantics (approved/changes-requested/commented)

---

### 📸 Screenshots / Demo

---

### ✅ Checklist
- [x] I've tested my changes locally
- [x] Code follows the project's code style guidelines
- [ ] I've updated documentation (if applicable)

  
**Note:** Requires GitHub authentication token (Personal Access Token) as per GitHub API documentation

---

### 👀 Reviewer Notes

**Important:** 

- The `reviewed-by:` qualifier is more restrictive than `commenter:`, so results will be fewer but more accurate
