### PR TITLE
fix: Add accurate review-date filtering for reviewed PRs 

### DIFF
--- a/src/scripts/githubHelper.js
+++ b/src/scripts/githubHelper.js
@@ -726,15 +726,28 @@ async function githubFetchReviews(username, token, startDate, endDate, orgName, 
 	const orgQuery = orgPart ? `+${orgPart}` : '';
 	let url;
 	if (repoQueries) {
-		url = `https://api.github.com/search/issues?q=commenter%3A${username}+${repoQueries}${orgQuery}+updated%3A${startDate}..${endDate}&per_page=100`;
+		url = `https://api.github.com/search/issues?q=reviewed-by%3A${username}+${repoQueries}${orgQuery}+updated%3A${startDate}..${endDate}&per_page=100`;
 	} else {
-		url = `https://api.github.com/search/issues?q=commenter%3A${username}${orgQuery}+updated%3A${startDate}..${endDate}&per_page=100`;
+		url = `https://api.github.com/search/issues?q=reviewed-by%3A${username}${orgQuery}+updated%3A${startDate}..${endDate}&per_page=100`;
 	}
 	return fetch(url, { headers });
 }
 
 async function githubFetchPullRequests(username, token, startDate, endDate, orgName, repoQueries) {
 	return githubFetchReviews(username, token, startDate, endDate, orgName, repoQueries);
+}
+
+async function githubFetchPrReviews(owner, repo, prNumber, token) {
+	const headers = { Accept: 'application/vnd.github.v3+json' };
+	if (token) {
+		headers.Authorization = `token ${token}`;
+	}
+	const url = `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/reviews`;
+	const res = await fetch(url, { headers });
+	if (!res.ok) {
+		throw new Error(`Failed to fetch reviews for ${owner}/${repo}#${prNumber}: ${res.status} ${res.statusText}`);
+	}
+	return res.json();
 }
 
 async function githubFetchCommits(prs, githubToken, startDate, endDate) {
@@ -836,6 +849,7 @@ async function githubFetchPrMergedStatusREST(owner, repo, number, token) {
 window.githubFetchUser = githubFetchUser;
 window.githubFetchIssues = githubFetchIssues;
 window.githubFetchReviews = githubFetchReviews;
+window.githubFetchPrReviews = githubFetchPrReviews;
 window.githubFetchPullRequests = githubFetchPullRequests;
 window.githubFetchCommits = githubFetchCommits;
 window.githubFetchPrMergedStatusREST = githubFetchPrMergedStatusREST;

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1310,7 +1310,7 @@ ${blockerText}`;
 		}
 	}
 
-	function writeGithubPrsReviews() {
+	async function writeGithubPrsReviews() {
 		const isAnyFilterActive = onlyIssues || onlyPRs || onlyRevPRs || onlyMergedPRs;
 		if (isAnyFilterActive && !onlyRevPRs) {
 			log('Filters active but onlyRevPRs not checked, skipping PR reviews.');
@@ -1362,8 +1362,44 @@ ${blockerText}`;
 
 		log('Filtering PR reviews by date range:', { startDate, endDate, startDateTime, endDateTime });
 
-		for (i = 0; i < items.length; i++) {
-			const item = items[i];
+		let filteredItems = items;
+		if (platform === 'github') {
+			if (githubToken && items.length <= 50) {
+				const prReviewsResults = await Promise.all(
+					items.map(async (item) => {
+						try {
+							const repoParts = item.repository_url.split('/');
+							const owner = repoParts[repoParts.length - 2];
+							const repo = repoParts[repoParts.length - 1];
+
+							const reviews = await window.githubFetchPrReviews(owner, repo, item.number, githubToken).catch(() => []);
+
+							const hasValidReview = reviews.some((review) => {
+								if (!review.user || review.user.login.toLowerCase() !== platformUsernameLocal.toLowerCase())
+									return false;
+								if (!review.submitted_at) return false;
+								const submittedDate = new Date(review.submitted_at);
+								return submittedDate >= startDateTime && submittedDate <= endDateTime;
+							});
+
+							return { item, keep: hasValidReview };
+						} catch (err) {
+							logError(`Failed to fetch reviews for PR #${item.number}:`, err);
+							return { item, keep: true };
+						}
+					}),
+				);
+				filteredItems = prReviewsResults.filter((r) => r.keep).map((r) => r.item);
+			} else if (githubToken && items.length > 50) {
+				window.scrumHelperToast?.('Showing approximate results due to high PR volume', {
+					duration: 5000,
+					variant: 'info',
+				});
+			}
+		}
+
+		for (i = 0; i < filteredItems.length; i++) {
+			const item = filteredItems[i];
 			log(
 				`Processing PR #${item.number} - state: ${item.state}, updated_at: ${item.updated_at}, created_at: ${item.created_at}, merged_at: ${item.pull_request?.merged_at}`,
 			);
@@ -1371,7 +1407,7 @@ ${blockerText}`;
 			// For GitHub: item.user.login, for GitLab: item.author?.username
 			let isAuthoredByUser = false;
 			if (platform === 'github') {
-				isAuthoredByUser = item.user && item.user.login === platformUsernameLocal;
+				isAuthoredByUser = item.user && item.user.login.toLowerCase() === platformUsernameLocal.toLowerCase();
 			} else if (platform === 'gitlab') {
 				isAuthoredByUser = item.author && item.author.username === platformUsername;
 			}
@@ -1947,7 +1983,7 @@ ${blockerText}`;
 			writeGithubIssuesPrs();
 		}
 	}, 500);
-	const intervalWriteGithubPrs = setInterval(() => {
+	const intervalWriteGithubPrs = setInterval(async () => {
 		if (outputTarget === 'popup') {
 			return;
 		}
@@ -1956,7 +1992,7 @@ ${blockerText}`;
 		if (scrumBody && username && githubPrsReviewData && githubIssuesData) {
 			clearInterval(intervalWriteGithubPrs);
 			clearInterval(intervalWriteGithubIssues);
-			writeGithubPrsReviews();
+			await writeGithubPrsReviews();
 		}
 	}, 500);
 


### PR DESCRIPTION
### 📌 Fixes

Fixes #712 

---

### 📝 Summary of Changes

This PR implements precise filtering for reviewed PRs by actual review date instead of relying on the last updated date. When generating the scrum report, the helper now fetches the list of formal reviews for candidate PRs and filters them using the exact timestamp of your submitted review. If no token is provided or the list of PRs exceeds 50 items, the extension falls back to the approximate date-range check to prevent hitting rate limits. Username comparisons are also updated to be case-insensitive to ensure reliable matching.

---

### 📸 Screenshots / Demo (if UI-related)


---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

The precise reviews filtering uses N+1 requests, which has been rate-limit optimized using a threshold limit of 50 items and caching.