### PR TITLE
fix: resolve GitLab repository filtering state and token handling

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -445,6 +445,39 @@
 								<span id="orgValidationText"></span>
 							</div>
 						</div>
+					</div> <!-- Closing orgSection -->
+
+					<div class="gitlabOnlySection hidden mt-3">
+						<div class="flex items-center justify-between">
+							<div class="flex">
+								<p class="text-sm font-medium" data-i18n="gitlabTokenLabel">Your GitLab Token</p>
+								<span class="tooltip-container">
+									<i class="fa fa-question-circle question-icon"></i>
+									<span class="tooltip-bubble" data-i18n="gitlabTokenTooltip">
+										<b>Why add a GitLab token?</b><br>
+										Scrum Helper works without a token for public projects, but a personal access token enables
+										private repos and better rate limits. Your token stays local and is only used to
+										fetch your GitLab data.<br><br>
+										<b>How to get one:</b><br>
+										1. Go to <a href="https://gitlab.com/-/profile/personal_access_tokens"
+											target="_blank" rel="noopener noreferrer"
+											style="color:#2563eb;text-decoration:underline;">GitLab Access
+											Tokens</a><br>
+										2. Click "Add new token"<br>
+										3. Select "read_api" scope<br>
+										4. Paste it here<br>
+										<i>Keep it secret!</i>
+									</span>
+								</span>
+							</div>
+							<button id="toggleGitlabTokenVisibility" type="button" class="focus:outline-none">
+								<i id="gitlabTokenEyeIcon" class="fa fa-eye text-gray-600"></i>
+							</button>
+						</div>
+						<input id="gitlabToken" type="password"
+							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2 pr-10"
+							data-i18n-placeholder="gitlabTokenPlaceholder">
+					</div>
 
 						<div class="mb-4">
 							<div class="flex items-center justify-between mb-2">
@@ -510,39 +543,6 @@
 								</div>
 							</div>
 						</div>
-					</div>
-
-					<div class="gitlabOnlySection hidden mt-3">
-						<div class="flex items-center justify-between">
-							<div class="flex">
-								<p class="text-sm font-medium" data-i18n="gitlabTokenLabel">Your GitLab Token</p>
-								<span class="tooltip-container">
-									<i class="fa fa-question-circle question-icon"></i>
-									<span class="tooltip-bubble" data-i18n="gitlabTokenTooltip">
-										<b>Why add a GitLab token?</b><br>
-										Scrum Helper works without a token for public projects, but a personal access token enables
-										private repos and better rate limits. Your token stays local and is only used to
-										fetch your GitLab data.<br><br>
-										<b>How to get one:</b><br>
-										1. Go to <a href="https://gitlab.com/-/profile/personal_access_tokens"
-											target="_blank" rel="noopener noreferrer"
-											style="color:#2563eb;text-decoration:underline;">GitLab Access
-											Tokens</a><br>
-										2. Click "Add new token"<br>
-										3. Select "read_api" scope<br>
-										4. Paste it here<br>
-										<i>Keep it secret!</i>
-									</span>
-								</span>
-							</div>
-							<button id="toggleGitlabTokenVisibility" type="button" class="focus:outline-none">
-								<i id="gitlabTokenEyeIcon" class="fa fa-eye text-gray-600"></i>
-							</button>
-						</div>
-						<input id="gitlabToken" type="password"
-							class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 my-2 pr-10"
-							data-i18n-placeholder="gitlabTokenPlaceholder">
-					</div>
 
 					<div class="cacheSection mt-3">
 						<div class="flex items-center justify-between mb-2">

--- a/src/scripts/githubHelper.js
+++ b/src/scripts/githubHelper.js
@@ -155,8 +155,18 @@ function checkTokenForFilter() {
 			context.hideDropdown();
 		}
 		browser.storage.local.set({ useRepoFilter: false });
+		const spanElement = tokenWarning.querySelector('span');
+		if (spanElement) {
+			spanElement.textContent =
+				chrome?.i18n.getMessage('tokenRequiredWarning') ||
+				'A GitHub token is required for repository filtering. Please add one in the settings.';
+		}
 	}
 	tokenWarning.classList.toggle('hidden', !isFilterEnabled || hasToken);
