### PR TITLE
fix: change orgs to groups for gitlab

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -94,6 +94,10 @@
     "message": "Enter organization name",
     "description": "Placeholder for the organization name input."
   },
+  "gitlabOrgNamePlaceholder": {
+    "message": "Enter group name",
+    "description": "Placeholder for the GitLab group name input."
+  },
   "setButton": {
     "message": "Set",
     "description": "Text for the 'Set' button for the organization."

--- a/src/popup.html
+++ b/src/popup.html
@@ -422,7 +422,7 @@
 					</div>
 
 					<div class="orgSection">
-						<div class="flex items-center mt-4">
+						<div class="flex items-center mt-4 githubOnlySection">
 							<p class="text-sm font-semibold" data-i18n="settingsOrgNameLabel">Your Organization Name
 							</p>
 							<span class="tooltip-container ml-2">
@@ -434,6 +434,21 @@
 									your GitHub
 									activities across all organizations.
 									Organization name is not case-sensitive.
+								</span>
+							</span>
+						</div>
+						<div class="flex items-center mt-4 gitlabOnlySection hidden">
+							<p class="text-sm font-semibold" data-i18n="settingsGroupNameLabel">Your Group Name
+							</p>
+							<span class="tooltip-container ml-2">
+								<i class="fa fa-question-circle question-icon"></i>
+								<span class="tooltip-bubble" data-i18n="gitlabOrgNameTooltip">
+									<b>Which group's GitLab activity?</b><br>
+									Enter the GitLab group name to fetch activities for. Leave empty to fetch
+									all
+									your GitLab
+									activities across all groups.
+									Group name is not case-sensitive.
 								</span>
 							</span>
 						</div>

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1686,7 +1686,12 @@ function updatePlatformUI(platform) {
 
 	const orgInput = document.getElementById('orgInput');
 	if (orgInput) {
-		orgInput.placeholder = platform === 'gitlab' ? 'Enter group name' : 'Enter organization name';
+		const key = platform === 'gitlab' ? 'gitlabOrgNamePlaceholder' : 'settingsOrgNamePlaceholder';
+		orgInput.setAttribute('data-i18n-placeholder', key);
+		const message = browser.i18n.getMessage(key);
+		if (message) {
+			orgInput.placeholder = message;
+		}
 	}
 
 	const orgSection = document.querySelector('.orgSection');

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1684,6 +1684,11 @@ function updatePlatformUI(platform) {
 		}
 	}
 
+	const orgInput = document.getElementById('orgInput');
+	if (orgInput) {
+		orgInput.placeholder = platform === 'gitlab' ? 'Enter group name' : 'Enter organization name';
+	}
+
 	const orgSection = document.querySelector('.orgSection');
 	if (orgSection) {
 		if (platform === 'github' || platform === 'gitlab') {


### PR DESCRIPTION
### 📌 Fixes

Fixes #742

---

### 📝 Summary of Changes

- **Platform-Specific Settings Layout**: Split the settings organization name label and question tooltip into two separate markup blocks in `src/popup.html`.
- **Automatic Class Toggle Integration**: Decorated the GitHub tooltip block with `githubOnlySection` and the new GitLab group tooltip block with `gitlabOnlySection` (`hidden` by default) to leverage the existing UI toggle loops.
- **Secure Placeholder Update**: Added a secure placeholder setter in `updatePlatformUI()` (`src/scripts/popup.js`) to switch between "Enter organization name" and "Enter group name" without using `innerHTML` or adding/updating translation locales.

---

### 📸 Screenshots / Demo (if UI-related)

#### Before

<img width="501" height="288" alt="image" src="https://github.com/user-attachments/assets/fe3b77ef-aba7-4f3c-b016-0c0b43082192" />


<img width="498" height="163" alt="image" src="https://github.com/user-attachments/assets/5e50a198-632f-443d-88cc-79999c1a0537" />


#### After

<img width="496" height="278" alt="image" src="https://github.com/user-attachments/assets/b555bf34-0f27-4e1b-9e9d-43002481d7b5" />

<img width="498" height="163" alt="image" src="https://github.com/user-attachments/assets/09ff0742-5fc6-455a-8513-5f9fb9eaa675" />


---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [x] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

## Summary by Sourcery

Update popup settings UI to distinguish GitHub organizations from GitLab groups and adjust input placeholder text based on selected platform.

New Features:
- Add a GitLab-specific group name label and tooltip in the settings UI alongside the existing GitHub organization label.

Enhancements:
- Tie the organization/group name input placeholder to the selected platform, switching between organization and group wording without altering translations.
- Scope the organization name label and tooltip to GitHub only, and introduce a GitLab-only section that is toggled via existing platform UI logic.