### PR TITLE
chore: fill all languages related missing values

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "Vorheriger Tag"
     },
+    "lastWeekLabel": {
+        "message": "Vorherige Woche"
+    },
     "startDateLabel": {
         "message": "Von:"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "Bericht in E-Mail eingefügt!"
+    },
+    "rateLimitError": {
+        "message": "GitHub-API-Ratenbegrenzung überschritten. Bitte versuchen Sie es später noch einmal oder fügen Sie Ihr GitHub-Token in den Einstellungen des Scrum Helpers hinzu/überprüfen Sie es."
+    },
+    "rateLimitWarningMessage": {
+        "message": "Einige Daten fehlen möglicherweise aufgrund der GitHub-Ratenbegrenzung. Bitte fügen Sie Ihr GitHub-Token in den Einstellungen hinzu oder überprüfen Sie es."
     }
 }

--- a/src/_locales/el/messages.json
+++ b/src/_locales/el/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "Προηγούμενη ημέρα"
     },
+    "lastWeekLabel": {
+        "message": "Προηγούμενη εβδομάδα"
+    },
     "startDateLabel": {
         "message": "Από:"
     },
@@ -154,6 +157,9 @@
     },
     "repoCount": {
         "message": "$1 αποθετήρια επιλεγμένα"
+    },
+    "clearAllBtn": {
+        "message": "Καθαρισμός όλων"
     },
     "repoLoading": {
         "message": "Φόρτωση αποθετηρίων..."
@@ -331,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "Η αναφορά εισήχθη στο email!"
+    },
+    "rateLimitError": {
+        "message": "Υπέρβαση του ορίου ρυθμού του API του GitHub. Παρακαλώ δοκιμάστε ξανά αργότερα ή προσθέστε/ελέγξτε το GitHub token σας στις ρυθμίσεις του Scrum Helper."
+    },
+    "rateLimitWarningMessage": {
+        "message": "Κάποια δεδομένα ενδέχεται να λείπουν λόγω του ορίου ρυθμού του GitHub. Παρακαλώ προσθέστε ή ελέγξτε το GitHub token σας στις ρυθμίσεις."
     }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -68,7 +68,8 @@
     "description": "Placeholder text for the blockers input field."
   },
   "scrumReportLabel": {
-    "message": "Scrum Report"
+    "message": "Scrum Report",
+    "description": "Heading for the Scrum Report section."
   },
   "generateReportButton": {
     "message": "Generate",
@@ -127,19 +128,24 @@
     "description": "Label for the checkbox to show commits in open PRs."
   },
   "showCommitsTooltip": {
-    "message": "Github Token required, add it in the settings."
+    "message": "Github Token required, add it in the settings.",
+    "description": "Tooltip explaining that GitHub Token is required to show commits."
   },
   "onlyIssuesLabel": {
-    "message": "Include issues in the report"
+    "message": "Include issues in the report",
+    "description": "Label for the checkbox to only include issues in the report."
   },
   "onlyIssuesTooltip": {
-    "message": "If checked, the report will include issues created or assigned to the user."
+    "message": "If checked, the report will include issues created or assigned to the user.",
+    "description": "Tooltip explaining what checking the only issues checkbox does."
   },
   "onlyPRsLabel": {
-    "message": "Include PRs in the report"
+    "message": "Include PRs in the report",
+    "description": "Label for the checkbox to only include PRs in the report."
   },
   "onlyPRsTooltip": {
-    "message": "If checked, the report will include PRs created by the user. Reviewed PRs will be excluded."
+    "message": "If checked, the report will include PRs created by the user. Reviewed PRs will be excluded.",
+    "description": "Tooltip explaining what checking the only PRs checkbox does."
   },
   "cacheTTLLabel": {
     "message": "Enter cache TTL",

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "Día anterior"
     },