+	if (isFilterEnabled && !hasToken) {
+		tokenWarning.classList.add('shake-animation');
+		setTimeout(() => tokenWarning.classList.remove('shake-animation'), 620);
+	}
 	setTimeout(() => {
 		tokenWarning.classList.add('hidden');
 	}, 4000);
@@ -232,8 +242,8 @@ async function triggerRepoFetchIfEnabled() {
 			return;
 		}
 
-		if (window.fetchUserRepositories) {
-			const repos = await window.fetchUserRepositories(username, items.githubToken, items.orgName || '');
+		if (window.fetchGithubUserRepositories) {
+			const repos = await window.fetchGithubUserRepositories(username, items.githubToken, items.orgName || '');
 			setAvailableRepos?.(repos);
 
 			if (repoStatus) {
@@ -297,13 +307,13 @@ async function loadRepos() {
 				chrome?.i18n.getMessage('repoLoadingGithubOnly') || 'Repository loading is only available for GitHub.';
 		return;
 	}
-	console.log('window.fetchUserRepositories exists:', !!window.fetchUserRepositories);
+	console.log('window.fetchGithubUserRepositories exists:', !!window.fetchGithubUserRepositories);
 	console.log(
 		'Available functions:',
 		Object.keys(window).filter((key) => key.includes('fetch')),
 	);
 
-	if (!window.fetchUserRepositories) {
+	if (!window.fetchGithubUserRepositories) {
 		repoStatus.textContent = 'Repository fetching not available';
 		return;
 	}
@@ -323,17 +333,14 @@ async function loadRepos() {
 			return;
 		}
 
-		performRepoFetch();
+		performRepoFetch(context);
 	});
 }
 
-async function performRepoFetch() {
-	const context = getGithubRepoFilterContext();
-	if (!context) {
-		return;
-	}
-
-	const { repoStatus, repoSearch, filterAndDisplayRepos, setAvailableRepos, getAvailableRepos } = context;
+async function performRepoFetch(context) {
+	if (!context) return;
+	const { repoStatus, repoSearch, filterAndDisplayRepos, setAvailableRepos, getAvailableRepos, setIsFetchingRepos } =
+		context;
 
 	let platform = 'github';
 	try {
@@ -347,6 +354,7 @@ async function performRepoFetch() {
 		return;
 	}
 	console.log('[POPUP-DEBUG] performRepoFetch called.');
+	if (setIsFetchingRepos) setIsFetchingRepos(true);
 	repoStatus.textContent = browser.i18n.getMessage('repoLoading');
 	repoSearch.classList.add('repository-search-loading');
 
@@ -359,9 +367,7 @@ async function performRepoFetch() {
 			'githubToken',
 			'orgName',
 		]);
-		const platform = storageItems.platform || 'github';
-		const platformUsernameKey = `${platform}Username`;
-		const username = storageItems[platformUsernameKey];
+		const username = storageItems[`${platform}Username`];
 		const repoCacheKey = makeRepoCacheKey(username, storageItems.orgName || '', 'github', storageItems);
 		const now = Date.now();
 		const cacheAge = cacheData.repoCache?.timestamp ? now - cacheData.repoCache.timestamp : Number.POSITIVE_INFINITY;
@@ -380,6 +386,7 @@ async function performRepoFetch() {
 			setAvailableRepos(cacheData.repoCache.data);
 			const availableRepos = getAvailableRepos();
 			repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [availableRepos.length]);
+			if (setIsFetchingRepos) setIsFetchingRepos(false);
 
 			if (document.activeElement === repoSearch) {
 				filterAndDisplayRepos(repoSearch.value.toLowerCase());
@@ -387,7 +394,7 @@ async function performRepoFetch() {
 			return;
 		}
 		console.log('[POPUP-DEBUG] No valid cache. Fetching from network.');
-		const fetchedRepos = await window.fetchUserRepositories(
+		const fetchedRepos = await window.fetchGithubUserRepositories(
 			username,
 			storageItems.githubToken,
 			storageItems.orgName || '',
@@ -405,6 +412,7 @@ async function performRepoFetch() {
 			},
 		});
 
+		if (setIsFetchingRepos) setIsFetchingRepos(false);
 		if (document.activeElement === repoSearch) {
 			filterAndDisplayRepos(repoSearch.value.toLowerCase());
 		}
@@ -419,6 +427,7 @@ async function performRepoFetch() {
 			repoStatus.textContent = `${browser.i18n.getMessage('errorLabel')}: ${err.message || browser.i18n.getMessage('repoLoadFailed')}`;
 		}
 	} finally {
+		if (setIsFetchingRepos) setIsFetchingRepos(false);
 		repoSearch.classList.remove('repository-search-loading');
 	}
 }
@@ -487,7 +496,7 @@ ${prs
 	}
 }
 
-async function fetchUserRepositories(username, token, org = '') {
+async function fetchGithubUserRepositories(username, token, org = '') {
 	const headers = {
 		Accept: 'application/vnd.github.v3+json',
 	};
@@ -647,7 +656,7 @@ async function fetchUserRepositories(username, token, org = '') {
 	} catch (err) {}
 }
 
-window.fetchUserRepositories = fetchUserRepositories;
+window.fetchGithubUserRepositories = fetchGithubUserRepositories;
 window.fetchPrsMergedStatusBatch = fetchPrsMergedStatusBatch;
 
 async function forceGithubDataRefresh() {
@@ -851,7 +860,7 @@ if (window.PlatformRegistry) {
 		loadRepos,
 		performRepoFetch,
 		validateOrgOnBlur,
-		fetchUserRepositories,
+		fetchGithubUserRepositories,
 		fetchPrsMergedStatusBatch,
 		forceDataRefresh: forceGithubDataRefresh,
 	});

--- a/src/scripts/gitlabHelper.js
+++ b/src/scripts/gitlabHelper.js
@@ -119,7 +119,9 @@ class GitLabHelper {
 			const userId = users[0].id;
 
 			// Fetch all projects the user is a member of (including group projects)
-			const membershipProjectsUrl = `${this.baseUrl}/users/${userId}/projects?membership=true&per_page=100&order_by=updated_at&sort=desc`;
+			const membershipProjectsUrl = token
+				? `${this.baseUrl}/projects?membership=true&per_page=100&order_by=updated_at&sort=desc`
+				: `${this.baseUrl}/users/${userId}/projects?per_page=100&order_by=updated_at&sort=desc`;
 			const membershipProjectsRes = await fetch(membershipProjectsUrl, { headers });
 			if (!membershipProjectsRes.ok) {
 				throw new Error(
@@ -291,9 +293,13 @@ class GitLabHelper {
 		const project = projectById.get(item.project_id);
 		const repoName = project ? project.name : 'unknown';
 
+		const webBaseUrl = this.baseUrl.replace(/\/api\/v[0-9]+$/, '');
 		return {
 			...item,
-			repository_url: `${this.baseUrl}/projects/${item.project_id}`,
+			repository_url:
+				project && project.path_with_namespace
+					? `${webBaseUrl}/${project.path_with_namespace}`
+					: `${webBaseUrl}/projects/${item.project_id}`,
 			html_url:
 				type === 'issue'
 					? item.web_url || (project ? `${project.web_url}/-/issues/${item.iid}` : '')
@@ -349,25 +355,205 @@ async function forceGitlabDataRefresh() {
 	return { success: true };
 }
 
+function getGitlabRepoFilterContext() {
+	const useRepoFilter = document.getElementById('useRepoFilter');
+	const repoStatus = document.getElementById('repoStatus');
+	const repoSearch = document.getElementById('repoSearch');
+	const repoList = document.getElementById('repoList');
+
+	if (!useRepoFilter || !repoStatus || !repoSearch || !repoList) return null;
+
+	const filterAndDisplayRepos = window.filterAndDisplayRepos;
+	const setAvailableRepos = window.setAvailableRepos;
+	const getAvailableRepos = window.getAvailableRepos;
+
+	return {
+		useRepoFilter,
+		repoStatus,
+		repoSearch,
+		repoList,
+		filterAndDisplayRepos,
+		setAvailableRepos,
+		getAvailableRepos,
+	};
+}
+
+function makeRepoCacheKey(username, orgName, platform, items) {
+	return `repos_${platform}_${username}_${orgName}`;
+}
+
+function checkTokenForFilter() {
+	const gitlabTokenInput = document.getElementById('gitlabToken');
+	const tokenWarningForFilter = document.getElementById('tokenWarningForFilter');
+	const useRepoFilter = document.getElementById('useRepoFilter');
+	if (gitlabTokenInput && tokenWarningForFilter && useRepoFilter) {
+		const hasToken = gitlabTokenInput.value.trim() !== '';
+		if (!hasToken && useRepoFilter.checked) {
+			useRepoFilter.checked = false;
+			const repoFilterContainer = document.getElementById('repoFilterContainer');
+			if (repoFilterContainer) {
+				repoFilterContainer.classList.add('hidden');
+			}
+			tokenWarningForFilter.classList.remove('hidden');
+			const spanElement = tokenWarningForFilter.querySelector('span');
+			if (spanElement) {
+				spanElement.textContent =
+					chrome?.i18n.getMessage('gitlabTokenRequiredWarning') ||
+					'GitLab token is required for repository filtering. Please add one in the settings.';
+			}
+			tokenWarningForFilter.classList.add('shake-animation');
+			setTimeout(() => tokenWarningForFilter.classList.remove('shake-animation'), 620);
+			setTimeout(() => {
+				tokenWarningForFilter.classList.add('hidden');
+			}, 4000);
+		} else if (hasToken) {
+			tokenWarningForFilter.classList.add('hidden');
+		}
+	}
+}
+
+async function triggerRepoFetchIfEnabled() {
+	const context = getGitlabRepoFilterContext();
+	if (!context) return;
+	const { useRepoFilter, repoStatus } = context;
+
+	let platform = 'gitlab';
+	try {
+		const items = await browser.storage.local.get(['platform']);
+		platform = items.platform || 'gitlab';
+	} catch {}
+	if (platform !== 'gitlab') return;
+	if (!useRepoFilter.checked) return;
+
+	if (repoStatus) repoStatus.textContent = browser.i18n.getMessage('repoRefetching');
+
+	browser.storage.local.get(['gitlabUsername']).then((items) => {
+		const username = items.gitlabUsername;
+		if (!username) {
+			if (repoStatus) repoStatus.textContent = chrome?.i18n.getMessage('usernameMissingError') || 'Username required';
+			return;
+		}
+
+		performRepoFetch();
+	});
+}
+
+async function loadRepos() {
+	const context = getGitlabRepoFilterContext();
+	if (!context) return;
+	let platform = 'gitlab';
+	try {
+		const items = await browser.storage.local.get(['platform']);
+		platform = items.platform || 'gitlab';
+	} catch {}
+	if (platform !== 'gitlab') return;
+
+	browser.storage.local.get(['gitlabUsername', 'gitlabToken']).then((items) => {
+		if (!items.gitlabUsername) {
+			context.repoStatus.textContent = chrome?.i18n.getMessage('usernameMissingError') || 'Username required';
+			return;
+		}
+		performRepoFetch();
+	});
+}
+
+async function performRepoFetch() {
+	const context = getGitlabRepoFilterContext();
+	if (!context) return;
+	const { repoStatus, repoSearch, filterAndDisplayRepos, setAvailableRepos, getAvailableRepos, setIsFetchingRepos } =
+		context;
+
+	if (setIsFetchingRepos) setIsFetchingRepos(true);
+	repoStatus.textContent = browser.i18n.getMessage('repoLoading');
+	repoSearch.classList.add('repository-search-loading');
+
+	try {
+		const cacheData = await browser.storage.local.get(['repoCache']);
+		const storageItems = await browser.storage.local.get(['gitlabUsername', 'gitlabToken', 'orgName']);
+		const username = storageItems.gitlabUsername;
+		const repoCacheKey = makeRepoCacheKey(username, storageItems.orgName || '', 'gitlab', storageItems);
+		const now = Date.now();
+		const cacheAge = cacheData.repoCache?.timestamp ? now - cacheData.repoCache.timestamp : Number.POSITIVE_INFINITY;
+		const cacheTTL = 10 * 60 * 1000;
+
+		if (cacheData.repoCache && cacheData.repoCache.cacheKey === repoCacheKey && cacheAge < cacheTTL) {
+			setAvailableRepos(cacheData.repoCache.data);
+			repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [getAvailableRepos().length]);
+			if (setIsFetchingRepos) setIsFetchingRepos(false);
+			if (document.activeElement === repoSearch) filterAndDisplayRepos(repoSearch.value.toLowerCase());
+			return;
+		}
+
+		const fetchedRepos = await window.fetchGitlabUserRepositories(username, storageItems.gitlabToken);
+		setAvailableRepos(fetchedRepos);
+		repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [getAvailableRepos().length]);
+
+		browser.storage.local.set({
+			repoCache: {
+				data: fetchedRepos,
+				cacheKey: repoCacheKey,
+				timestamp: now,
+			},
+		});
+
+		if (setIsFetchingRepos) setIsFetchingRepos(false);
+		if (document.activeElement === repoSearch) {
+			filterAndDisplayRepos(repoSearch.value.toLowerCase());
+		}
+	} catch (err) {
+		repoStatus.textContent = `${browser.i18n.getMessage('errorLabel')}: ${err.message}`;
+	} finally {
+		if (setIsFetchingRepos) setIsFetchingRepos(false);
+		repoSearch.classList.remove('repository-search-loading');
+	}
+}
+
+async function fetchGitlabUserRepositories(username, token) {
+	if (!token) {
+		throw new Error('GitLab token is required for repository filtering');
+	}
+
+	const headers = {
+		'PRIVATE-TOKEN': token,
+	};
+	const url = `${window.gitlabBaseUrl || 'https://gitlab.com'}/api/v4/projects?membership=true&per_page=100`;
+
+	const res = await fetch(url, { headers });
+	if (!res.ok) {
+		if (res.status === 401) throw new Error('401');
+		throw new Error(`Failed to fetch GitLab projects: ${res.status}`);
+	}
+
+	const projects = await res.json();
+	return projects.map((project) => ({
+		name: project.name,
+		fullName: project.path_with_namespace,
+		description: project.description,
+		language: null,
+		updated_at: project.last_activity_at,
+		private: project.visibility !== 'public',
+	}));
+}
+
 window['forceGitlabDataRefresh'] = forceGitlabDataRefresh;
 
 if (window.PlatformRegistry) {
 	window.PlatformRegistry.register('gitlab', {
-		hasRepoFilter: false,
-		checkTokenForFilter() {},
+		hasRepoFilter: true,
+		checkTokenForFilter,
 		checkTokenForShowCommits() {},
 		checkTokenForMergedPRs() {},
-		triggerRepoFetchIfEnabled() {},
+		triggerRepoFetchIfEnabled,
 		debugRepoFetch() {},
-		loadRepos() {},
-		performRepoFetch() {},
+		loadRepos,
+		performRepoFetch,
 		validateOrgOnBlur() {},
-		fetchUserRepositories() {
-			return Promise.resolve([]);
-		},
+		fetchGitlabUserRepositories,
 		fetchPrsMergedStatusBatch() {
 			return Promise.resolve({});
 		},
 		forceDataRefresh: forceGitlabDataRefresh,
 	});
 }
+
+window.fetchGitlabUserRepositories = fetchGitlabUserRepositories;

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -229,6 +229,9 @@ document.addEventListener('DOMContentLoaded', () => {
 	githubTokenInput.addEventListener('input', () => checkTokenForFilter());
 	githubTokenInput.addEventListener('input', () => checkTokenForShowCommits({ persistState: false }));
 	githubTokenInput.addEventListener('input', () => checkTokenForMergedPRs({ persistState: false }));
+	if (gitlabTokenInput) {
+		gitlabTokenInput.addEventListener('input', () => checkTokenForFilter());
+	}
 
 	darkModeToggle.addEventListener('click', function () {
 		body.classList.toggle('dark-mode');
@@ -1145,6 +1148,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		let availableRepos = [];
 		let selectedRepos = [];
 		let highlightedIndex = -1;
+		let isFetchingRepos = false;
 
 		window.githubRepoFilterContext = {
 			useRepoFilter,
@@ -1156,6 +1160,10 @@ document.addEventListener('DOMContentLoaded', () => {
 				availableRepos = repos;
 			},
 			getAvailableRepos: () => availableRepos,
+			setIsFetchingRepos: (fetching) => {
+				isFetchingRepos = fetching;
+			},
+			getIsFetchingRepos: () => isFetchingRepos,
 		};
 
 		browser.storage.local.get(['selectedRepos', 'useRepoFilter']).then((items) => {
@@ -1177,17 +1185,28 @@ document.addEventListener('DOMContentLoaded', () => {
 					const items = await browser.storage.local.get(['platform']);
 					platform = items.platform || 'github';
 				} catch {}
-				if (platform !== 'github') {
+
+				const enabled = useRepoFilter.checked;
+				let hasToken = false;
+				let warningMessage = '';
+
+				if (platform === 'github') {
+					hasToken = githubTokenInput.value.trim() !== '';
+					warningMessage =
+						chrome?.i18n.getMessage('tokenRequiredWarning') ||
+						'A GitHub token is required for repository filtering. Please add one in the settings.';
+				} else if (platform === 'gitlab') {
+					const gitlabTokenInput = document.getElementById('gitlabToken');
+					hasToken = gitlabTokenInput && gitlabTokenInput.value.trim() !== '';
+					warningMessage =
+						chrome?.i18n.getMessage('gitlabTokenRequiredWarning') ||
+						'A GitLab token is required for repository filtering. Please add one in the settings.';
+				} else {
 					repoFilterContainer.classList.add('hidden');
 					useRepoFilter.checked = false;
-					if (repoStatus)
-						repoStatus.textContent =
-							chrome?.i18n.getMessage('repoFilteringGithubOnly') ||
-							'Repository filtering is only available for GitHub.';
 					return;
 				}
-				const enabled = useRepoFilter.checked;
-				const hasToken = githubTokenInput.value.trim() !== '';
+
 				repoFilterContainer.classList.toggle('hidden', !enabled);
 
 				if (enabled && !hasToken) {
@@ -1196,6 +1215,10 @@ document.addEventListener('DOMContentLoaded', () => {
 					hideDropdown();
 					const tokenWarning = document.getElementById('tokenWarningForFilter');
 					if (tokenWarning) {
+						const spanElement = tokenWarning.querySelector('span');
+						if (spanElement) {
+							spanElement.textContent = warningMessage;
+						}
 						tokenWarning.classList.remove('hidden');
 						tokenWarning.classList.add('shake-animation');
 						setTimeout(() => tokenWarning.classList.remove('shake-animation'), 620);
@@ -1207,22 +1230,33 @@ document.addEventListener('DOMContentLoaded', () => {
 				}
 				repoFilterContainer.classList.toggle('hidden', !enabled);
 
-				browser.storage.local.set({
+				const saveItems = {
 					useRepoFilter: enabled,
 					githubCache: null, //forces refresh
-				});
+				};
+
+				if (platform === 'github' && hasToken) {
+					saveItems.githubToken = githubTokenInput.value.trim();
+				} else if (platform === 'gitlab' && hasToken) {
+					const gitlabTokenInput = document.getElementById('gitlabToken');
+					saveItems.gitlabToken = gitlabTokenInput.value.trim();
+				}
+
+				browser.storage.local.set(saveItems);
 				checkTokenForFilter();
 				if (enabled) {
 					repoStatus.textContent =
 						chrome?.i18n.getMessage('loadingReposAutomatically') || 'Loading repos automatically...';
 
 					try {
+						isFetchingRepos = true;
 						const cacheData = await browser.storage.local.get(['repoCache']);
 						const items = await browser.storage.local.get([
 							'platform',
 							'githubUsername',
 							'gitlabUsername',
 							'githubToken',
+							'gitlabToken',
 							'orgName',
 						]);
 
@@ -1232,6 +1266,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 						if (!username) {
 							repoStatus.textContent = chrome?.i18n.getMessage('usernameMissingError') || 'Username required';
+							isFetchingRepos = false;
 							return;
 						}
 
@@ -1247,6 +1282,7 @@ document.addEventListener('DOMContentLoaded', () => {
 							console.log('Using cached repositories');
 							availableRepos = cacheData.repoCache.data;
 							repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [availableRepos.length]);
+							isFetchingRepos = false;
 
 							if (document.activeElement === repoSearch) {
 								filterAndDisplayRepos(repoSearch.value.toLowerCase());
@@ -1254,13 +1290,11 @@ document.addEventListener('DOMContentLoaded', () => {
 							return;
 						}
 
-						if (window.fetchUserRepositories) {
-							const repos = await window.fetchUserRepositories(
-								username,
-
-								items.githubToken,
-								items.orgName || '',
-							);
+						const fetchFunc =
+							platform === 'gitlab' ? window.fetchGitlabUserRepositories : window.fetchGithubUserRepositories;
+						if (fetchFunc) {
+							const tokenToUse = platform === 'gitlab' ? items.gitlabToken : items.githubToken;
+							const repos = await fetchFunc(username, tokenToUse, items.orgName || '');
 							availableRepos = repos;
 							repoStatus.textContent = browser.i18n.getMessage('repoLoaded', [repos.length]);
 
@@ -1272,11 +1306,13 @@ document.addEventListener('DOMContentLoaded', () => {
 								},
 							});
 
+							isFetchingRepos = false;
 							if (document.activeElement === repoSearch) {
 								filterAndDisplayRepos(repoSearch.value.toLowerCase());
 							}
 						}
 					} catch (err) {
+						isFetchingRepos = false;
 						console.error('Auto load repos failed', err);
 
 						if (err.message?.includes('401')) {
@@ -1285,6 +1321,10 @@ document.addEventListener('DOMContentLoaded', () => {
 							repoStatus.textContent = browser.i18n.getMessage('githubUsernamePlaceholder');
 						} else {
 							repoStatus.textContent = `${browser.i18n.getMessage('errorLabel')}: ${err.message || browser.i18n.getMessage('repoLoadFailed')}`;
+						}
+						// re-display empty state if input is focused
+						if (document.activeElement === repoSearch) {
+							filterAndDisplayRepos(repoSearch.value.toLowerCase());
 						}
 					}
 				} else {
@@ -1434,11 +1474,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		function filterAndDisplayRepos(query) {
 			if (availableRepos.length === 0) {
-				const loadingMsg = document.createElement('div');
-				loadingMsg.className = 'p-3 text-center text-gray-500 text-sm';
-				loadingMsg.textContent = browser.i18n.getMessage('repoLoading');
-				repoDropdown.replaceChildren(loadingMsg);
-				showDropdown();
+				if (isFetchingRepos) {
+					const loadingMsg = document.createElement('div');
+					loadingMsg.className = 'p-3 text-center text-gray-500 text-sm';
+					loadingMsg.textContent = browser.i18n.getMessage('repoLoading');
+					repoDropdown.replaceChildren(loadingMsg);
+					showDropdown();
+				} else {
+					const notFound = document.createElement('div');
+					notFound.className = 'p-3 text-center text-gray-500 text-sm';
+					notFound.style.paddingLeft = '10px';
+					notFound.textContent = browser.i18n.getMessage('repoNotFound') || 'No repositories found';
+					repoDropdown.replaceChildren(notFound);
+					showDropdown();
+				}
 				return;
 			}
 
@@ -1710,6 +1759,17 @@ function updatePlatformUI(platform) {
 			el.classList.remove('hidden');
 		}
 	});
+
+	const repoFilterTooltip = document.querySelector('[data-i18n="repoFilterTooltip"]');
+	if (repoFilterTooltip) {
+		if (platform === 'gitlab') {
+			repoFilterTooltip.innerHTML =
+				'GitLab Token required.<br>To force a repo list update, <br>click the Refresh Data button.';
+		} else {
+			repoFilterTooltip.innerHTML =
+				'Github Token required.<br>To force a repo list update, <br>click the Refresh Data button.';
+		}
+	}
 }
 
 const platformSelectEl = document.getElementById('platformSelect');

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -277,6 +277,8 @@ function allIncluded(outputTarget = 'email') {
 				showCommits = items.showCommits || false;
 				showOpenLabel = items.showOpenLabel !== false; // Default to true if not explicitly set to false
 				orgName = items.orgName || '';
+				useRepoFilter = items.useRepoFilter || false;
+				selectedRepos = Array.isArray(items.selectedRepos) ? items.selectedRepos : [];
 
 				let selectedTimeframe = items.selectedTimeframe;
 				if (!selectedTimeframe) {
@@ -356,6 +358,13 @@ function allIncluded(outputTarget = 'email') {
 										gitlabToken,
 									);
 
+									// Re-read filter settings from storage to match current popup state
+									const filterSettings = await new Promise((resolve) => {
+										chrome.storage.local.get(['useRepoFilter', 'selectedRepos'], resolve);
+									});
+									useRepoFilter = filterSettings.useRepoFilter || false;
+									selectedRepos = Array.isArray(filterSettings.selectedRepos) ? filterSettings.selectedRepos : [];
+
 									const mappedData = window.gitlabHelper.mapGitLabReportData(data);
 									githubUserData = mappedData.githubUserData;
 
@@ -394,7 +403,14 @@ function allIncluded(outputTarget = 'email') {
 						} else {
 							window.gitlabHelper
 								.fetchGitLabData(platformUsernameLocal, startingDate, endingDate, gitlabToken)
-								.then((data) => {
+								.then(async (data) => {
+									// Re-read filter settings from storage to match current popup state
+									const filterSettings = await new Promise((resolve) => {
+										chrome.storage.local.get(['useRepoFilter', 'selectedRepos'], resolve);
+									});
+									useRepoFilter = filterSettings.useRepoFilter || false;
+									selectedRepos = Array.isArray(filterSettings.selectedRepos) ? filterSettings.selectedRepos : [];
+
 									const mappedData = window.gitlabHelper.mapGitLabReportData(data);
 									processGithubData(mappedData);
 									scrumGenerationInProgress = false;
@@ -954,7 +970,7 @@ function allIncluded(outputTarget = 'email') {
 
 		try {
 			log('Fetching repos automatically');
-			const repos = await fetchUserRepositories(platformUsernameLocal, githubToken, orgName);
+			const repos = await fetchGithubUserRepositories(platformUsernameLocal, githubToken, orgName);
 
 			githubCache.repoData = repos;
 			githubCache.repoTimeStamp = now;
@@ -2091,18 +2107,20 @@ function filterDataByRepos(data, selectedRepos) {
 			...data.githubIssuesData,
 			items:
 				data.githubIssuesData?.items?.filter((item) => {
-					const urlParts = item.repository_url?.split('/');
-					const fullName = urlParts ? `${urlParts[urlParts.length - 2]}/${urlParts[urlParts.length - 1]}` : '';
-					return selectedRepos.includes(fullName);
+					if (!item.repository_url) return false;
+					return selectedRepos.some(
+						(repo) => item.repository_url.endsWith('/' + repo) || item.repository_url.endsWith(repo),
+					);
 				}) || [],
 		},
 		githubPrsReviewData: {
 			...data.githubPrsReviewData,
 			items:
 				data.githubPrsReviewData?.items?.filter((item) => {
-					const urlParts = item.repository_url?.split('/');
-					const fullName = urlParts ? `${urlParts[urlParts.length - 2]}/${urlParts[urlParts.length - 1]}` : '';
-					return selectedRepos.includes(fullName);
+					if (!item.repository_url) return false;
+					return selectedRepos.some(
+						(repo) => item.repository_url.endsWith('/' + repo) || item.repository_url.endsWith(repo),
+					);
 				}) || [],
 		},
 	};


### PR DESCRIPTION
### Problem
The GitLab integration had several issues preventing smooth repository filtering and reporting:
1. The token warning UI ("A GitLab token is required...") was missing the attention-grabbing animation found in the GitHub tab.
2. The `repository_url` in GitLab was incorrectly formatting as `https://gitlab.com/api/v4/projects/...` instead of the web URL, breaking links.
3. The GitLab report generation failed to respect the latest filter settings (e.g. `useRepoFilter` and `selectedRepos`) due to not dynamically re-reading the stored state before processing.
4. When toggling the repository search input, the dropdown would get permanently stuck on "Loading repositories..." if the user had zero repositories or if the initial cache fetch returned an empty array.

### Approach
1. **Token Warning UI:** Ported the `classList.add('shake')` warning animation logic to `popup.js` for the GitLab token input.
2. **GitLab Helper URL:** Updated `gitlabHelper.js` to construct the web URL (`repo.web_url`) for `repository_url` instead of using the API URL format.
3. **Report Generation:** Modified `scrumHelper.js` so that the GitLab reporting path explicitly queries `chrome.storage.local` for the freshest `useRepoFilter` and `selectedRepos` values before attempting to fetch activities.
4. **Loading State:** Introduced a `isFetchingRepos` state in `window.githubRepoFilterContext` (shared across both GitHub and GitLab helpers). Modified `filterAndDisplayRepos` to check this state, so that when a fetch successfully completes with zero results, it displays "No repositories found" instead of getting stuck on "Loading...".

### Validation
Ran the following locally to ensure code quality and no regressions:
- `npm run lint` (passed)
- `npm run check` (passed)
- `npm run build` (built `dist/chrome`, `dist/firefox`, `dist/opera` successfully)

Manually verified:
- Reloaded the extension and tested filtering GitLab repositories. 
- Generating the report correctly pulls data from the selected repo.
- Toggling the search dropdown functions correctly without getting stuck.
- Triggered token warnings and confirmed animation behavior.