### PR TITLE
fix: resolve email signature and reply thread destruction during repo…

### DIFF
--- a/src/scripts/emailClientAdapter.js
+++ b/src/scripts/emailClientAdapter.js
@@ -249,17 +249,29 @@ class EmailClientAdapter {
 		const config = this.clientConfigs[clientType];
 
 		try {
+			const sanitizedContent = sanitizeHtml(content);
+			const containerClass = 'scrum-helper-report-container';
+
+			const performInjection = (el) => {
+				const container = el.querySelector(`.${containerClass}`);
+				if (container) {
+					container.innerHTML = sanitizedContent;
+				} else {
+					el.innerHTML = `<div class="${containerClass}">${sanitizedContent}</div><br><br>` + el.innerHTML;
+				}
+			};
+
 			switch (config?.injectMethod) {
 				case 'focusAndPaste':
 					// Special handling for Outlook
 					element.focus();
-					element.innerHTML = sanitizeHtml(content);
+					performInjection(element);
 					this.dispatchElementEvents(element, ['input', 'change'], true);
 					break;
 
 				case 'setContent': {
 					// Special handling for Yahoo
-					element.innerHTML = sanitizeHtml(content);
+					performInjection(element);
 					element.focus();
 					// Force Yahoo's editor to recognize the change
 					const selection = window.getSelection();
@@ -273,7 +285,7 @@ class EmailClientAdapter {
 
 				default:
 					// Default handling for Google clients
-					element.innerHTML = sanitizeHtml(content);
+					performInjection(element);
 					element.dispatchEvent(new Event(eventType, { bubbles: true }));
 			}
 			return true;


### PR DESCRIPTION
###  Fixes

Fixes #666

---

###  Summary of Changes

- **The Problem:** Currently, when injecting the scrum report, the adapter uses a direct `element.innerHTML` override. This destroys any existing content in the composer window, causing immediate data loss by wiping out default email signatures and reply history/quote blocks on email threads.
- **The Fix:** Wrapped the injected report HTML in a custom container class (`.scrum-helper-report-container`). 
- **Preserves Existing Context:** The injection method now checks if this container is already present in the composer:
  - If it is not present, we prepend the container at the top of the email draft, keeping existing signatures or text intact below it.
  - If the container already exists (e.g., if the user updates settings and inserts again), the script updates the container's contents in-place, which avoids duplicating the report.

---

###  Screenshots / Demo (if UI-related)

<img width="682" height="322" alt="image" src="https://github.com/user-attachments/assets/9ad7fd04-cb82-42c9-8c39-d7ea8bf548e7" />

Manual testing in Gmail shows the report prepends correctly above signatures and text drafts without wiping the composer.

---

###  Checklist

- [x] I’ve tested my changes locally
- [x] My code follows the project’s code style guidelines

---

###  Contribution Verification Checklist

- [x] I have searched existing issues to ensure this bug hasn't been reported (Confirmed tracking Issue #666)
- [x] I have provided clear reproduction steps
- [x] I have included relevant environment details (Chrome/Chromium in Developer Mode)
- [x] I have described both expected and actual behavior

---

###  Reviewer Notes

####  Implementation Details
We added a queryable block container `scrum-helper-report-container` inside the `injectContent` method in `emailClientAdapter.js`. By querying this class using `el.querySelector`, we can safely identify if the extension has already injected a report in the active compose tab.

####  Side Effects During Merge
- **None.** The fix does not modify any build tools, external manifest variables, configuration files, or style templates. 
- It uses standard vanilla JS DOM APIs supported across Chrome, Firefox, and Opera.

####  Proof of No Global Impact
- **Highly Localized:** The code changes are restricted *solely* to the `injectContent` function inside `src/scripts/emailClientAdapter.js`. 
- **Zero API/Storage Impact:** It does not change how data is fetched from GitHub/GitLab APIs, nor does it affect local browser storage or date-range calculation algorithms.
- **Sanitization Maintained:** The implementation continues to pass the content through the existing `sanitizeHtml` handler, preserving the project's security rules against XSS injection.