+    "lastWeekLabel": {
+        "message": "Semana anterior"
+    },
     "startDateLabel": {
         "message": "Desde:"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "¡Informe insertado en el correo!"
+    },
+    "rateLimitError": {
+        "message": "Se ha excedido el límite de velocidad de la API de GitHub. Inténtelo de nuevo más tarde o añada/verifique su token de GitHub en la configuración de Scrum Helper."
+    },
+    "rateLimitWarningMessage": {
+        "message": "Es posible que falten algunos datos debido al límite de velocidad de GitHub. Añada o verifique su token de GitHub en la configuración."
     }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "Jour précédent"
     },
+    "lastWeekLabel": {
+        "message": "Semaine précédente"
+    },
     "startDateLabel": {
         "message": "De :"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "Rapport inséré dans l'e-mail !"
+    },
+    "rateLimitError": {
+        "message": "Limite de taux de l'API GitHub dépassée. Veuillez réessayer plus tard ou ajouter/vérifier votre jeton GitHub dans les paramètres de Scrum Helper."
+    },
+    "rateLimitWarningMessage": {
+        "message": "Certaines données peuvent être manquantes en raison de la limite de taux de GitHub. Veuillez ajouter ou vérifier votre jeton GitHub dans les paramètres."
     }
 }

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "היום הקודם"
     },
+    "lastWeekLabel": {
+        "message": "שבוע שעבר"
+    },
     "startDateLabel": {
         "message": "מ:"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "הדוח הוכנס לאימייל!"
+    },
+    "rateLimitError": {
+        "message": "חריגה ממגבלת הקצב של ה-API של GitHub. אנא נסה שוב מאוחר יותר או הוסף/בדוק את האסימון (token) של GitHub בהגדרות Scrum Helper."
+    },
+    "rateLimitWarningMessage": {
+        "message": "חלק מהנתונים עשויים להיות חסרים עקב מגבלת הקצב של GitHub. אנא הוסף או בדוק את האסימון של GitHub בהגדרות."
     }
 }

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "पिछला दिन"
     },
+    "lastWeekLabel": {
+        "message": "पिछला सप्ताह"
+    },
     "startDateLabel": {
         "message": "प्रारंभ तिथि:"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "रिपोर्ट ईमेल में डाल दी गई!"
+    },
+    "rateLimitError": {
+        "message": "GitHub API दर सीमा समाप्त हो गई है। कृपया बाद में पुनः प्रयास करें या Scrum Helper सेटिंग्स में अपना GitHub टोकन जोड़ें/जांचें।,"
+    },
+    "rateLimitWarningMessage": {
+        "message": "GitHub दर सीमा के कारण कुछ डेटा गायब हो सकता है। कृपया सेटिंग्स में अपना GitHub टोकन जोड़ें या जांचें।"
     }
 }

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "Hari sebelumnya"
     },
+    "lastWeekLabel": {
+        "message": "Minggu sebelumnya"
+    },
     "startDateLabel": {
         "message": "Dari:"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "Laporan disisipkan ke email!"
+    },
+    "rateLimitError": {
+        "message": "Batas tingkat API GitHub terlampaui. Silakan coba lagi nanti atau tambahkan/periksa token GitHub Anda di pengaturan Scrum Helper."
+    },
+    "rateLimitWarningMessage": {
+        "message": "Beberapa data mungkin hilang karena batas tingkat GitHub. Silakan tambahkan atau periksa token GitHub Anda di pengaturan."
     }
 }

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "Giorno precedente"
     },
+    "lastWeekLabel": {
+        "message": "Settimana precedente"
+    },
     "startDateLabel": {
         "message": "Da:"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "Report inserito nell'email!"
+    },
+    "rateLimitError": {
+        "message": "Limite di frequenza delle API GitHub superato. Riprova più tardi o aggiungi/verifica il tuo token GitHub nelle impostazioni di Scrum Helper."
+    },
+    "rateLimitWarningMessage": {
+        "message": "Alcuni dati potrebbero mancare a causa del limite di frequenza di GitHub. Aggiungi o verifica il tuo token GitHub nelle impostazioni."
     }
 }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "前日"
     },
