### PR TITLE
fix: enable Copy button on initial automatic report render

### DIFF
--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1213,8 +1213,8 @@ ${blockerText}`;
 			if (scrumReport) {
 				log('Found popup div, updating content');
 				scrumReport.innerHTML = sanitizeHtml(content);
-				window.updateCopyButtonState?.();
 				delete scrumReport.dataset.copyPlaceholder;
+				window.updateCopyButtonState?.();
 				try {
 					const cacheKey =
 						platform === 'gitlab' ? (window.gitlabHelper?.cache?.cacheKey ?? null) : (githubCache?.cacheKey ?? null);


### PR DESCRIPTION
## Description
When the popup opens and automatically fetches and renders the scrum report, the **Copy** button stays disabled until the user clicks **Generate** a second time.

## Root cause
In `src/scripts/scrumHelper.js`, after rendering the report into the popup, `updateCopyButtonState()` was called *before* `scrumReport.dataset.copyPlaceholder` was deleted. Because `updateCopyButtonState()` disables the button while `copyPlaceholder === 'true'`, it read the stale placeholder and kept the button disabled until a manual "Generate".

## Fix
Delete the `copyPlaceholder` flag *before* refreshing the button state — the same ordering already used at the other call sites in `popup.js` (e.g. lines 454–455, 468–469, 614–616). One-line reorder, no behavioural change elsewhere.

## Testing
Cleared the extension cache, opened the popup, waited for the automatic fetch: the Copy button now enables as soon as content renders, without a manual Generate.

Fixes #729
