### PR TITLE
fix: label and project name issue

### DIFF
--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -65,6 +65,54 @@ function formatLocalDate(date) {
 }
 
 /**
+ * Resolves the project name from the report item.
+ * For GitLab, it prioritizes the pre-mapped human-readable name.
+ * For GitHub and fallbacks, it extracts it from the repository URL.
+ * @param {Object} item - The report item
+ * @param {string} platform - The SCM platform ('github', 'gitlab', etc.)
+ * @returns {string} The resolved project name or empty string if not found
+ */
+function getProjectName(item, platform) {
+	if (platform === 'gitlab' && item.project) {
+		return item.project;
+	}
+	const repository_url = item.repository_url;
+	if (repository_url) {
+		return repository_url.substr(repository_url.lastIndexOf('/') + 1);
+	}
+	return '';
+}
+
+/**
+ * Normalizes the SCM state of a pull/merge request.
+ * Normalizes platform-specific states (e.g., GitLab 'opened'/'reopened') into standard 'open', 'closed', or 'merged'.
+ * @param {Object} item - The report item
+ * @param {string} platform - The SCM platform ('github', 'gitlab', etc.)
+ * @returns {string} Normalized state ('open', 'merged', or 'closed')
+ */
+function normalizePrState(item, platform) {
+	if (platform === 'gitlab') {
+		const state = item.state;
+		if (state === 'opened' || state === 'reopened') {
+			return 'open';
+		}
+		if (state === 'closed' || state === 'locked') {
+			return 'closed';
+		}
+		if (state === 'merged') {
+			return 'merged';
+		}
+		return state;
+	}
+
+	// GitHub mapping
+	if (item.state === 'closed' && item.pull_request?.merged_at) {
+		return 'merged';
+	}
+	return item.state;
+}
+
+/**
  * Redact sensitive storage data for safe logging
  * Prevents exposure of authentication tokens and credentials in console logs
  * @param {Object} items - Storage data that may contain sensitive keys
@@ -1471,13 +1519,7 @@ ${blockerText}`;
 				}
 			}
 
-			const repository_url = item.repository_url;
-			const project =
-				platform === 'gitlab' && item.project
-					? item.project
-					: repository_url
-						? repository_url.substr(repository_url.lastIndexOf('/') + 1)
-						: '';
+			const project = getProjectName(item, platform);
 			if (!project) {
 				logError('Project name could not be determined for item:', item);
 				continue;
@@ -1493,14 +1535,7 @@ ${blockerText}`;
 				number: number,
 				html_url: html_url,
 				title: title,
-				state:
-					platform === 'gitlab'
-						? item.state === 'opened'
-							? 'open'
-							: item.state
-						: item.state === 'closed' && item.pull_request?.merged_at
-							? 'merged'
-							: item.state,
+				state: normalizePrState(item, platform),
 			};
 			githubPrsReviewDataProcessed[project].push(obj);
 		}
@@ -1743,13 +1778,7 @@ ${blockerText}`;
 			log('[SCRUM-DEBUG] isMR:', isMR, 'platform:', platform, 'item:', item);
 			const html_url = item.html_url;
 			const repository_url = item.repository_url;
-			// Use project name for GitLab, repo extraction for GitHub
-			const project =
-				platform === 'gitlab' && item.project
-					? item.project
-					: repository_url
-						? repository_url.substr(repository_url.lastIndexOf('/') + 1)
-						: '';
+			const project = getProjectName(item, platform);
 			const title = item.title;
 			const number = item.number;
 			let li = '';

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1472,11 +1472,16 @@ ${blockerText}`;
 			}
 
 			const repository_url = item.repository_url;
-			if (!repository_url) {
-				logError('repository_url is undefined for item:', item);
+			const project =
+				platform === 'gitlab' && item.project
+					? item.project
+					: repository_url
+						? repository_url.substr(repository_url.lastIndexOf('/') + 1)
+						: '';
+			if (!project) {
+				logError('Project name could not be determined for item:', item);
 				continue;
 			}
-			const project = repository_url.substr(repository_url.lastIndexOf('/') + 1);
 			const title = item.title;
 			const number = item.number;
 			const html_url = item.html_url;
@@ -1488,7 +1493,14 @@ ${blockerText}`;
 				number: number,
 				html_url: html_url,
 				title: title,
-				state: item.state === 'closed' && item.pull_request?.merged_at ? 'merged' : item.state,
+				state:
+					platform === 'gitlab'
+						? item.state === 'opened'
+							? 'open'
+							: item.state
+						: item.state === 'closed' && item.pull_request?.merged_at
+							? 'merged'
+							: item.state,
 			};
 			githubPrsReviewDataProcessed[project].push(obj);
 		}


### PR DESCRIPTION
### Fixes #733 


### Description
This PR resolves two UI issues in the Reviewed PRs section of the scrum report when using the GitLab platform:
1. Shows the human-readable project name instead of the numerical project ID.
2. Correctly displays the status labels (open, merged, closed) for reviewed GitLab merge requests.

### Steps to Test
1. Set the platform to GitLab in the extension settings.
2. Enable the option to include reviewed PRs.
3. Fetch a report within a date range containing reviewed merge requests.
4. Verify that the correct project name and status badges are rendered in the generated report.

### 📸 Screenshots / Demo (if UI-related)


#### Before

<img width="508" height="865" alt="image" src="https://github.com/user-attachments/assets/baf67266-d67e-4cee-ba70-94b145435feb" />

#### After

<img width="508" height="865" alt="image" src="https://github.com/user-attachments/assets/dc392a2d-de98-4fc4-81b9-c3749d94265c" />

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_

## Summary by Sourcery

Fix project name resolution and status label mapping for reviewed GitLab merge requests in the scrum report.

Bug Fixes:
- Use GitLab project name when available instead of deriving it from the repository URL in reviewed PRs.
- Normalize GitLab merge request states so reviewed items display correct open, merged, or closed badges in the report.