+    "lastWeekLabel": {
+        "message": "前週"
+    },
     "startDateLabel": {
         "message": "開始:"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "レポートをメールに挿入しました！"
+    },
+    "rateLimitError": {
+        "message": "GitHub API のレート制限を超過しました。しばらく時間をおいてから再試行するか、Scrum Helper の設定で GitHub トークンを追加または確認してください。"
+    },
+    "rateLimitWarningMessage": {
+        "message": "GitHub のレート制限により、一部のデータが欠落している可能性があります。設定で GitHub トークンを追加または確認してください。"
     }
 }

--- a/src/_locales/ml/messages.json
+++ b/src/_locales/ml/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "മുൻ ദിവസം"
     },
+    "lastWeekLabel": {
+        "message": "കഴിഞ്ഞ ആഴ്ച"
+    },
     "startDateLabel": {
         "message": "മുതൽ:"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "റിപ്പോർട്ട് ഇമെയിലിൽ ചേർത്തു!"
+    },
+    "rateLimitError": {
+        "message": "GitHub API നിരക്ക് പരിധി കവിഞ്ഞു. ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക അല്ലെങ്കിൽ Scrum Helper ക്രമീകരണങ്ങളിൽ നിങ്ങളുടെ GitHub ടോക്കൺ ചേർക്കുക/പരിശോധിക്കുക."
+    },
+    "rateLimitWarningMessage": {
+        "message": "GitHub നിരക്ക് പരിധി കാരണം ചില വിവരങ്ങൾ നഷ്ടപ്പെട്ടിട്ടുണ്ടാകാം. ക്രമീകരണങ്ങളിൽ നിങ്ങളുടെ GitHub ടോക്കൺ ചേർക്കുകയോ പരിശോധിക്കുകയോ ചെയ്യുക."
     }
 }

--- a/src/_locales/my/messages.json
+++ b/src/_locales/my/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "အရင်နေ့"
     },
+    "lastWeekLabel": {
+        "message": "ပြီးခဲ့သည့်အပတ်"
+    },
     "startDateLabel": {
         "message": "မှ :"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "အစီရင်ခံစာကို အီးမေးလ်ထဲသို့ ထည့်သွင်းပြီးပါပြီ။"
+    },
+    "rateLimitError": {
+        "message": "GitHub API နှုန်းကန့်သတ်ချက် ကျော်လွန်သွားပါပြီ။ ကျေးဇူးပြု၍ နောက်မှပြန်လည်ကြိုးစားပါ သို့မဟုတ် Scrum Helper ဆက်တင်များတွင် သင်၏ GitHub တိုကင်ကို ထည့်သွင်း/စစ်ဆေးပါ။"
+    },
+    "rateLimitWarningMessage": {
+        "message": "GitHub နှုန်းကန့်သတ်ချက်ကြောင့် အချို့သောအချက်အလက်များ လိုအပ်နေနိုင်ပါသည်။ ဆက်တင်များတွင် သင်၏ GitHub တိုကင်ကို ထည့်သွင်း သို့မဟုတ် စစ်ဆေးပါ။"
     }
 }

--- a/src/_locales/nb/messages.json
+++ b/src/_locales/nb/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "Forrige dag"
     },
+    "lastWeekLabel": {
+        "message": "Forrige uke"
+    },
     "startDateLabel": {
         "message": "Fra:"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "Rapport satt inn i e-post!"
+    },
+    "rateLimitError": {
+        "message": "GitHub API-ratebegrensning overskredet. Prøv igjen senere eller legg til/sjekk GitHub-tokenet ditt i Scrum Helper-innstillingene."
+    },
+    "rateLimitWarningMessage": {
+        "message": "Noen data kan mangle på grunn av GitHub-ratebegrensningen. Vennligst legg til eller sjekk GitHub-tokenet ditt i innstillingene."
     }
 }

--- a/src/_locales/pt/messages.json
+++ b/src/_locales/pt/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "Dia anterior"
     },
