### PR TITLE
Fix: Add date range validation to prevent reversed start/end dates

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -88,8 +88,17 @@ if (!window.scrumDateRangeUtils) {
 		},
 		normalizeSyncAndPersistDateRange(startDateInput, endDateInput) {
 			if (!startDateInput || !endDateInput) return;
-			this.normalizeDateRangeValues(startDateInput, endDateInput);
+			const wasChanged = this.normalizeDateRangeValues(startDateInput, endDateInput);
 			this.persistDateRange(startDateInput, endDateInput);
+			// Show user feedback if dates were corrected
+			if (wasChanged) {
+				const message = startDateInput.value && !endDateInput.value 
+					? 'End date cleared: start date was after end date' 
+					: 'Dates adjusted to valid range';
+				if (typeof window.scrumHelperToast === 'function') {
+					window.scrumHelperToast(message, { variant: 'info', duration: 3000 });
+				}
+			}
 		},
 	};
 }

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -298,10 +298,23 @@ function allIncluded(outputTarget = 'email') {
 					weeklyContribution = true;
 					handleWeeklyContributionChange();
 				} else if (items.startingDate && items.endingDate) {
-					yesterdayContribution = false;
-					weeklyContribution = false;
-					startingDate = items.startingDate;
-					endingDate = items.endingDate;
+					// Validate date range: startingDate must not be after endingDate
+					if (items.startingDate > items.endingDate) {
+						console.warn('[SCRUM-HELPER] Invalid date range detected: startingDate > endingDate. Falling back to yesterday contribution.');
+						if (outputTarget === 'popup' && typeof window.scrumHelperToast === 'function') {
+							window.scrumHelperToast('Invalid date range: start date must be before or equal to end date. Using yesterday instead.', { variant: 'error', duration: 5000 });
+						}
+						yesterdayContribution = true;
+						weeklyContribution = false;
+						startingDate = '';
+						endingDate = '';
+						handleYesterdayContributionChange();
+					} else {
+						yesterdayContribution = false;
+						weeklyContribution = false;
+						startingDate = items.startingDate;
+						endingDate = items.endingDate;
+					}
 				} else {
 					yesterdayContribution = true;
 					weeklyContribution = false;


### PR DESCRIPTION
## Fixes

Fixes #735 

---

## Summary of Changes

- Added validation for date ranges before report generation.
- Prevented reversed dates where `startingDate > endingDate` from producing malformed reports.
- Added user feedback when date inputs are corrected.
- Added an error toast and fallback behavior to yesterday contribution when an invalid range is detected.
- Logged warnings to help diagnose invalid date range states during debugging.

---

##  What Changed

- Date blur handlers now surface feedback when dates are normalized.
- Report generation now checks for invalid start/end ordering.
- Invalid ranges no longer fail silently.
- The extension falls back safely instead of generating broken scrum output.

---

## Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests
- [ ] I’ve updated documentation
- [x] My code follows the project’s code style guidelines

---