+    "lastWeekLabel": {
+        "message": "Semana anterior"
+    },
     "startDateLabel": {
         "message": "De:"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "Relatório inserido no e-mail!"
+    },
+    "rateLimitError": {
+        "message": "Limite de taxa da API do GitHub excedido. Tente novamente mais tarde ou adicione/verifique o seu token do GitHub nas configurações do Scrum Helper."
+    },
+    "rateLimitWarningMessage": {
+        "message": "Alguns dados podem estar em falta devido ao limite de taxa do GitHub. Adicione ou verifique o seu token do GitHub nas configurações."
     }
 }

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "Dia anterior"
     },
+    "lastWeekLabel": {
+        "message": "Semana anterior"
+    },
     "startDateLabel": {
         "message": "De:"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "Relatório inserido no e-mail!"
+    },
+    "rateLimitError": {
+        "message": "Limite de requisições da API do GitHub excedido. Por favor, tente novamente mais tarde ou adicione/verifique seu token do GitHub nas configurações do Scrum Helper."
+    },
+    "rateLimitWarningMessage": {
+        "message": "Alguns dados podem estar faltando devido ao limite de requisições do GitHub. Por favor, adicione ou verifique seu token do GitHub nas configurações."
     }
 }

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "Предыдущий день"
     },
+    "lastWeekLabel": {
+        "message": "Предыдущая неделя"
+    },
     "startDateLabel": {
         "message": "С:"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "Отчёт вставлен в письмо!"
+    },
+    "rateLimitError": {
+        "message": "Превышен лимит запросов GitHub API. Пожалуйста, попробуйте позже или добавьте/проверьте ваш токен GitHub в настройках Scrum Helper."
+    },
+    "rateLimitWarningMessage": {
+        "message": "Некоторые данные могут отсутствовать из-за ограничения лимита запросов GitHub. Пожалуйста, добавьте или проверьте ваш токен GitHub в настройках."
     }
 }

--- a/src/_locales/ta/messages.json
+++ b/src/_locales/ta/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "முந்தைய நாள்"
     },
+    "lastWeekLabel": {
+        "message": "கடந்த வாரம்"
+    },
     "startDateLabel": {
         "message": "தொடக்கம்:"
     },
@@ -154,6 +157,9 @@
     },
     "repoCount": {
         "message": "$1 களஞ்சியங்கள் தேர்ந்தெடுக்கப்பட்டன"
+    },
+    "clearAllBtn": {
+        "message": "அனைத்தையும் அழி"
     },
     "repoLoading": {
         "message": "களஞ்சியங்கள் ஏற்றப்படுகின்றன..."
@@ -331,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "அறிக்கை மின்னஞ்சலில் செருகப்பட்டது!"
+    },
+    "rateLimitError": {
+        "message": "GitHub API விகித வரம்பு மீறப்பட்டது. பின்னர் மீண்டும் முயற்சிக்கவும் அல்லது Scrum Helper அமைப்புகளில் உங்கள் GitHub டோக்கனை சேர்க்கவும்/சரிபார்க்கவும்."
+    },
+    "rateLimitWarningMessage": {
+        "message": "GitHub விகித வரம்பு காரணமாக சில தரவுகள் విடுபட்டிருக்கலாம். அமைப்புகளில் உங்கள் GitHub டோக்கனை சேர்க்கவும் அல்லது சரிபார்க்கவும்."
     }
 }

--- a/src/_locales/te/messages.json
+++ b/src/_locales/te/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "గత రోజు"
     },
+    "lastWeekLabel": {
+        "message": "గత వారం"
+    },
     "startDateLabel": {
         "message": "నుండి:"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "నివేదిక ఇమెయిల్‌లో చేర్చబడింది!"
+    },
+    "rateLimitError": {
+        "message": "GitHub API రేట్ పరిమితి మించిపోయింది. దయచేసి తర్వాత మళ్లీ ప్రయత్నించండి లేదా Scrum Helper సెట్టింగ్‌లలో మీ GitHub టోకెన్‌ను జోడించండి/తనిఖీ చేయండి."
+    },
+    "rateLimitWarningMessage": {
+        "message": "GitHub రేట్ పరిమితి కారణంగా కొంత డేటా మిస్ కావచ్చు. దయచేసి సెట్టింగ్‌లలో మీ GitHub టోకెన్‌ను జోడించండి లేదా తనిఖీ చేయండి."
     }
 }

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "Попередній день"
     },
+    "lastWeekLabel": {
+        "message": "Минулий тиждень"
+    },
     "startDateLabel": {
         "message": "З:"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "Звіт вставлено в лист!"
+    },
+    "rateLimitError": {
+        "message": "Перевищено ліміт запитів GitHub API. Будь ласка, спробуйте пізніше або додайте/перевірте свій токен GitHub у налаштуваннях Scrum Helper."
+    },
+    "rateLimitWarningMessage": {
+        "message": "Деякі дані можуть бути відсутні через обмеження ліміту запитів GitHub. Будь ласка, додайте або перевірте свій токен GitHub у налаштуваннях."
     }
 }

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "Ngày trước"
     },
+    "lastWeekLabel": {
+        "message": "Tuần trước"
+    },
     "startDateLabel": {
         "message": "Từ:"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "Đã chèn báo cáo vào email!"
+    },
+    "rateLimitError": {
+        "message": "Đã vượt quá giới hạn tỷ lệ API GitHub. Vui lòng thử lại sau hoặc thêm/kiểm tra mã thông báo GitHub của bạn trong cài đặt Scrum Helper."
+    },
+    "rateLimitWarningMessage": {
+        "message": "Một số dữ liệu có thể bị thiếu do giới hạn tỷ lệ của GitHub. Vui lòng thêm hoặc kiểm tra mã thông báo GitHub của bạn trong phần cài đặt."
     }
 }

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -32,6 +32,9 @@
     "last1DayLabel": {
         "message": "前一天"
     },
+    "lastWeekLabel": {
+        "message": "上周"
+    },
     "startDateLabel": {
         "message": "从:"
     },
@@ -334,5 +337,11 @@
     },
     "insertedInEmailNotification": {
         "message": "报告已插入邮件！"
+    },
+    "rateLimitError": {
+        "message": "超出 GitHub API 速率限制。请稍后再试，或在 Scrum Helper 设置中添加/检查您的 GitHub 令牌。"
+    },
+    "rateLimitWarningMessage": {
+        "message": "由于 GitHub 速率限制，部分数据可能缺失。请在设置中添加或检查您的 GitHub 令牌。"
     }
 }


### PR DESCRIPTION
### 📌 Fixes

Fixes #659 

---

### 📝 Summary of Changes

- **Added Missing Translations**: Added the missing keys (`lastWeekLabel`, `rateLimitError`, `rateLimitWarningMessage`, and `clearAllBtn`) to all 20 non-English locale files (`de`, `el`, `es`, `fr`, `he`, `hi`, `id`, `it`, `ja`, `ml`, `my`, `nb`, `pt`, `pt_BR`, `ru`, `ta`, `te`, `uk`, `vi`, and `zh_CN`) in their respective languages.
- **Added English Descriptions**: Added the missing `"description"` keys to 6 translation entries (`scrumReportLabel`, `showCommitsTooltip`, `onlyIssuesLabel`, `onlyIssuesTooltip`, `onlyPRsLabel`, and `onlyPRsTooltip`) in `src/_locales/en/messages.json`.
- **Validation and Schema Conformity**: Validated that all non-English locale files do not contain any `"description"` fields, leaving only the `"message"` key per translation entry to match Web Extension standards.
- **Preserved Original Formatting**: Synced the translation key order with `en/messages.json` and preserved the original indentation styling (2 spaces for `en`, 4 spaces for all other locales) to prevent whitespace clutter in the PR diff.

---

### 📸 Screenshots / Demo (if UI-related)

_Not applicable (purely translation and localization improvements)_

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [x] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

* Used an AI assistant to fetch, structure, and translate the missing keys accurately for each locale, and verified all files for schema conformity and build consistency before pushing.