### PR TITLE
feat(report): replace Previous Week report with concise Previous Week Summary (#746)

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Berichten Sie über Ihren Entwicklungsfortschritt, indem Sie Ihre Git-Aktivität für einen ausgewählten Zeitraum automatisch abrufen"
-    },
-    "disableLabel": {
-        "message": "Deaktivieren"
-    },
-    "enableLabel": {
-        "message": "Aktivieren"
-    },
-    "projectNameLabel": {
-        "message": "Projektname (wird im E-Mail-Betreff verwendet)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Geben Sie Ihren Projektnamen ein"
-    },
-    "githubUsernameLabel": {
-        "message": "Ihr GitHub-Benutzername"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Ihr GitLab-Benutzername"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Erforderlich, um Ihre Beiträge abzurufen"
-    },
-    "contributionsLabel": {
-        "message": "Ihre Beiträge abrufen für:"
-    },
-    "last1DayLabel": {
-        "message": "Vorheriger Tag"
-    },
-    "startDateLabel": {
-        "message": "Von:"
-    },
-    "endDateLabel": {
-        "message": "Bis:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Offen/Geschlossen-Status anzeigen"
-    },
-    "blockersLabel": {
-        "message": "Was hindert Sie am Fortschritt?"
-    },
-    "blockersPlaceholder": {
-        "message": "Geben Sie hier den Grund ein"
-    },
-    "scrumReportLabel": {
-        "message": "Scrum-Bericht"
-    },
-    "generateReportButton": {
-        "message": "Erstellen"
-    },
-    "copyReportButton": {
-        "message": "Kopieren"
-    },
-    "insertInEmailButton": {
-        "message": "In E-Mail einfügen"
-    },
-    "insertToEmailFailedError": {
-        "message": "Öffnen Sie einen E-Mail-Tab, um den Bericht einzufügen"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Name der Organisation"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Namen der Organisation eingeben"
-    },
-    "setButton": {
-        "message": "Festlegen"
-    },
-    "githubTokenLabel": {
-        "message": "Ihr GitHub-Token"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Erforderlich für authentifizierte Anfragen"
-    },
-    "githubTokenTooltip": {
-        "message": "Warum wird empfohlen, ein GitHub-Token hinzuzufügen? Scrum Helper funktioniert ohne ein GitHub-Token, aber das Hinzufügen eines persönlichen Zugriffstokens wird für ein besseres Erlebnis empfohlen."
-    },
-    "gitlabTokenLabel": {
-        "message": "Ihr GitLab-Token"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Erforderlich für private Repos"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Warum wird empfohlen, ein GitLab-Token hinzuzufügen? Scrum Helper funktioniert ohne ein GitLab-Token für öffentliche Projekte, aber das Hinzufügen eines persönlichen Zugriffstokens wird für ein besseres Erlebnis empfohlen."
-    },
-    "showCommitsLabel": {
-        "message": "Commits in offenen PRs/ Entwurfs-PRs anzeigen"
-    },
-    "showCommitsTooltip": {
-        "message": "Github-Token erforderlich, bitte in den Einstellungen hinzufügen."
-    },
-    "onlyIssuesLabel": {
-        "message": "Nur Probleme in den Bericht aufnehmen"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Wenn diese Option aktiviert ist, enthält der Bericht nur Probleme, die vom Benutzer erstellt oder ihm zugewiesen wurden."
-    },
-    "onlyPRsLabel": {
-        "message": "Nur PRs in den Bericht aufnehmen"
-    },
-    "onlyPRsTooltip": {
-        "message": "Wenn diese Option aktiviert ist, enthält der Bericht nur von Ihnen erstellte Pull Requests; überprüfte PRs werden ausgeschlossen."
-    },
-    "cacheTTLLabel": {
-        "message": "Cache-TTL eingeben"
-    },
-    "cacheTTLUnit": {
-        "message": "(in Minuten)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Cache-TTL in Minuten (Standard: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Daten aktualisieren (Cache umgehen)"
-    },
-    "refreshDataInfo": {
-        "message": "Verwenden Sie diese Schaltfläche, um neue Daten sofort abzurufen."
-    },
-    "noteTitle": {
-        "message": "Hinweis:"
-    },
-    "viewCodeButton": {
-        "message": "Code ansehen"
-    },
-    "reportIssueButton": {
-        "message": "Problem melden"
-    },
-    "repoFilterLabel": {
-        "message": "Nach Repositories filtern"
-    },
-    "enableFilteringLabel": {
-        "message": "Filterung aktivieren"
-    },
-    "tokenRequiredWarning": {
-        "message": "Für die Repository-Filterung ist ein GitHub-Token erforderlich. Bitte fügen Sie einen in den Einstellungen hinzu."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "Ein GitHub-Token ist erforderlich, um Commits in offenen oder Entwurfs-PRs anzuzeigen. Bitte fügen Sie eines in den Einstellungen hinzu."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Repository zum Hinzufügen suchen..."
-    },
-    "repoPlaceholder": {
-        "message": "Keine Repositories ausgewählt (alle werden einbezogen)"
-    },
-    "repoCountNone": {
-        "message": "0 Repositories ausgewählt"
-    },
-    "repoCount": {
-        "message": "$1 Repositories ausgewählt"
-    },
-    "clearAllBtn": {
-        "message": "Alle löschen"
-    },
-    "repoLoading": {
-        "message": "Lade Repositories..."
-    },
-    "repoLoaded": {
-        "message": "$1 Repositories geladen."
-    },
-    "repoNotFound": {
-        "message": "Keine Repositories gefunden"
-    },
-    "repoRefetching": {
-        "message": "Lade Repositories neu..."
-    },
-    "repoLoadFailed": {
-        "message": "Laden der Repositories fehlgeschlagen."
-    },
-    "repoTokenPrivate": {
-        "message": "Token ist ungültig oder hat keine Rechte für private Repos."
-    },
-    "repoRefetchFailed": {
-        "message": "Neuladen der Repositories fehlgeschlagen."
-    },
-    "orgSetMessage": {
-        "message": "Organisation erfolgreich festgelegt."
-    },
-    "orgClearedMessage": {
-        "message": "Organisation gelöscht. Klicken Sie auf 'Bericht erstellen', um alle Aktivitäten abzurufen."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organisation auf GitHub nicht gefunden."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Fehler bei der Validierung der Organisation."
-    },
-    "refreshingButton": {
-        "message": "Wird aktualisiert..."
-    },
-    "cacheClearFailed": {
-        "message": "Cache-Löschung fehlgeschlagen."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Wird generiert..."
-    },
-    "copiedButton": {
-        "message": "Kopiert!"
-    },
-    "orgChangedMessage": {
-        "message": "Organisation geändert. Klicken Sie auf 'Bericht erstellen', um die GitHub-Aktivitäten abzurufen."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache erfolgreich geleert. Klicken Sie auf 'Bericht erstellen', um neue Daten abzurufen."
-    },
-    "cacheExpiredMessage": {
-        "message": "Cache abgelaufen. Klicken Sie auf \"Erstellen\", um neue Daten abzurufen."
-    },
-    "cacheClearedButton": {
-        "message": "Cache geleert!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Erweiterung ist deaktiviert. Aktivieren Sie sie in den Einstellungen, um Scrum-Berichte zu erstellen."
-    },
-    "notePoint1": {
-        "message": "Pull-Requests werden basierend auf der letzten Review-Aktivität eines beliebigen Beitragenden abgerufen, nicht nur Ihrer eigenen. Bitte überprüfen und passen Sie den generierten SCRUM-Bericht an, um sicherzustellen, dass er Ihre Arbeit korrekt widerspiegelt, bevor Sie ihn teilen."
-    },
-    "noteSeeIssue": {
-        "message": "Siehe dieses Issue"
-    },
-    "platformLabel": {
-        "message": "Plattform"
-    },
-    "usernameLabel": {
-        "message": "Ihr Benutzername"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Nur überprüfte PRs in den Bericht aufnehmen"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Wenn diese Option aktiviert ist, enthält der Bericht nur PRs, die von Ihnen überprüft wurden."
-    },
-    "onlyMergedPRsLabel": {
-        "message": "Nur zusammengeführte (merged) PRs in den Bericht aufnehmen"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "Wenn aktiviert, enthält der Bericht nur zusammengeführte PRs. Ein GitHub-Token ist erforderlich."
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "Ein GitHub-Token ist erforderlich, um nach zusammengeführten PRs zu filtern. Bitte fügen Sie eines in den Einstellungen hinzu."
-    },
-    "usernameRequiredError": {
-        "message": "Bitte geben Sie Ihren Benutzernamen ein, um einen Bericht zu erstellen."
-    },
-    "unknownPlatformError": {
-        "message": "Unbekannte Plattform ausgewählt."
-    },
-    "gitlabFetchingError": {
-        "message": "Beim Abrufen der GitLab-Daten ist ein Fehler aufgetreten."
-    },
-    "reportGenerationError": {
-        "message": "Beim Erstellen des Berichts ist ein Fehler aufgetreten."
-    },
-    "githubUserNotFoundError": {
-        "message": "GitHub-Benutzer \"$1\" nicht gefunden (404). Bitte überprüfen Sie den Benutzernamen und versuchen Sie es erneut."
-    },
-    "githubUserValidationError": {
-        "message": "Fehler bei der Validierung des GitHub-Benutzers: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Ungültige Suchanfrage oder Datumsbereich. Bitte überprüfen Sie das Format Ihres Datumsbereichs und versuchen Sie es erneut."
-    },
-    "githubIssuesFetchError": {
-        "message": "Fehler beim Abrufen von GitHub-Issues: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Fehler beim Abrufen der GitHub-PR-Review-Daten: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Fehler beim Abrufen der GitHub-Benutzerdaten: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Ungültiges oder abgelaufenes GitHub-Token. Bitte überprüfen Sie Ihr Token in den Scrum Helper-Einstellungen und versuchen Sie es erneut."
-    },
-    "displayModeNotice": {
-        "message": "Die Erweiterung wird beim nächsten Start im $1-Modus geöffnet."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Repository-Filterung ist nur für GitHub verfügbar."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Repository-Laden ist nur für GitHub verfügbar."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Repository-Abruf ist nur für GitHub verfügbar."
-    },
-    "loadingReposAutomatically": {
-        "message": "Lade Repositories automatisch..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Fehler beim Abrufen des GitLab-Benutzers: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "GitLab-Benutzer '$1' nicht gefunden"
-    },
-    "gitlabMembershipError": {
-        "message": "Fehler beim Abrufen der GitLab-Mitgliedschaftsprojekte: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Fehler beim Abrufen der GitLab-Beitragsprojekte: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Benutzername erforderlich."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Bericht wird erstellt..."
-    },
-    "copyingReportNotification": {
-        "message": "Bericht wird kopiert..."
-    },
-    "copiedReportNotification": {
-        "message": "Bericht kopiert!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Bericht wird in E-Mail eingefügt..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Bericht in E-Mail eingefügt!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Berichten Sie über Ihren Entwicklungsfortschritt, indem Sie Ihre Git-Aktivität für einen ausgewählten Zeitraum automatisch abrufen"
+  },
+  "disableLabel": {
+    "message": "Deaktivieren"
+  },
+  "enableLabel": {
+    "message": "Aktivieren"
+  },
+  "projectNameLabel": {
+    "message": "Projektname (wird im E-Mail-Betreff verwendet)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Geben Sie Ihren Projektnamen ein"
+  },
+  "githubUsernameLabel": {
+    "message": "Ihr GitHub-Benutzername"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Ihr GitLab-Benutzername"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Erforderlich, um Ihre Beiträge abzurufen"
+  },
+  "contributionsLabel": {
+    "message": "Ihre Beiträge abrufen für:"
+  },
+  "last1DayLabel": {
+    "message": "Vorheriger Tag"
+  },
+  "lastWeekLabel": {
+    "message": "Zusammenfassung der letzten Woche",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "Von:"
+  },
+  "endDateLabel": {
+    "message": "Bis:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Offen/Geschlossen-Status anzeigen"
+  },
+  "blockersLabel": {
+    "message": "Was hindert Sie am Fortschritt?"
+  },
+  "blockersPlaceholder": {
+    "message": "Geben Sie hier den Grund ein"
+  },
+  "scrumReportLabel": {
+    "message": "Scrum-Bericht"
+  },
+  "generateReportButton": {
+    "message": "Erstellen"
+  },
+  "copyReportButton": {
+    "message": "Kopieren"
+  },
+  "insertInEmailButton": {
+    "message": "In E-Mail einfügen"
+  },
+  "insertToEmailFailedError": {
+    "message": "Öffnen Sie einen E-Mail-Tab, um den Bericht einzufügen"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Name der Organisation"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Namen der Organisation eingeben"
+  },
+  "setButton": {
+    "message": "Festlegen"
+  },
+  "githubTokenLabel": {
+    "message": "Ihr GitHub-Token"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Erforderlich für authentifizierte Anfragen"
+  },
+  "githubTokenTooltip": {
+    "message": "Warum wird empfohlen, ein GitHub-Token hinzuzufügen? Scrum Helper funktioniert ohne ein GitHub-Token, aber das Hinzufügen eines persönlichen Zugriffstokens wird für ein besseres Erlebnis empfohlen."
+  },
+  "gitlabTokenLabel": {
+    "message": "Ihr GitLab-Token"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Erforderlich für private Repos"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Warum wird empfohlen, ein GitLab-Token hinzuzufügen? Scrum Helper funktioniert ohne ein GitLab-Token für öffentliche Projekte, aber das Hinzufügen eines persönlichen Zugriffstokens wird für ein besseres Erlebnis empfohlen."
+  },
+  "showCommitsLabel": {
+    "message": "Commits in offenen PRs/ Entwurfs-PRs anzeigen"
+  },
+  "showCommitsTooltip": {
+    "message": "Github-Token erforderlich, bitte in den Einstellungen hinzufügen."
+  },
+  "onlyIssuesLabel": {
+    "message": "Nur Probleme in den Bericht aufnehmen"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Wenn diese Option aktiviert ist, enthält der Bericht nur Probleme, die vom Benutzer erstellt oder ihm zugewiesen wurden."
+  },
+  "onlyPRsLabel": {
+    "message": "Nur PRs in den Bericht aufnehmen"
+  },
+  "onlyPRsTooltip": {
+    "message": "Wenn diese Option aktiviert ist, enthält der Bericht nur von Ihnen erstellte Pull Requests; überprüfte PRs werden ausgeschlossen."
+  },
+  "cacheTTLLabel": {
+    "message": "Cache-TTL eingeben"
+  },
+  "cacheTTLUnit": {
+    "message": "(in Minuten)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Cache-TTL in Minuten (Standard: 10)"
+  },
+  "refreshDataButton": {
+    "message": "Daten aktualisieren (Cache umgehen)"
+  },
+  "refreshDataInfo": {
+    "message": "Verwenden Sie diese Schaltfläche, um neue Daten sofort abzurufen."
+  },
+  "noteTitle": {
+    "message": "Hinweis:"
+  },
+  "viewCodeButton": {
+    "message": "Code ansehen"
+  },
+  "reportIssueButton": {
+    "message": "Problem melden"
+  },
+  "repoFilterLabel": {
+    "message": "Nach Repositories filtern"
+  },
+  "enableFilteringLabel": {
+    "message": "Filterung aktivieren"
+  },
+  "tokenRequiredWarning": {
+    "message": "Für die Repository-Filterung ist ein GitHub-Token erforderlich. Bitte fügen Sie einen in den Einstellungen hinzu."
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "Ein GitHub-Token ist erforderlich, um Commits in offenen oder Entwurfs-PRs anzuzeigen. Bitte fügen Sie eines in den Einstellungen hinzu."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Repository zum Hinzufügen suchen..."
+  },
+  "repoPlaceholder": {
+    "message": "Keine Repositories ausgewählt (alle werden einbezogen)"
+  },
+  "repoCountNone": {
+    "message": "0 Repositories ausgewählt"
+  },
+  "repoCount": {
+    "message": "$1 Repositories ausgewählt"
+  },
+  "clearAllBtn": {
+    "message": "Alle löschen"
+  },
+  "repoLoading": {
+    "message": "Lade Repositories..."
+  },
+  "repoLoaded": {
+    "message": "$1 Repositories geladen."
+  },
+  "repoNotFound": {
+    "message": "Keine Repositories gefunden"
+  },
+  "repoRefetching": {
+    "message": "Lade Repositories neu..."
+  },
+  "repoLoadFailed": {
+    "message": "Laden der Repositories fehlgeschlagen."
+  },
+  "repoTokenPrivate": {
+    "message": "Token ist ungültig oder hat keine Rechte für private Repos."
+  },
+  "repoRefetchFailed": {
+    "message": "Neuladen der Repositories fehlgeschlagen."
+  },
+  "orgSetMessage": {
+    "message": "Organisation erfolgreich festgelegt."
+  },
+  "orgClearedMessage": {
+    "message": "Organisation gelöscht. Klicken Sie auf 'Bericht erstellen', um alle Aktivitäten abzurufen."
+  },
+  "orgNotFoundMessage": {
+    "message": "Organisation auf GitHub nicht gefunden."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Fehler bei der Validierung der Organisation."
+  },
+  "refreshingButton": {
+    "message": "Wird aktualisiert..."
+  },
+  "cacheClearFailed": {
+    "message": "Cache-Löschung fehlgeschlagen."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Wird generiert..."
+  },
+  "copiedButton": {
+    "message": "Kopiert!"
+  },
+  "orgChangedMessage": {
+    "message": "Organisation geändert. Klicken Sie auf 'Bericht erstellen', um die GitHub-Aktivitäten abzurufen."
+  },
+  "cacheClearedMessage": {
+    "message": "Cache erfolgreich geleert. Klicken Sie auf 'Bericht erstellen', um neue Daten abzurufen."
+  },
+  "cacheExpiredMessage": {
+    "message": "Cache abgelaufen. Klicken Sie auf \"Erstellen\", um neue Daten abzurufen."
+  },
+  "cacheClearedButton": {
+    "message": "Cache geleert!"
+  },
+  "extensionDisabledMessage": {
+    "message": "Erweiterung ist deaktiviert. Aktivieren Sie sie in den Einstellungen, um Scrum-Berichte zu erstellen."
+  },
+  "notePoint1": {
+    "message": "Pull-Requests werden basierend auf der letzten Review-Aktivität eines beliebigen Beitragenden abgerufen, nicht nur Ihrer eigenen. Bitte überprüfen und passen Sie den generierten SCRUM-Bericht an, um sicherzustellen, dass er Ihre Arbeit korrekt widerspiegelt, bevor Sie ihn teilen."
+  },
+  "noteSeeIssue": {
+    "message": "Siehe dieses Issue"
+  },
+  "platformLabel": {
+    "message": "Plattform"
+  },
+  "usernameLabel": {
+    "message": "Ihr Benutzername"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Nur überprüfte PRs in den Bericht aufnehmen"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Wenn diese Option aktiviert ist, enthält der Bericht nur PRs, die von Ihnen überprüft wurden."
+  },
+  "onlyMergedPRsLabel": {
+    "message": "Nur zusammengeführte (merged) PRs in den Bericht aufnehmen"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "Wenn aktiviert, enthält der Bericht nur zusammengeführte PRs. Ein GitHub-Token ist erforderlich."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "Ein GitHub-Token ist erforderlich, um nach zusammengeführten PRs zu filtern. Bitte fügen Sie eines in den Einstellungen hinzu."
+  },
+  "usernameRequiredError": {
+    "message": "Bitte geben Sie Ihren Benutzernamen ein, um einen Bericht zu erstellen."
+  },
+  "unknownPlatformError": {
+    "message": "Unbekannte Plattform ausgewählt."
+  },
+  "gitlabFetchingError": {
+    "message": "Beim Abrufen der GitLab-Daten ist ein Fehler aufgetreten."
+  },
+  "reportGenerationError": {
+    "message": "Beim Erstellen des Berichts ist ein Fehler aufgetreten."
+  },
+  "githubUserNotFoundError": {
+    "message": "GitHub-Benutzer \"$1\" nicht gefunden (404). Bitte überprüfen Sie den Benutzernamen und versuchen Sie es erneut."
+  },
+  "githubUserValidationError": {
+    "message": "Fehler bei der Validierung des GitHub-Benutzers: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Ungültige Suchanfrage oder Datumsbereich. Bitte überprüfen Sie das Format Ihres Datumsbereichs und versuchen Sie es erneut."
+  },
+  "githubIssuesFetchError": {
+    "message": "Fehler beim Abrufen von GitHub-Issues: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Fehler beim Abrufen der GitHub-PR-Review-Daten: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Fehler beim Abrufen der GitHub-Benutzerdaten: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Ungültiges oder abgelaufenes GitHub-Token. Bitte überprüfen Sie Ihr Token in den Scrum Helper-Einstellungen und versuchen Sie es erneut."
+  },
+  "displayModeNotice": {
+    "message": "Die Erweiterung wird beim nächsten Start im $1-Modus geöffnet."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Repository-Filterung ist nur für GitHub verfügbar."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Repository-Laden ist nur für GitHub verfügbar."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Repository-Abruf ist nur für GitHub verfügbar."
+  },
+  "loadingReposAutomatically": {
+    "message": "Lade Repositories automatisch..."
+  },
+  "gitlabUserFetchError": {
+    "message": "Fehler beim Abrufen des GitLab-Benutzers: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "GitLab-Benutzer '$1' nicht gefunden"
+  },
+  "gitlabMembershipError": {
+    "message": "Fehler beim Abrufen der GitLab-Mitgliedschaftsprojekte: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Fehler beim Abrufen der GitLab-Beitragsprojekte: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Benutzername erforderlich."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Bericht wird erstellt..."
+  },
+  "copyingReportNotification": {
+    "message": "Bericht wird kopiert..."
+  },
+  "copiedReportNotification": {
+    "message": "Bericht kopiert!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Bericht wird in E-Mail eingefügt..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Bericht in E-Mail eingefügt!"
+  }
 }

--- a/src/_locales/el/messages.json
+++ b/src/_locales/el/messages.json
@@ -1,335 +1,339 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Αναφέρετε την πρόοδο της ανάπτυξής σας ανακτώντας αυτόματα τη δραστηριότητα Git για μια επιλεγμένη περίοδο"
-    },
-    "disableLabel": {
-        "message": "Απενεργοποίηση"
-    },
-    "enableLabel": {
-        "message": "Ενεργοποίηση"
-    },
-    "projectNameLabel": {
-        "message": "Όνομα Έργου (χρησιμοποιείται στο θέμα του email)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Εισαγάγετε το όνομα του έργου σας"
-    },
-    "githubUsernameLabel": {
-        "message": "Το όνομα χρήστη σας στο GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Το όνομα χρήστη σας στο GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Απαιτείται για την ανάκτηση των συνεισφορών σας"
-    },
-    "contributionsLabel": {
-        "message": "Ανακτήστε τις συνεισφορές σας μεταξύ:"
-    },
-    "last1DayLabel": {
-        "message": "Προηγούμενη ημέρα"
-    },
-    "startDateLabel": {
-        "message": "Από:"
-    },
-    "endDateLabel": {
-        "message": "Έως:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Εμφάνιση ετικετών PR"
-    },
-    "blockersLabel": {
-        "message": "Τι σας εμποδίζει να προχωρήσετε;"
-    },
-    "blockersPlaceholder": {
-        "message": "Εισαγάγετε τον λόγο σας"
-    },
-    "scrumReportLabel": {
-        "message": "Αναφορά Scrum"
-    },
-    "generateReportButton": {
-        "message": "Δημιουργία"
-    },
-    "copyReportButton": {
-        "message": "Αντιγραφή"
-    },
-    "insertInEmailButton": {
-        "message": "Εισαγωγή σε email"
-    },
-    "insertToEmailFailedError": {
-        "message": "Ανοίξτε μια καρτέλα email για να εισαγάγετε την αναφορά"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Όνομα οργανισμού"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Εισαγάγετε το όνομα του οργανισμού"
-    },
-    "setButton": {
-        "message": "Ορισμός"
-    },
-    "githubTokenLabel": {
-        "message": "Το GitHub token σας"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Απαιτείται για την υποβολή αιτημάτων με έλεγχο ταυτότητας"
-    },
-    "githubTokenTooltip": {
-        "message": "Γιατί συνιστάται η προσθήκη GitHub token; Το Scrum Helper λειτουργεί χωρίς GitHub token, αλλά η προσθήκη ενός προσωπικού token πρόσβασης συνιστάται για καλύτερη εμπειρία."
-    },
-    "gitlabTokenLabel": {
-        "message": "Το GitLab token σας"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Απαιτείται για πρόσβαση σε ιδιωτικά έργα"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Γιατί συνιστάται η προσθήκη GitLab token; Το Scrum Helper λειτουργεί χωρίς GitLab token για δημόσια έργα, αλλά η προσθήκη ενός προσωπικού token πρόσβασης συνιστάται για καλύτερη εμπειρία."
-    },
-    "showCommitsLabel": {
-        "message": "Εμφάνιση commits σε ανοιχτά PR / πρόχειρα PR"
-    },
-    "showCommitsTooltip": {
-        "message": "Απαιτείται GitHub token, προσθέστε το στις ρυθμίσεις."
-    },
-    "onlyIssuesLabel": {
-        "message": "Συμπερίληψη μόνο ζητημάτων στην αναφορά"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Εάν επιλεγεί, η αναφορά θα περιλαμβάνει μόνο ζητήματα που δημιουργήθηκαν ή ανατέθηκαν στον χρήστη."
-    },
-    "onlyPRsLabel": {
-        "message": "Συμπερίληψη μόνο PR στην αναφορά"
-    },
-    "onlyPRsTooltip": {
-        "message": "Εάν επιλεγεί, η αναφορά θα περιλαμβάνει μόνο PR που δημιουργήθηκαν από τον χρήστη. Τα αναθεωρημένα PR θα εξαιρεθούν."
-    },
-    "cacheTTLLabel": {
-        "message": "Εισαγάγετε TTL cache"
-    },
-    "cacheTTLUnit": {
-        "message": "(σε λεπτά)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Εισαγάγετε TTL cache σε λεπτά (Προεπιλογή: 10 λεπτά)"
-    },
-    "refreshDataButton": {
-        "message": "Ανανέωση δεδομένων (παράκαμψη cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Χρησιμοποιήστε αυτό το κουμπί για άμεση ανάκτηση νέων δεδομένων."
-    },
-    "noteTitle": {
-        "message": "Σημείωση:"
-    },
-    "viewCodeButton": {
-        "message": "Προβολή κώδικα"
-    },
-    "reportIssueButton": {
-        "message": "Αναφορά προβλήματος"
-    },
-    "repoFilterLabel": {
-        "message": "Φιλτράρισμα κατά αποθετήρια"
-    },
-    "enableFilteringLabel": {
-        "message": "Ενεργοποίηση φιλτραρίσματος"
-    },
-    "tokenRequiredWarning": {
-        "message": "Απαιτείται GitHub token για φιλτράρισμα αποθετηρίων. Παρακαλώ προσθέστε ένα στις ρυθμίσεις."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "Απαιτείται GitHub token για εμφάνιση commits σε ανοιχτά ή πρόχειρα PR. Παρακαλώ προσθέστε ένα στις ρυθμίσεις."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Αναζητήστε ένα αποθετήριο για προσθήκη..."
-    },
-    "repoPlaceholder": {
-        "message": "Δεν επιλέχθηκαν αποθετήρια (θα συμπεριληφθούν όλα)"
-    },
-    "repoCountNone": {
-        "message": "0 αποθετήρια επιλεγμένα"
-    },
-    "repoCount": {
-        "message": "$1 αποθετήρια επιλεγμένα"
-    },
-    "repoLoading": {
-        "message": "Φόρτωση αποθετηρίων..."
-    },
-    "repoLoaded": {
-        "message": "Φορτώθηκαν $1 αποθετήρια."
-    },
-    "repoNotFound": {
-        "message": "Δεν βρέθηκαν αποθετήρια"
-    },
-    "repoRefetching": {
-        "message": "Επαναφόρτωση αποθετηρίων..."
-    },
-    "repoLoadFailed": {
-        "message": "Αποτυχία φόρτωσης αποθετηρίων."
-    },
-    "repoTokenPrivate": {
-        "message": "Το token είναι άκυρο ή δεν έχει δικαιώματα για ιδιωτικά αποθετήρια."
-    },
-    "repoRefetchFailed": {
-        "message": "Αποτυχία επαναφόρτωσης αποθετηρίων."
-    },
-    "orgSetMessage": {
-        "message": "Ο οργανισμός ορίστηκε επιτυχώς."
-    },
-    "orgClearedMessage": {
-        "message": "Ο οργανισμός διαγράφηκε. Κάντε κλικ στο 'Δημιουργία' για ανάκτηση όλων των δραστηριοτήτων."
-    },
-    "orgNotFoundMessage": {
-        "message": "Ο οργανισμός δεν βρέθηκε στο GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Σφάλμα κατά την επαλήθευση του οργανισμού."
-    },
-    "refreshingButton": {
-        "message": "Ανανέωση..."
-    },
-    "cacheClearFailed": {
-        "message": "Αποτυχία εκκαθάρισης cache."
-    },
-    "madeWithLoveBy": {
-        "message": "Φτιαγμένο με ❤️ από"
-    },
-    "generatingButton": {
-        "message": "Δημιουργία..."
-    },
-    "copiedButton": {
-        "message": "Αντιγράφηκε!"
-    },
-    "orgChangedMessage": {
-        "message": "Ο οργανισμός άλλαξε. Κάντε κλικ στο κουμπί 'Δημιουργία' για ανάκτηση δραστηριοτήτων GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Το cache εκκαθαρίστηκε επιτυχώς. Κάντε κλικ στο «Δημιουργία» για ανάκτηση νέων δεδομένων."
-    },
-    "cacheExpiredMessage": {
-        "message": "Το cache έληξε. Κάντε κλικ στο «Δημιουργία» για ανάκτηση νέων δεδομένων."
-    },
-    "cacheClearedButton": {
-        "message": "Το cache εκκαθαρίστηκε!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Η επέκταση είναι απενεργοποιημένη. Ενεργοποιήστε τη από τις επιλογές για δημιουργία αναφορών Scrum."
-    },
-    "notePoint1": {
-        "message": "Τα pull requests ανακτώνται βάσει της πιο πρόσφατης δραστηριότητας αναθεώρησης από οποιονδήποτε συντελεστή, όχι μόνο τη δική σας. Παρακαλώ ελέγξτε και προσαρμόστε την παραγόμενη αναφορά SCRUM για να διασφαλίσετε ότι αντικατοπτρίζει με ακρίβεια την εργασία σας πριν την κοινοποίηση."
-    },
-    "noteSeeIssue": {
-        "message": "Δείτε αυτό το ζήτημα"
-    },
-    "platformLabel": {
-        "message": "Πλατφόρμα"
-    },
-    "usernameLabel": {
-        "message": "Το όνομα χρήστη σας"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Συμπερίληψη μόνο αναθεωρημένων PR στην αναφορά"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Εάν επιλεγεί, η αναφορά θα περιλαμβάνει μόνο PR που έχετε αναθεωρήσει εσείς."
-    },
-    "onlyMergedPRsLabel": {
-        "message": "Να συμπεριλαμβάνονται μόνο συγχωνευμένα PR στην αναφορά"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "Εάν επιλεγεί, η αναφορά θα περιλαμβάνει μόνο PR που έχουν συγχωνευθεί. Απαιτείται διακριτικό GitHub."
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "Απαιτείται διακριτικό GitHub για το φιλτράρισμα βάσει συγχωνευμένων PR. Προσθέστε ένα στις ρυθμίσεις."
-    },
-    "usernameRequiredError": {
-        "message": "Παρακαλώ εισάγετε το όνομα χρήστη σας για να δημιουργήσετε μια αναφορά."
-    },
-    "unknownPlatformError": {
-        "message": "Επιλέχθηκε άγνωστη πλατφόρμα."
-    },
-    "gitlabFetchingError": {
-        "message": "Παρουσιάστηκε σφάλμα κατά την ανάκτηση των δεδομένων GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Παρουσιάστηκε σφάλμα κατά τη δημιουργία της αναφοράς."
-    },
-    "githubUserNotFoundError": {
-        "message": "Ο χρήστης GitHub \"$1\" δεν βρέθηκε."
-    },
-    "githubUserValidationError": {
-        "message": "Σφάλμα κατά την επαλήθευση του χρήστη GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Μη έγκυρο ερώτημα αναζήτησης ή εύρος ημερομηνιών. Επαληθεύστε τη μορφή και δοκιμάστε ξανά."
-    },
-    "githubIssuesFetchError": {
-        "message": "Σφάλμα κατά την ανάκτηση των θεμάτων (issues) GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Σφάλμα κατά την ανάκτηση των δεδομένων αξιολόγησης PR από το GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Σφάλμα κατά την ανάκτηση των δεδομένων χρήστη GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Μη έγκυρο ή ληγμένο διακριτικό GitHub. Ελέγξτε το διακριτικό σας στις ρυθμίσεις του Scrum Helper και δοκιμάστε ξανά."
-    },
-    "displayModeNotice": {
-        "message": "Η επέκταση θα ανοίξει σε λειτουργία $1 στην επόμενη εκκίνηση."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Το φιλτράρισμα αποθετηρίων είναι διαθέσιμο μόνο για το GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Η φόρτωση αποθετηρίων είναι διαθέσιμη μόνο για το GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Η ανάκτηση αποθετηρίων είναι διαθέσιμη μόνο για το GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Αυτόματη φόρτωση αποθετηρίων..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Σφάλμα κατά την ανάκτηση του χρήστη GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Ο χρήστης GitLab \"$1\" δεν βρέθηκε."
-    },
-    "gitlabMembershipError": {
-        "message": "Σφάλμα κατά την ανάκτηση των έργων συμμετοχής GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Σφάλμα κατά την ανάκτηση των έργων συνεισφοράς GitLab: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Απαιτείται όνομα χρήστη."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Δημιουργία αναφοράς..."
-    },
-    "copyingReportNotification": {
-        "message": "Αντιγραφή αναφοράς..."
-    },
-    "copiedReportNotification": {
-        "message": "Η αναφορά αντιγράφηκε!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Εισαγωγή αναφοράς στο email..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Η αναφορά εισήχθη στο email!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Αναφέρετε την πρόοδο της ανάπτυξής σας ανακτώντας αυτόματα τη δραστηριότητα Git για μια επιλεγμένη περίοδο"
+  },
+  "disableLabel": {
+    "message": "Απενεργοποίηση"
+  },
+  "enableLabel": {
+    "message": "Ενεργοποίηση"
+  },
+  "projectNameLabel": {
+    "message": "Όνομα Έργου (χρησιμοποιείται στο θέμα του email)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Εισαγάγετε το όνομα του έργου σας"
+  },
+  "githubUsernameLabel": {
+    "message": "Το όνομα χρήστη σας στο GitHub"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Το όνομα χρήστη σας στο GitLab"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Απαιτείται για την ανάκτηση των συνεισφορών σας"
+  },
+  "contributionsLabel": {
+    "message": "Ανακτήστε τις συνεισφορές σας μεταξύ:"
+  },
+  "last1DayLabel": {
+    "message": "Προηγούμενη ημέρα"
+  },
+  "lastWeekLabel": {
+    "message": "Σύνοψη προηγούμενης εβδομάδας",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "Από:"
+  },
+  "endDateLabel": {
+    "message": "Έως:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Εμφάνιση ετικετών PR"
+  },
+  "blockersLabel": {
+    "message": "Τι σας εμποδίζει να προχωρήσετε;"
+  },
+  "blockersPlaceholder": {
+    "message": "Εισαγάγετε τον λόγο σας"
+  },
+  "scrumReportLabel": {
+    "message": "Αναφορά Scrum"
+  },
+  "generateReportButton": {
+    "message": "Δημιουργία"
+  },
+  "copyReportButton": {
+    "message": "Αντιγραφή"
+  },
+  "insertInEmailButton": {
+    "message": "Εισαγωγή σε email"
+  },
+  "insertToEmailFailedError": {
+    "message": "Ανοίξτε μια καρτέλα email για να εισαγάγετε την αναφορά"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Όνομα οργανισμού"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Εισαγάγετε το όνομα του οργανισμού"
+  },
+  "setButton": {
+    "message": "Ορισμός"
+  },
+  "githubTokenLabel": {
+    "message": "Το GitHub token σας"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Απαιτείται για την υποβολή αιτημάτων με έλεγχο ταυτότητας"
+  },
+  "githubTokenTooltip": {
+    "message": "Γιατί συνιστάται η προσθήκη GitHub token; Το Scrum Helper λειτουργεί χωρίς GitHub token, αλλά η προσθήκη ενός προσωπικού token πρόσβασης συνιστάται για καλύτερη εμπειρία."
+  },
+  "gitlabTokenLabel": {
+    "message": "Το GitLab token σας"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Απαιτείται για πρόσβαση σε ιδιωτικά έργα"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Γιατί συνιστάται η προσθήκη GitLab token; Το Scrum Helper λειτουργεί χωρίς GitLab token για δημόσια έργα, αλλά η προσθήκη ενός προσωπικού token πρόσβασης συνιστάται για καλύτερη εμπειρία."
+  },
+  "showCommitsLabel": {
+    "message": "Εμφάνιση commits σε ανοιχτά PR / πρόχειρα PR"
+  },
+  "showCommitsTooltip": {
+    "message": "Απαιτείται GitHub token, προσθέστε το στις ρυθμίσεις."
+  },
+  "onlyIssuesLabel": {
+    "message": "Συμπερίληψη μόνο ζητημάτων στην αναφορά"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Εάν επιλεγεί, η αναφορά θα περιλαμβάνει μόνο ζητήματα που δημιουργήθηκαν ή ανατέθηκαν στον χρήστη."
+  },
+  "onlyPRsLabel": {
+    "message": "Συμπερίληψη μόνο PR στην αναφορά"
+  },
+  "onlyPRsTooltip": {
+    "message": "Εάν επιλεγεί, η αναφορά θα περιλαμβάνει μόνο PR που δημιουργήθηκαν από τον χρήστη. Τα αναθεωρημένα PR θα εξαιρεθούν."
+  },
+  "cacheTTLLabel": {
+    "message": "Εισαγάγετε TTL cache"
+  },
+  "cacheTTLUnit": {
+    "message": "(σε λεπτά)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Εισαγάγετε TTL cache σε λεπτά (Προεπιλογή: 10 λεπτά)"
+  },
+  "refreshDataButton": {
+    "message": "Ανανέωση δεδομένων (παράκαμψη cache)"
+  },
+  "refreshDataInfo": {
+    "message": "Χρησιμοποιήστε αυτό το κουμπί για άμεση ανάκτηση νέων δεδομένων."
+  },
+  "noteTitle": {
+    "message": "Σημείωση:"
+  },
+  "viewCodeButton": {
+    "message": "Προβολή κώδικα"
+  },
+  "reportIssueButton": {
+    "message": "Αναφορά προβλήματος"
+  },
+  "repoFilterLabel": {
+    "message": "Φιλτράρισμα κατά αποθετήρια"
+  },
+  "enableFilteringLabel": {
+    "message": "Ενεργοποίηση φιλτραρίσματος"
+  },
+  "tokenRequiredWarning": {
+    "message": "Απαιτείται GitHub token για φιλτράρισμα αποθετηρίων. Παρακαλώ προσθέστε ένα στις ρυθμίσεις."
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "Απαιτείται GitHub token για εμφάνιση commits σε ανοιχτά ή πρόχειρα PR. Παρακαλώ προσθέστε ένα στις ρυθμίσεις."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Αναζητήστε ένα αποθετήριο για προσθήκη..."
+  },
+  "repoPlaceholder": {
+    "message": "Δεν επιλέχθηκαν αποθετήρια (θα συμπεριληφθούν όλα)"
+  },
+  "repoCountNone": {
+    "message": "0 αποθετήρια επιλεγμένα"
+  },
+  "repoCount": {
+    "message": "$1 αποθετήρια επιλεγμένα"
+  },
+  "repoLoading": {
+    "message": "Φόρτωση αποθετηρίων..."
+  },
+  "repoLoaded": {
+    "message": "Φορτώθηκαν $1 αποθετήρια."
+  },
+  "repoNotFound": {
+    "message": "Δεν βρέθηκαν αποθετήρια"
+  },
+  "repoRefetching": {
+    "message": "Επαναφόρτωση αποθετηρίων..."
+  },
+  "repoLoadFailed": {
+    "message": "Αποτυχία φόρτωσης αποθετηρίων."
+  },
+  "repoTokenPrivate": {
+    "message": "Το token είναι άκυρο ή δεν έχει δικαιώματα για ιδιωτικά αποθετήρια."
+  },
+  "repoRefetchFailed": {
+    "message": "Αποτυχία επαναφόρτωσης αποθετηρίων."
+  },
+  "orgSetMessage": {
+    "message": "Ο οργανισμός ορίστηκε επιτυχώς."
+  },
+  "orgClearedMessage": {
+    "message": "Ο οργανισμός διαγράφηκε. Κάντε κλικ στο 'Δημιουργία' για ανάκτηση όλων των δραστηριοτήτων."
+  },
+  "orgNotFoundMessage": {
+    "message": "Ο οργανισμός δεν βρέθηκε στο GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Σφάλμα κατά την επαλήθευση του οργανισμού."
+  },
+  "refreshingButton": {
+    "message": "Ανανέωση..."
+  },
+  "cacheClearFailed": {
+    "message": "Αποτυχία εκκαθάρισης cache."
+  },
+  "madeWithLoveBy": {
+    "message": "Φτιαγμένο με ❤️ από"
+  },
+  "generatingButton": {
+    "message": "Δημιουργία..."
+  },
+  "copiedButton": {
+    "message": "Αντιγράφηκε!"
+  },
+  "orgChangedMessage": {
+    "message": "Ο οργανισμός άλλαξε. Κάντε κλικ στο κουμπί 'Δημιουργία' για ανάκτηση δραστηριοτήτων GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Το cache εκκαθαρίστηκε επιτυχώς. Κάντε κλικ στο «Δημιουργία» για ανάκτηση νέων δεδομένων."
+  },
+  "cacheExpiredMessage": {
+    "message": "Το cache έληξε. Κάντε κλικ στο «Δημιουργία» για ανάκτηση νέων δεδομένων."
+  },
+  "cacheClearedButton": {
+    "message": "Το cache εκκαθαρίστηκε!"
+  },
+  "extensionDisabledMessage": {
+    "message": "Η επέκταση είναι απενεργοποιημένη. Ενεργοποιήστε τη από τις επιλογές για δημιουργία αναφορών Scrum."
+  },
+  "notePoint1": {
+    "message": "Τα pull requests ανακτώνται βάσει της πιο πρόσφατης δραστηριότητας αναθεώρησης από οποιονδήποτε συντελεστή, όχι μόνο τη δική σας. Παρακαλώ ελέγξτε και προσαρμόστε την παραγόμενη αναφορά SCRUM για να διασφαλίσετε ότι αντικατοπτρίζει με ακρίβεια την εργασία σας πριν την κοινοποίηση."
+  },
+  "noteSeeIssue": {
+    "message": "Δείτε αυτό το ζήτημα"
+  },
+  "platformLabel": {
+    "message": "Πλατφόρμα"
+  },
+  "usernameLabel": {
+    "message": "Το όνομα χρήστη σας"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Συμπερίληψη μόνο αναθεωρημένων PR στην αναφορά"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Εάν επιλεγεί, η αναφορά θα περιλαμβάνει μόνο PR που έχετε αναθεωρήσει εσείς."
+  },
+  "onlyMergedPRsLabel": {
+    "message": "Να συμπεριλαμβάνονται μόνο συγχωνευμένα PR στην αναφορά"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "Εάν επιλεγεί, η αναφορά θα περιλαμβάνει μόνο PR που έχουν συγχωνευθεί. Απαιτείται διακριτικό GitHub."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "Απαιτείται διακριτικό GitHub για το φιλτράρισμα βάσει συγχωνευμένων PR. Προσθέστε ένα στις ρυθμίσεις."
+  },
+  "usernameRequiredError": {
+    "message": "Παρακαλώ εισάγετε το όνομα χρήστη σας για να δημιουργήσετε μια αναφορά."
+  },
+  "unknownPlatformError": {
+    "message": "Επιλέχθηκε άγνωστη πλατφόρμα."
+  },
+  "gitlabFetchingError": {
+    "message": "Παρουσιάστηκε σφάλμα κατά την ανάκτηση των δεδομένων GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Παρουσιάστηκε σφάλμα κατά τη δημιουργία της αναφοράς."
+  },
+  "githubUserNotFoundError": {
+    "message": "Ο χρήστης GitHub \"$1\" δεν βρέθηκε."
+  },
+  "githubUserValidationError": {
+    "message": "Σφάλμα κατά την επαλήθευση του χρήστη GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Μη έγκυρο ερώτημα αναζήτησης ή εύρος ημερομηνιών. Επαληθεύστε τη μορφή και δοκιμάστε ξανά."
+  },
+  "githubIssuesFetchError": {
+    "message": "Σφάλμα κατά την ανάκτηση των θεμάτων (issues) GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Σφάλμα κατά την ανάκτηση των δεδομένων αξιολόγησης PR από το GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Σφάλμα κατά την ανάκτηση των δεδομένων χρήστη GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Μη έγκυρο ή ληγμένο διακριτικό GitHub. Ελέγξτε το διακριτικό σας στις ρυθμίσεις του Scrum Helper και δοκιμάστε ξανά."
+  },
+  "displayModeNotice": {
+    "message": "Η επέκταση θα ανοίξει σε λειτουργία $1 στην επόμενη εκκίνηση."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Το φιλτράρισμα αποθετηρίων είναι διαθέσιμο μόνο για το GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Η φόρτωση αποθετηρίων είναι διαθέσιμη μόνο για το GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Η ανάκτηση αποθετηρίων είναι διαθέσιμη μόνο για το GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Αυτόματη φόρτωση αποθετηρίων..."
+  },
+  "gitlabUserFetchError": {
+    "message": "Σφάλμα κατά την ανάκτηση του χρήστη GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Ο χρήστης GitLab \"$1\" δεν βρέθηκε."
+  },
+  "gitlabMembershipError": {
+    "message": "Σφάλμα κατά την ανάκτηση των έργων συμμετοχής GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Σφάλμα κατά την ανάκτηση των έργων συνεισφοράς GitLab: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Απαιτείται όνομα χρήστη."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Δημιουργία αναφοράς..."
+  },
+  "copyingReportNotification": {
+    "message": "Αντιγραφή αναφοράς..."
+  },
+  "copiedReportNotification": {
+    "message": "Η αναφορά αντιγράφηκε!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Εισαγωγή αναφοράς στο email..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Η αναφορά εισήχθη στο email!"
+  }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -44,7 +44,7 @@
     "description": "Radio button option for the last 1 day."
   },
   "lastWeekLabel": {
-    "message": "Previous week",
+    "message": "Previous week summary",
     "description": "Radio button option for the last 7 days."
   },
   "startDateLabel": {
@@ -412,7 +412,7 @@
   "usernameMissingError": {
     "message": "Username required.",
     "description": "Error shown when username is missing."
-   },
+  },
   "generateReportTooltip": {
     "message": "Ctrl+G",
     "description": "Tooltip shortcut for the Generate button. Dynamically replaced with Cmd+G on macOS."

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Informe sobre su progreso de desarrollo obteniendo automáticamente su actividad de Git para un período seleccionado."
-    },
-    "disableLabel": {
-        "message": "Desactivar"
-    },
-    "enableLabel": {
-        "message": "Activar"
-    },
-    "projectNameLabel": {
-        "message": "Nombre del proyecto (usado en el asunto del correo)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Ingrese el nombre de su proyecto"
-    },
-    "githubUsernameLabel": {
-        "message": "Su nombre de usuario de GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Su nombre de usuario de GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Requerido para obtener sus contribuciones"
-    },
-    "contributionsLabel": {
-        "message": "Obtener sus contribuciones de:"
-    },
-    "last1DayLabel": {
-        "message": "Día anterior"
-    },
-    "startDateLabel": {
-        "message": "Desde:"
-    },
-    "endDateLabel": {
-        "message": "Hasta:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Mostrar estado Abierto/Cerrado"
-    },
-    "blockersLabel": {
-        "message": "¿Qué le impide progresar?"
-    },
-    "blockersPlaceholder": {
-        "message": "Ingrese su motivo"
-    },
-    "scrumReportLabel": {
-        "message": "Informe de Scrum"
-    },
-    "generateReportButton": {
-        "message": "Generar"
-    },
-    "copyReportButton": {
-        "message": "Copiar"
-    },
-    "insertInEmailButton": {
-        "message": "Insertar en correo"
-    },
-    "insertToEmailFailedError": {
-        "message": "Abra una pestaña de correo electrónico para insertar el informe"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nombre de la organización"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Ingrese el nombre de la organización"
-    },
-    "setButton": {
-        "message": "Establecer"
-    },
-    "githubTokenLabel": {
-        "message": "Su token de GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Requerido para realizar solicitudes autenticadas"
-    },
-    "githubTokenTooltip": {
-        "message": "¿Por qué se recomienda agregar un token de GitHub? Scrum Helper funciona sin un token de GitHub, pero se recomienda agregar un token de acceso personal para una mejor experiencia."
-    },
-    "gitlabTokenLabel": {
-        "message": "Tu token de GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Requerido para repos privados"
-    },
-    "gitlabTokenTooltip": {
-        "message": "¿Por qué se recomienda agregar un token de GitLab? Scrum Helper funciona sin un token de GitLab para proyectos públicos, pero se recomienda agregar un token de acceso personal para una mejor experiencia."
-    },
-    "showCommitsLabel": {
-        "message": "Mostrar commits en PRs abiertos/ borradores de PRs"
-    },
-    "showCommitsTooltip": {
-        "message": "Se requiere un token de GitHub, agréguelo en la configuración."
-    },
-    "onlyIssuesLabel": {
-        "message": "Incluir solo incidencias en el informe"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Si está marcado, el informe solo incluirá las incidencias creadas o asignadas al usuario."
-    },
-    "onlyPRsLabel": {
-        "message": "Incluir solo PRs en el informe"
-    },
-    "onlyPRsTooltip": {
-        "message": "Si está marcado, el informe solo incluirá pull requests creados por el usuario; los pull requests revisados se excluirán."
-    },
-    "cacheTTLLabel": {
-        "message": "Introducir TTL de caché"
-    },
-    "cacheTTLUnit": {
-        "message": "(en minutos)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Escriba el TTL del caché en minutos (Predeterminado: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Actualizar datos (omitir caché)"
-    },
-    "refreshDataInfo": {
-        "message": "Use este botón para obtener datos nuevos inmediatamente."
-    },
-    "noteTitle": {
-        "message": "Nota:"
-    },
-    "viewCodeButton": {
-        "message": "Ver código"
-    },
-    "reportIssueButton": {
-        "message": "Reportar un problema"
-    },
-    "repoFilterLabel": {
-        "message": "Filtrar por repositorios"
-    },
-    "enableFilteringLabel": {
-        "message": "Activar filtrado"
-    },
-    "tokenRequiredWarning": {
-        "message": "Se requiere un token de GitHub para filtrar repositorios. Por favor, agregue uno en la configuración."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "Se requiere un token de GitHub para mostrar commits en PR abiertos o borradores. Agregue uno en la configuración."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Buscar un repositorio para agregar..."
-    },
-    "repoPlaceholder": {
-        "message": "No hay repositorios seleccionados (se incluirán todos)"
-    },
-    "repoCountNone": {
-        "message": "0 repositorios seleccionados"
-    },
-    "repoCount": {
-        "message": "$1 repositorios seleccionados"
-    },
-    "clearAllBtn": {
-        "message": "Limpiar todo"
-    },
-    "repoLoading": {
-        "message": "Cargando repositorios..."
-    },
-    "repoLoaded": {
-        "message": "$1 repositorios cargados."
-    },
-    "repoNotFound": {
-        "message": "No se encontraron repositorios"
-    },
-    "repoRefetching": {
-        "message": "Recargando repositorios..."
-    },
-    "repoLoadFailed": {
-        "message": "Error al cargar los repositorios."
-    },
-    "repoTokenPrivate": {
-        "message": "El token no es válido o no tiene derechos para repositorios privados."
-    },
-    "repoRefetchFailed": {
-        "message": "Error al recargar los repositorios."
-    },
-    "orgSetMessage": {
-        "message": "Organización establecida correctamente."
-    },
-    "orgClearedMessage": {
-        "message": "Organización eliminada. Haga clic en 'Generar informe' para obtener todas las actividades."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organización no encontrada en GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Error al validar la organización."
-    },
-    "refreshingButton": {
-        "message": "Actualizando..."
-    },
-    "cacheClearFailed": {
-        "message": "Error al borrar el caché."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Generando..."
-    },
-    "copiedButton": {
-        "message": "¡Copiado!"
-    },
-    "orgChangedMessage": {
-        "message": "Organización cambiada. Haga clic en 'Generar informe' para obtener las actividades de GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Caché borrado con éxito. Haga clic en 'Generar informe' para obtener datos nuevos."
-    },
-    "cacheExpiredMessage": {
-        "message": "La caché ha expirado. Haga clic en \"Generar\" para obtener datos nuevos."
-    },
-    "cacheClearedButton": {
-        "message": "¡Caché borrado!"
-    },
-    "extensionDisabledMessage": {
-        "message": "La extensión está deshabilitada. Habilítela desde las opciones para generar informes de scrum."
-    },
-    "notePoint1": {
-        "message": "Las solicitudes de extracción se obtienen en función de la actividad de revisión más reciente de cualquier colaborador, no solo la suya. Revise y ajuste el informe SCRUM generado para asegurarse de que refleje con precisión su trabajo antes de compartirlo."
-    },
-    "noteSeeIssue": {
-        "message": "Ver este issue"
-    },
-    "platformLabel": {
-        "message": "Plataforma"
-    },
-    "usernameLabel": {
-        "message": "Su nombre de usuario"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Incluir solo PRs revisados en el informe"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Si está marcado, el informe solo incluirá PRs revisados por usted."
-    },
-    "onlyMergedPRsLabel": {
-        "message": "Incluir solo PR combinados (merged) en el informe"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "Si está marcado, el informe solo incluirá PR que hayan sido combinados. Se requiere un token de GitHub."
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "Se requiere un token de GitHub para filtrar por PR combinados. Agregue uno en la configuración."
-    },
-    "usernameRequiredError": {
-        "message": "Por favor, introduzca su nombre de usuario para generar un informe."
-    },
-    "unknownPlatformError": {
-        "message": "Plataforma desconocida seleccionada."
-    },
-    "gitlabFetchingError": {
-        "message": "Se produjo un error al obtener los datos de GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Se produjo un error al generar el informe."
-    },
-    "githubUserNotFoundError": {
-        "message": "Usuario de GitHub \"$1\" no encontrado (404). Por favor, verifique el nombre de usuario e inténtelo de nuevo."
-    },
-    "githubUserValidationError": {
-        "message": "Error al validar el usuario de GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Consulta de búsqueda o rango de fechas no válido. Por favor, verifique el formato de su rango de fechas e inténtelo de nuevo."
-    },
-    "githubIssuesFetchError": {
-        "message": "Error al obtener los issues de GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Error al obtener los datos de revisión de PR de GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Error al obtener los datos del usuario de GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Token de GitHub no válido o caducado. Por favor, verifique su token en la configuración de Scrum Helper e inténtelo de nuevo."
-    },
-    "displayModeNotice": {
-        "message": "La extensión se abrirá en modo $1 en el próximo inicio."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "El filtrado de repositorios solo está disponible para GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "La carga de repositorios solo está disponible para GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "La obtención de repositorios solo está disponible para GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Cargando repositorios automáticamente.."
-    },
-    "gitlabUserFetchError": {
-        "message": "Error al obtener el usuario de GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Usuario de GitLab '$1' no encontrado"
-    },
-    "gitlabMembershipError": {
-        "message": "Error al obtener los proyectos de membresía de GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Error al obtener los proyectos a los que contribuyó en GitLab: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Nombre de usuario requerido."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Generando informe..."
-    },
-    "copyingReportNotification": {
-        "message": "Copiando informe..."
-    },
-    "copiedReportNotification": {
-        "message": "¡Informe copiado!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Insertando informe en el correo..."
-    },
-    "insertedInEmailNotification": {
-        "message": "¡Informe insertado en el correo!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Informe sobre su progreso de desarrollo obteniendo automáticamente su actividad de Git para un período seleccionado."
+  },
+  "disableLabel": {
+    "message": "Desactivar"
+  },
+  "enableLabel": {
+    "message": "Activar"
+  },
+  "projectNameLabel": {
+    "message": "Nombre del proyecto (usado en el asunto del correo)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Ingrese el nombre de su proyecto"
+  },
+  "githubUsernameLabel": {
+    "message": "Su nombre de usuario de GitHub"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Su nombre de usuario de GitLab"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Requerido para obtener sus contribuciones"
+  },
+  "contributionsLabel": {
+    "message": "Obtener sus contribuciones de:"
+  },
+  "last1DayLabel": {
+    "message": "Día anterior"
+  },
+  "lastWeekLabel": {
+    "message": "Resumen de la semana anterior",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "Desde:"
+  },
+  "endDateLabel": {
+    "message": "Hasta:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Mostrar estado Abierto/Cerrado"
+  },
+  "blockersLabel": {
+    "message": "¿Qué le impide progresar?"
+  },
+  "blockersPlaceholder": {
+    "message": "Ingrese su motivo"
+  },
+  "scrumReportLabel": {
+    "message": "Informe de Scrum"
+  },
+  "generateReportButton": {
+    "message": "Generar"
+  },
+  "copyReportButton": {
+    "message": "Copiar"
+  },
+  "insertInEmailButton": {
+    "message": "Insertar en correo"
+  },
+  "insertToEmailFailedError": {
+    "message": "Abra una pestaña de correo electrónico para insertar el informe"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Nombre de la organización"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Ingrese el nombre de la organización"
+  },
+  "setButton": {
+    "message": "Establecer"
+  },
+  "githubTokenLabel": {
+    "message": "Su token de GitHub"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Requerido para realizar solicitudes autenticadas"
+  },
+  "githubTokenTooltip": {
+    "message": "¿Por qué se recomienda agregar un token de GitHub? Scrum Helper funciona sin un token de GitHub, pero se recomienda agregar un token de acceso personal para una mejor experiencia."
+  },
+  "gitlabTokenLabel": {
+    "message": "Tu token de GitLab"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Requerido para repos privados"
+  },
+  "gitlabTokenTooltip": {
+    "message": "¿Por qué se recomienda agregar un token de GitLab? Scrum Helper funciona sin un token de GitLab para proyectos públicos, pero se recomienda agregar un token de acceso personal para una mejor experiencia."
+  },
+  "showCommitsLabel": {
+    "message": "Mostrar commits en PRs abiertos/ borradores de PRs"
+  },
+  "showCommitsTooltip": {
+    "message": "Se requiere un token de GitHub, agréguelo en la configuración."
+  },
+  "onlyIssuesLabel": {
+    "message": "Incluir solo incidencias en el informe"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Si está marcado, el informe solo incluirá las incidencias creadas o asignadas al usuario."
+  },
+  "onlyPRsLabel": {
+    "message": "Incluir solo PRs en el informe"
+  },
+  "onlyPRsTooltip": {
+    "message": "Si está marcado, el informe solo incluirá pull requests creados por el usuario; los pull requests revisados se excluirán."
+  },
+  "cacheTTLLabel": {
+    "message": "Introducir TTL de caché"
+  },
+  "cacheTTLUnit": {
+    "message": "(en minutos)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Escriba el TTL del caché en minutos (Predeterminado: 10)"
+  },
+  "refreshDataButton": {
+    "message": "Actualizar datos (omitir caché)"
+  },
+  "refreshDataInfo": {
+    "message": "Use este botón para obtener datos nuevos inmediatamente."
+  },
+  "noteTitle": {
+    "message": "Nota:"
+  },
+  "viewCodeButton": {
+    "message": "Ver código"
+  },
+  "reportIssueButton": {
+    "message": "Reportar un problema"
+  },
+  "repoFilterLabel": {
+    "message": "Filtrar por repositorios"
+  },
+  "enableFilteringLabel": {
+    "message": "Activar filtrado"
+  },
+  "tokenRequiredWarning": {
+    "message": "Se requiere un token de GitHub para filtrar repositorios. Por favor, agregue uno en la configuración."
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "Se requiere un token de GitHub para mostrar commits en PR abiertos o borradores. Agregue uno en la configuración."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Buscar un repositorio para agregar..."
+  },
+  "repoPlaceholder": {
+    "message": "No hay repositorios seleccionados (se incluirán todos)"
+  },
+  "repoCountNone": {
+    "message": "0 repositorios seleccionados"
+  },
+  "repoCount": {
+    "message": "$1 repositorios seleccionados"
+  },
+  "clearAllBtn": {
+    "message": "Limpiar todo"
+  },
+  "repoLoading": {
+    "message": "Cargando repositorios..."
+  },
+  "repoLoaded": {
+    "message": "$1 repositorios cargados."
+  },
+  "repoNotFound": {
+    "message": "No se encontraron repositorios"
+  },
+  "repoRefetching": {
+    "message": "Recargando repositorios..."
+  },
+  "repoLoadFailed": {
+    "message": "Error al cargar los repositorios."
+  },
+  "repoTokenPrivate": {
+    "message": "El token no es válido o no tiene derechos para repositorios privados."
+  },
+  "repoRefetchFailed": {
+    "message": "Error al recargar los repositorios."
+  },
+  "orgSetMessage": {
+    "message": "Organización establecida correctamente."
+  },
+  "orgClearedMessage": {
+    "message": "Organización eliminada. Haga clic en 'Generar informe' para obtener todas las actividades."
+  },
+  "orgNotFoundMessage": {
+    "message": "Organización no encontrada en GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Error al validar la organización."
+  },
+  "refreshingButton": {
+    "message": "Actualizando..."
+  },
+  "cacheClearFailed": {
+    "message": "Error al borrar el caché."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Generando..."
+  },
+  "copiedButton": {
+    "message": "¡Copiado!"
+  },
+  "orgChangedMessage": {
+    "message": "Organización cambiada. Haga clic en 'Generar informe' para obtener las actividades de GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Caché borrado con éxito. Haga clic en 'Generar informe' para obtener datos nuevos."
+  },
+  "cacheExpiredMessage": {
+    "message": "La caché ha expirado. Haga clic en \"Generar\" para obtener datos nuevos."
+  },
+  "cacheClearedButton": {
+    "message": "¡Caché borrado!"
+  },
+  "extensionDisabledMessage": {
+    "message": "La extensión está deshabilitada. Habilítela desde las opciones para generar informes de scrum."
+  },
+  "notePoint1": {
+    "message": "Las solicitudes de extracción se obtienen en función de la actividad de revisión más reciente de cualquier colaborador, no solo la suya. Revise y ajuste el informe SCRUM generado para asegurarse de que refleje con precisión su trabajo antes de compartirlo."
+  },
+  "noteSeeIssue": {
+    "message": "Ver este issue"
+  },
+  "platformLabel": {
+    "message": "Plataforma"
+  },
+  "usernameLabel": {
+    "message": "Su nombre de usuario"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Incluir solo PRs revisados en el informe"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Si está marcado, el informe solo incluirá PRs revisados por usted."
+  },
+  "onlyMergedPRsLabel": {
+    "message": "Incluir solo PR combinados (merged) en el informe"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "Si está marcado, el informe solo incluirá PR que hayan sido combinados. Se requiere un token de GitHub."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "Se requiere un token de GitHub para filtrar por PR combinados. Agregue uno en la configuración."
+  },
+  "usernameRequiredError": {
+    "message": "Por favor, introduzca su nombre de usuario para generar un informe."
+  },
+  "unknownPlatformError": {
+    "message": "Plataforma desconocida seleccionada."
+  },
+  "gitlabFetchingError": {
+    "message": "Se produjo un error al obtener los datos de GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Se produjo un error al generar el informe."
+  },
+  "githubUserNotFoundError": {
+    "message": "Usuario de GitHub \"$1\" no encontrado (404). Por favor, verifique el nombre de usuario e inténtelo de nuevo."
+  },
+  "githubUserValidationError": {
+    "message": "Error al validar el usuario de GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Consulta de búsqueda o rango de fechas no válido. Por favor, verifique el formato de su rango de fechas e inténtelo de nuevo."
+  },
+  "githubIssuesFetchError": {
+    "message": "Error al obtener los issues de GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Error al obtener los datos de revisión de PR de GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Error al obtener los datos del usuario de GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Token de GitHub no válido o caducado. Por favor, verifique su token en la configuración de Scrum Helper e inténtelo de nuevo."
+  },
+  "displayModeNotice": {
+    "message": "La extensión se abrirá en modo $1 en el próximo inicio."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "El filtrado de repositorios solo está disponible para GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "La carga de repositorios solo está disponible para GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "La obtención de repositorios solo está disponible para GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Cargando repositorios automáticamente.."
+  },
+  "gitlabUserFetchError": {
+    "message": "Error al obtener el usuario de GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Usuario de GitLab '$1' no encontrado"
+  },
+  "gitlabMembershipError": {
+    "message": "Error al obtener los proyectos de membresía de GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Error al obtener los proyectos a los que contribuyó en GitLab: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Nombre de usuario requerido."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Generando informe..."
+  },
+  "copyingReportNotification": {
+    "message": "Copiando informe..."
+  },
+  "copiedReportNotification": {
+    "message": "¡Informe copiado!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Insertando informe en el correo..."
+  },
+  "insertedInEmailNotification": {
+    "message": "¡Informe insertado en el correo!"
+  }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Rendez compte de votre progression en récupérant automatiquement votre activité Git pour une période sélectionnée."
-    },
-    "disableLabel": {
-        "message": "Désactiver"
-    },
-    "enableLabel": {
-        "message": "Activer"
-    },
-    "projectNameLabel": {
-        "message": "Nom du projet (utilisé dans l'objet de l'e-mail)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Entrez le nom de votre projet"
-    },
-    "githubUsernameLabel": {
-        "message": "Votre nom d'utilisateur GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Votre nom d'utilisateur GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Requis pour récupérer vos contributions"
-    },
-    "contributionsLabel": {
-        "message": "Récupérer vos contributions de :"
-    },
-    "last1DayLabel": {
-        "message": "Jour précédent"
-    },
-    "startDateLabel": {
-        "message": "De :"
-    },
-    "endDateLabel": {
-        "message": "À :"
-    },
-    "showOpenClosedLabel": {
-        "message": "Afficher le statut Ouvert/Fermé"
-    },
-    "blockersLabel": {
-        "message": "Qu'est-ce qui vous empêche de progresser ?"
-    },
-    "blockersPlaceholder": {
-        "message": "Entrez votre raison"
-    },
-    "scrumReportLabel": {
-        "message": "Rapport Scrum"
-    },
-    "generateReportButton": {
-        "message": "Générer"
-    },
-    "copyReportButton": {
-        "message": "Copier"
-    },
-    "insertInEmailButton": {
-        "message": "Insérer dans l’e-mail"
-    },
-    "insertToEmailFailedError": {
-        "message": "Ouvrez un onglet de messagerie pour insérer le rapport"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nom de l'organisation"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Entrez le nom de l'organisation"
-    },
-    "setButton": {
-        "message": "Définir"
-    },
-    "githubTokenLabel": {
-        "message": "Votre jeton GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Requis pour les requêtes authentifiées"
-    },
-    "githubTokenTooltip": {
-        "message": "Pourquoi est-il recommandé d'ajouter un jeton GitHub ? Scrum Helper fonctionne sans jeton GitHub, mais l'ajout d'un jeton d'accès personnel est recommandé pour une meilleure expérience."
-    },
-    "gitlabTokenLabel": {
-        "message": "Votre jeton GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Requis pour les dépôts privés"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Pourquoi est-il recommandé d'ajouter un jeton GitLab ? Scrum Helper fonctionne sans jeton GitLab pour les projets publics, mais l'ajout d'un jeton d'accès personnel est recommandé pour une meilleure expérience."
-    },
-    "showCommitsLabel": {
-        "message": "Afficher les commits sur les PRs ouverts/ brouillons de PRs"
-    },
-    "showCommitsTooltip": {
-        "message": "Jeton Github requis, ajoutez-le dans les paramètres."
-    },
-    "onlyIssuesLabel": {
-        "message": "Inclure uniquement les problèmes dans le rapport"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Si cette case est cochée, le rapport n'inclura que les problèmes créés par l'utilisateur ou qui lui sont assignés."
-    },
-    "onlyPRsLabel": {
-        "message": "Inclure uniquement les PRs dans le rapport"
-    },
-    "onlyPRsTooltip": {
-        "message": "Si coché, le rapport n'inclura que les pull requests créées par l'utilisateur ; les pull requests revues seront exclues."
-    },
-    "cacheTTLLabel": {
-        "message": "Entrez le TTL du cache"
-    },
-    "cacheTTLUnit": {
-        "message": "(en minutes)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Entrez le TTL du cache en minutes (Défaut : 10)"
-    },
-    "refreshDataButton": {
-        "message": "Actualiser les données (ignorer le cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Utilisez ce bouton pour récupérer des données fraîches immédiatement."
-    },
-    "noteTitle": {
-        "message": "Note :"
-    },
-    "viewCodeButton": {
-        "message": "Voir le code"
-    },
-    "reportIssueButton": {
-        "message": "Signaler un problème"
-    },
-    "repoFilterLabel": {
-        "message": "Filtrer par dépôts"
-    },
-    "enableFilteringLabel": {
-        "message": "Activer le filtrage"
-    },
-    "tokenRequiredWarning": {
-        "message": "Un jeton GitHub est requis pour filtrer les dépôts. Veuillez en ajouter un dans les paramètres."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "Un jeton GitHub est requis pour afficher les commits sur les PR ouvertes ou brouillons. Veuillez en ajouter un dans les paramètres."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Rechercher un dépôt à ajouter..."
-    },
-    "repoPlaceholder": {
-        "message": "Aucun dépôt sélectionné (tous seront inclus)"
-    },
-    "repoCountNone": {
-        "message": "0 dépôts sélectionnés"
-    },
-    "repoCount": {
-        "message": "$1 dépôts sélectionnés"
-    },
-    "clearAllBtn": {
-        "message": "Tout effacer"
-    },
-    "repoLoading": {
-        "message": "Chargement des dépôts..."
-    },
-    "repoLoaded": {
-        "message": "$1 dépôts chargés."
-    },
-    "repoNotFound": {
-        "message": "Aucun dépôt trouvé"
-    },
-    "repoRefetching": {
-        "message": "Rechargement des dépôts..."
-    },
-    "repoLoadFailed": {
-        "message": "Échec du chargement des dépôts."
-    },
-    "repoTokenPrivate": {
-        "message": "Le jeton est invalide ou n'a pas les droits pour les dépôts privés."
-    },
-    "repoRefetchFailed": {
-        "message": "Échec du rechargement des dépôts."
-    },
-    "orgSetMessage": {
-        "message": "Organisation définie avec succès."
-    },
-    "orgClearedMessage": {
-        "message": "Organisation effacée. Cliquez sur 'Générer le rapport' pour récupérer toutes les activités."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organisation non trouvée sur GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Erreur lors de la validation de l'organisation."
-    },
-    "refreshingButton": {
-        "message": "Actualisation..."
-    },
-    "cacheClearFailed": {
-        "message": "Échec de la suppression du cache."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Génération..."
-    },
-    "copiedButton": {
-        "message": "Copié !"
-    },
-    "orgChangedMessage": {
-        "message": "Organisation modifiée. Cliquez sur 'Générer le rapport' pour récupérer les activités GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache vidé avec succès. Cliquez sur 'Générer le rapport' pour récupérer des données fraîches."
-    },
-    "cacheExpiredMessage": {
-        "message": "Le cache a expiré. Cliquez sur \"Générer\" pour récupérer des données fraîches."
-    },
-    "cacheClearedButton": {
-        "message": "Cache vidé !"
-    },
-    "extensionDisabledMessage": {
-        "message": "L'extension est désactivée. Activez-la depuis les paramètres pour générer des rapports Scrum."
-    },
-    "notePoint1": {
-        "message": "Les pull requests sont récupérées en fonction de l'activité de revue la plus récente de n'importe quel contributeur, pas seulement la vôtre. Veuillez examiner et ajuster le rapport SCRUM généré pour vous assurer qu'il reflète fidèlement votre travail avant de le partager."
-    },
-    "noteSeeIssue": {
-        "message": "Voir ce ticket"
-    },
-    "platformLabel": {
-        "message": "Plateforme"
-    },
-    "usernameLabel": {
-        "message": "Votre nom d'utilisateur"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Inclure uniquement les PRs revues dans le rapport"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Si coché, le rapport n'inclura que les PRs que vous avez revues."
-    },
-    "onlyMergedPRsLabel": {
-        "message": "Inclure uniquement les PR fusionnées dans le rapport"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "Si coché, le rapport n'inclura que les PR fusionnées. Un jeton GitHub est requis."
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "Un jeton GitHub est requis pour filtrer par PR fusionnées. Veuillez en ajouter un dans les paramètres."
-    },
-    "usernameRequiredError": {
-        "message": "Veuillez saisir votre nom d'utilisateur pour générer un rapport."
-    },
-    "unknownPlatformError": {
-        "message": "Plateforme inconnue sélectionnée."
-    },
-    "gitlabFetchingError": {
-        "message": "Une erreur s'est produite lors de la récupération des données GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Une erreur s'est produite lors de la génération du rapport."
-    },
-    "githubUserNotFoundError": {
-        "message": "Utilisateur GitHub \"$1\" introuvable (404). Veuillez vérifier le nom d'utilisateur et réessayer."
-    },
-    "githubUserValidationError": {
-        "message": "Erreur lors de la validation de l'utilisateur GitHub : $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Requête de recherche ou plage de dates invalide. Veuillez vérifier le format de votre plage de dates et réessayer."
-    },
-    "githubIssuesFetchError": {
-        "message": "Erreur lors de la récupération des issues GitHub : $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Erreur lors de la récupération des données de révision de PR GitHub : $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Erreur lors de la récupération des données utilisateur GitHub : $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Jeton GitHub invalide ou expiré. Veuillez vérifier votre jeton dans les paramètres de Scrum Helper et réessayer."
-    },
-    "displayModeNotice": {
-        "message": "L'extension s'ouvrira en mode $1 au prochain lancement."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Le filtrage des dépôts est uniquement disponible pour GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Le chargement des dépôts est uniquement disponible pour GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "La récupération des dépôts est uniquement disponible pour GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Chargement automatique des dépôts.."
-    },
-    "gitlabUserFetchError": {
-        "message": "Erreur lors de la récupération de l'utilisateur GitLab : $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Utilisateur GitLab '$1' introuvable"
-    },
-    "gitlabMembershipError": {
-        "message": "Erreur lors de la récupération des projets d'adhésion GitLab : $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Erreur lors de la récupération des projets auxquels l'utilisateur a contribué sur GitLab : $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Nom d'utilisateur requis."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Génération du rapport..."
-    },
-    "copyingReportNotification": {
-        "message": "Copie du rapport..."
-    },
-    "copiedReportNotification": {
-        "message": "Rapport copié !"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Insertion du rapport dans l'e-mail..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Rapport inséré dans l'e-mail !"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Rendez compte de votre progression en récupérant automatiquement votre activité Git pour une période sélectionnée."
+  },
+  "disableLabel": {
+    "message": "Désactiver"
+  },
+  "enableLabel": {
+    "message": "Activer"
+  },
+  "projectNameLabel": {
+    "message": "Nom du projet (utilisé dans l'objet de l'e-mail)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Entrez le nom de votre projet"
+  },
+  "githubUsernameLabel": {
+    "message": "Votre nom d'utilisateur GitHub"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Votre nom d'utilisateur GitLab"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Requis pour récupérer vos contributions"
+  },
+  "contributionsLabel": {
+    "message": "Récupérer vos contributions de :"
+  },
+  "last1DayLabel": {
+    "message": "Jour précédent"
+  },
+  "lastWeekLabel": {
+    "message": "Résumé de la semaine précédente",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "De :"
+  },
+  "endDateLabel": {
+    "message": "À :"
+  },
+  "showOpenClosedLabel": {
+    "message": "Afficher le statut Ouvert/Fermé"
+  },
+  "blockersLabel": {
+    "message": "Qu'est-ce qui vous empêche de progresser ?"
+  },
+  "blockersPlaceholder": {
+    "message": "Entrez votre raison"
+  },
+  "scrumReportLabel": {
+    "message": "Rapport Scrum"
+  },
+  "generateReportButton": {
+    "message": "Générer"
+  },
+  "copyReportButton": {
+    "message": "Copier"
+  },
+  "insertInEmailButton": {
+    "message": "Insérer dans l’e-mail"
+  },
+  "insertToEmailFailedError": {
+    "message": "Ouvrez un onglet de messagerie pour insérer le rapport"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Nom de l'organisation"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Entrez le nom de l'organisation"
+  },
+  "setButton": {
+    "message": "Définir"
+  },
+  "githubTokenLabel": {
+    "message": "Votre jeton GitHub"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Requis pour les requêtes authentifiées"
+  },
+  "githubTokenTooltip": {
+    "message": "Pourquoi est-il recommandé d'ajouter un jeton GitHub ? Scrum Helper fonctionne sans jeton GitHub, mais l'ajout d'un jeton d'accès personnel est recommandé pour une meilleure expérience."
+  },
+  "gitlabTokenLabel": {
+    "message": "Votre jeton GitLab"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Requis pour les dépôts privés"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Pourquoi est-il recommandé d'ajouter un jeton GitLab ? Scrum Helper fonctionne sans jeton GitLab pour les projets publics, mais l'ajout d'un jeton d'accès personnel est recommandé pour une meilleure expérience."
+  },
+  "showCommitsLabel": {
+    "message": "Afficher les commits sur les PRs ouverts/ brouillons de PRs"
+  },
+  "showCommitsTooltip": {
+    "message": "Jeton Github requis, ajoutez-le dans les paramètres."
+  },
+  "onlyIssuesLabel": {
+    "message": "Inclure uniquement les problèmes dans le rapport"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Si cette case est cochée, le rapport n'inclura que les problèmes créés par l'utilisateur ou qui lui sont assignés."
+  },
+  "onlyPRsLabel": {
+    "message": "Inclure uniquement les PRs dans le rapport"
+  },
+  "onlyPRsTooltip": {
+    "message": "Si coché, le rapport n'inclura que les pull requests créées par l'utilisateur ; les pull requests revues seront exclues."
+  },
+  "cacheTTLLabel": {
+    "message": "Entrez le TTL du cache"
+  },
+  "cacheTTLUnit": {
+    "message": "(en minutes)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Entrez le TTL du cache en minutes (Défaut : 10)"
+  },
+  "refreshDataButton": {
+    "message": "Actualiser les données (ignorer le cache)"
+  },
+  "refreshDataInfo": {
+    "message": "Utilisez ce bouton pour récupérer des données fraîches immédiatement."
+  },
+  "noteTitle": {
+    "message": "Note :"
+  },
+  "viewCodeButton": {
+    "message": "Voir le code"
+  },
+  "reportIssueButton": {
+    "message": "Signaler un problème"
+  },
+  "repoFilterLabel": {
+    "message": "Filtrer par dépôts"
+  },
+  "enableFilteringLabel": {
+    "message": "Activer le filtrage"
+  },
+  "tokenRequiredWarning": {
+    "message": "Un jeton GitHub est requis pour filtrer les dépôts. Veuillez en ajouter un dans les paramètres."
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "Un jeton GitHub est requis pour afficher les commits sur les PR ouvertes ou brouillons. Veuillez en ajouter un dans les paramètres."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Rechercher un dépôt à ajouter..."
+  },
+  "repoPlaceholder": {
+    "message": "Aucun dépôt sélectionné (tous seront inclus)"
+  },
+  "repoCountNone": {
+    "message": "0 dépôts sélectionnés"
+  },
+  "repoCount": {
+    "message": "$1 dépôts sélectionnés"
+  },
+  "clearAllBtn": {
+    "message": "Tout effacer"
+  },
+  "repoLoading": {
+    "message": "Chargement des dépôts..."
+  },
+  "repoLoaded": {
+    "message": "$1 dépôts chargés."
+  },
+  "repoNotFound": {
+    "message": "Aucun dépôt trouvé"
+  },
+  "repoRefetching": {
+    "message": "Rechargement des dépôts..."
+  },
+  "repoLoadFailed": {
+    "message": "Échec du chargement des dépôts."
+  },
+  "repoTokenPrivate": {
+    "message": "Le jeton est invalide ou n'a pas les droits pour les dépôts privés."
+  },
+  "repoRefetchFailed": {
+    "message": "Échec du rechargement des dépôts."
+  },
+  "orgSetMessage": {
+    "message": "Organisation définie avec succès."
+  },
+  "orgClearedMessage": {
+    "message": "Organisation effacée. Cliquez sur 'Générer le rapport' pour récupérer toutes les activités."
+  },
+  "orgNotFoundMessage": {
+    "message": "Organisation non trouvée sur GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Erreur lors de la validation de l'organisation."
+  },
+  "refreshingButton": {
+    "message": "Actualisation..."
+  },
+  "cacheClearFailed": {
+    "message": "Échec de la suppression du cache."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Génération..."
+  },
+  "copiedButton": {
+    "message": "Copié !"
+  },
+  "orgChangedMessage": {
+    "message": "Organisation modifiée. Cliquez sur 'Générer le rapport' pour récupérer les activités GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Cache vidé avec succès. Cliquez sur 'Générer le rapport' pour récupérer des données fraîches."
+  },
+  "cacheExpiredMessage": {
+    "message": "Le cache a expiré. Cliquez sur \"Générer\" pour récupérer des données fraîches."
+  },
+  "cacheClearedButton": {
+    "message": "Cache vidé !"
+  },
+  "extensionDisabledMessage": {
+    "message": "L'extension est désactivée. Activez-la depuis les paramètres pour générer des rapports Scrum."
+  },
+  "notePoint1": {
+    "message": "Les pull requests sont récupérées en fonction de l'activité de revue la plus récente de n'importe quel contributeur, pas seulement la vôtre. Veuillez examiner et ajuster le rapport SCRUM généré pour vous assurer qu'il reflète fidèlement votre travail avant de le partager."
+  },
+  "noteSeeIssue": {
+    "message": "Voir ce ticket"
+  },
+  "platformLabel": {
+    "message": "Plateforme"
+  },
+  "usernameLabel": {
+    "message": "Votre nom d'utilisateur"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Inclure uniquement les PRs revues dans le rapport"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Si coché, le rapport n'inclura que les PRs que vous avez revues."
+  },
+  "onlyMergedPRsLabel": {
+    "message": "Inclure uniquement les PR fusionnées dans le rapport"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "Si coché, le rapport n'inclura que les PR fusionnées. Un jeton GitHub est requis."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "Un jeton GitHub est requis pour filtrer par PR fusionnées. Veuillez en ajouter un dans les paramètres."
+  },
+  "usernameRequiredError": {
+    "message": "Veuillez saisir votre nom d'utilisateur pour générer un rapport."
+  },
+  "unknownPlatformError": {
+    "message": "Plateforme inconnue sélectionnée."
+  },
+  "gitlabFetchingError": {
+    "message": "Une erreur s'est produite lors de la récupération des données GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Une erreur s'est produite lors de la génération du rapport."
+  },
+  "githubUserNotFoundError": {
+    "message": "Utilisateur GitHub \"$1\" introuvable (404). Veuillez vérifier le nom d'utilisateur et réessayer."
+  },
+  "githubUserValidationError": {
+    "message": "Erreur lors de la validation de l'utilisateur GitHub : $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Requête de recherche ou plage de dates invalide. Veuillez vérifier le format de votre plage de dates et réessayer."
+  },
+  "githubIssuesFetchError": {
+    "message": "Erreur lors de la récupération des issues GitHub : $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Erreur lors de la récupération des données de révision de PR GitHub : $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Erreur lors de la récupération des données utilisateur GitHub : $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Jeton GitHub invalide ou expiré. Veuillez vérifier votre jeton dans les paramètres de Scrum Helper et réessayer."
+  },
+  "displayModeNotice": {
+    "message": "L'extension s'ouvrira en mode $1 au prochain lancement."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Le filtrage des dépôts est uniquement disponible pour GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Le chargement des dépôts est uniquement disponible pour GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "La récupération des dépôts est uniquement disponible pour GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Chargement automatique des dépôts.."
+  },
+  "gitlabUserFetchError": {
+    "message": "Erreur lors de la récupération de l'utilisateur GitLab : $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Utilisateur GitLab '$1' introuvable"
+  },
+  "gitlabMembershipError": {
+    "message": "Erreur lors de la récupération des projets d'adhésion GitLab : $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Erreur lors de la récupération des projets auxquels l'utilisateur a contribué sur GitLab : $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Nom d'utilisateur requis."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Génération du rapport..."
+  },
+  "copyingReportNotification": {
+    "message": "Copie du rapport..."
+  },
+  "copiedReportNotification": {
+    "message": "Rapport copié !"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Insertion du rapport dans l'e-mail..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Rapport inséré dans l'e-mail !"
+  }
 }

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "דווח על התקדמות הפיתוח שלך על ידי שליפה אוטומטית של פעילות ה-Git שלך לתקופה נבחרת."
-    },
-    "disableLabel": {
-        "message": "השבת"
-    },
-    "enableLabel": {
-        "message": "הפעל"
-    },
-    "projectNameLabel": {
-        "message": "שם פרויקט (משמש בנושא האימייל)"
-    },
-    "projectNamePlaceholder": {
-        "message": "הזן את שם הפרויקט שלך"
-    },
-    "githubUsernameLabel": {
-        "message": "שם המשתמש שלך ב-GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "שם המשתמש שלך ב-GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "נדרש כדי להביא את התרומות שלך"
-    },
-    "contributionsLabel": {
-        "message": "הבא את התרומות שלך עבור:"
-    },
-    "last1DayLabel": {
-        "message": "היום הקודם"
-    },
-    "startDateLabel": {
-        "message": "מ:"
-    },
-    "endDateLabel": {
-        "message": "עד:"
-    },
-    "showOpenClosedLabel": {
-        "message": "הצג סטטוס פתוח/סגור"
-    },
-    "blockersLabel": {
-        "message": "מה מונע ממך להתקדם?"
-    },
-    "blockersPlaceholder": {
-        "message": "הזן את הסיבה שלך"
-    },
-    "scrumReportLabel": {
-        "message": "דוח סקראם"
-    },
-    "generateReportButton": {
-        "message": "צור דוח"
-    },
-    "copyReportButton": {
-        "message": "העתק דוח"
-    },
-    "insertInEmailButton": {
-        "message": "הוסף לאימייל"
-    },
-    "insertToEmailFailedError": {
-        "message": "פתח כרטיסיית אימייל כדי להכניס את הדוח"
-    },
-    "settingsOrgNameLabel": {
-        "message": "שם הארגון"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "הזן את שם הארגון"
-    },
-    "setButton": {
-        "message": "הגדר"
-    },
-    "githubTokenLabel": {
-        "message": "אסימון ה-GitHub שלך"
-    },
-    "githubTokenPlaceholder": {
-        "message": "נדרש לבקשות מאומתות"
-    },
-    "githubTokenTooltip": {
-        "message": "למה מומלץ להוסיף אסימון GitHub? Scrum Helper עובד ללא אסימון GitHub, אך הוספת אסימון גישה אישי מומלצת לחוויה טובה יותר."
-    },
-    "gitlabTokenLabel": {
-        "message": "אסימון ה-GitLab שלך"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "נדרש למאגרים פרטיים"
-    },
-    "gitlabTokenTooltip": {
-        "message": "למה מומלץ להוסיף אסימון GitLab? Scrum Helper עובד ללא אסימון GitLab לפרויקטים ציבוריים, אך הוספת אסימון גישה אישי מומלצת לחוויה טובה יותר."
-    },
-    "showCommitsLabel": {
-        "message": "הצג קומיטים ב-PR פתוחים/טיוטות PR"
-    },
-    "showCommitsTooltip": {
-        "message": "נדרש אסימון GitHub, הוסף אותו בהגדרות."
-    },
-    "onlyIssuesLabel": {
-        "message": "הכלל רק בעיות בדוח"
-    },
-    "onlyIssuesTooltip": {
-        "message": "אם מסומן, הדוח יכיל רק בעיות שנוצרו או הוקצו למשתמש."
-    },
-    "onlyPRsLabel": {
-        "message": "הכלל רק PR בדוח"
-    },
-    "onlyPRsTooltip": {
-        "message": "אם מסומן, הדוח יכיל רק pull requests שנוצרו על ידי המשתמש; PR שנסקרו יוחרגו."
-    },
-    "cacheTTLLabel": {
-        "message": "הזן TTL למטמון"
-    },
-    "cacheTTLUnit": {
-        "message": "(בדקות)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "כתוב את ה-TTL של המטמון בדקות (ברירת מחדל: 10)"
-    },
-    "refreshDataButton": {
-        "message": "רענן נתונים (עקוף מטמון)"
-    },
-    "refreshDataInfo": {
-        "message": "השתמש בכפתור זה כדי להביא נתונים טריים באופן מיידי."
-    },
-    "noteTitle": {
-        "message": "הערה:"
-    },
-    "viewCodeButton": {
-        "message": "הצג קוד"
-    },
-    "reportIssueButton": {
-        "message": "דווח על בעיה"
-    },
-    "repoFilterLabel": {
-        "message": "סנן לפי מאגרים"
-    },
-    "enableFilteringLabel": {
-        "message": "הפעל סינון"
-    },
-    "tokenRequiredWarning": {
-        "message": "נדרש אסימון GitHub לסינון מאגרים. אנא הוסף אחד בהגדרות."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "נדרש אסימון GitHub כדי להציג קומיטים ב-PR פתוחים או טיוטות. אנא הוסף אחד בהגדרות."
-    },
-    "repoSearchPlaceholder": {
-        "message": "חפש מאגר להוספה..."
-    },
-    "repoPlaceholder": {
-        "message": "לא נבחרו מאגרים (כולם ייכללו)"
-    },
-    "repoCountNone": {
-        "message": "נבחרו 0 מאגרים"
-    },
-    "repoCount": {
-        "message": "נבחרו $1 מאגרים"
-    },
-    "clearAllBtn": {
-        "message": "נקה הכל"
-    },
-    "repoLoading": {
-        "message": "טוען מאגרים..."
-    },
-    "repoLoaded": {
-        "message": "נטענו $1 מאגרים."
-    },
-    "repoNotFound": {
-        "message": "לא נמצאו מאגרים"
-    },
-    "repoRefetching": {
-        "message": "מביא מחדש מאגרים..."
-    },
-    "repoLoadFailed": {
-        "message": "נכשל בטעינת מאגרים."
-    },
-    "repoTokenPrivate": {
-        "message": "האסימון אינו חוקי או שאין לו הרשאות למאגרים פרטיים."
-    },
-    "repoRefetchFailed": {
-        "message": "נכשל בהבאה מחדש של מאגרים."
-    },
-    "orgSetMessage": {
-        "message": "הארגון הוגדר בהצלחה."
-    },
-    "orgClearedMessage": {
-        "message": "הארגון נוקה. לחץ על 'צור דוח' כדי להביא את כל הפעילויות."
-    },
-    "orgNotFoundMessage": {
-        "message": "הארגון לא נמצא ב-GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "שגיאה באימות הארגון."
-    },
-    "refreshingButton": {
-        "message": "מרענן..."
-    },
-    "cacheClearFailed": {
-        "message": "ניקוי המטמון נכשל."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "יוצר..."
-    },
-    "copiedButton": {
-        "message": "הועתק!"
-    },
-    "orgChangedMessage": {
-        "message": "הארגון השתנה. לחץ על 'צור דוח' כדי להביא פעילויות GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "המטמון נוקה בהצלחה. לחץ על 'צור דוח' כדי להביא נתונים טריים."
-    },
-    "cacheExpiredMessage": {
-        "message": "המטמון פג תוקף. לחץ על \"צור\" כדי להביא נתונים חדשים."
-    },
-    "cacheClearedButton": {
-        "message": "המטמון נוקה!"
-    },
-    "extensionDisabledMessage": {
-        "message": "ההרחבה מושבתת. הפעל אותה מההגדרות כדי ליצור דוחות סקראם."
-    },
-    "notePoint1": {
-        "message": "בקשות משיכה (Pull requests) מאוחזרות על סמך פעילות הסקירה האחרונה של כל תורם, לא רק שלך. אנא בדוק והתאם את דוח ה-SCRUM שנוצר כדי לוודא שהוא משקף במדויק את עבודתך לפני השיתוף."
-    },
-    "noteSeeIssue": {
-        "message": "ראה בעיה זו"
-    },
-    "platformLabel": {
-        "message": "פלטפורמה"
-    },
-    "usernameLabel": {
-        "message": "שם המשתמש שלך"
-    },
-    "onlyRevPRsLabel": {
-        "message": "כלול בדוח רק PR שנבדקו על ידך"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "אם מסומן, הדוח יכלול רק PR שנבדקו על ידך."
-    },
-    "onlyMergedPRsLabel": {
-        "message": "כלול רק PRs ממוזגים בדוח"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "אם מסומן, הדוח יכלול רק PRs שמוזגו. נדרש אסימון GitHub."
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "נדרש אסימון GitHub כדי לסנן לפי PRs ממוזגים. אנא הוסף אחד בהגדרות."
-    },
-    "usernameRequiredError": {
-        "message": "אנא הזן את שם המשתמש שלך כדי ליצור דוח."
-    },
-    "unknownPlatformError": {
-        "message": "נבחרה פלטפורמה לא מוכרת."
-    },
-    "gitlabFetchingError": {
-        "message": "אירעה שגיאה בעת אחזור נתוני GitLab."
-    },
-    "reportGenerationError": {
-        "message": "אירעה שגיאה בעת יצירת הדוח."
-    },
-    "githubUserNotFoundError": {
-        "message": "משתמש GitHub \"$1\" לא נמצא (404). אנא בדוק את שם המשתמש ונסה שוב."
-    },
-    "githubUserValidationError": {
-        "message": "שגיאה באימות משתמש GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "שאילתת חיפוש או טווח תאריכים לא תקינים. אנא בדוק את פורמט טווח התאריכים ונסה שוב."
-    },
-    "githubIssuesFetchError": {
-        "message": "שגיאה באחזור Issues מ-GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "שגיאה באחזור נתוני סקירת PR מ-GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "שגיאה באחזור נתוני משתמש GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "טוקן GitHub לא תקין או שפג תוקפו. אנא בדוק את הטוקן שלך בהגדרות Scrum Helper ונסה שוב."
-    },
-    "displayModeNotice": {
-        "message": "ההרחבה תיפתח במצב $1 בהפעלה הבאה."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "סינון מאגרים זמין רק עבור GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "טעינת מאגרים זמינה רק עבור GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "אחזור מאגרים זמין רק עבור GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "טוען מאגרים באופן אוטומטי.."
-    },
-    "gitlabUserFetchError": {
-        "message": "שגיאה באחזור משתמש GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "משתמש GitLab '$1' לא נמצא"
-    },
-    "gitlabMembershipError": {
-        "message": "שגיאה באחזור פרויקטי חברות ב-GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "שגיאה באחזור פרויקטים שאליהם המשתמש תרם ב-GitLab: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "שם משתמש נדרש."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "מייצר דוח..."
-    },
-    "copyingReportNotification": {
-        "message": "מעתיק דוח..."
-    },
-    "copiedReportNotification": {
-        "message": "הדוח הועתק!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "מוסיף דוח לאימייל..."
-    },
-    "insertedInEmailNotification": {
-        "message": "הדוח הוכנס לאימייל!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "דווח על התקדמות הפיתוח שלך על ידי שליפה אוטומטית של פעילות ה-Git שלך לתקופה נבחרת."
+  },
+  "disableLabel": {
+    "message": "השבת"
+  },
+  "enableLabel": {
+    "message": "הפעל"
+  },
+  "projectNameLabel": {
+    "message": "שם פרויקט (משמש בנושא האימייל)"
+  },
+  "projectNamePlaceholder": {
+    "message": "הזן את שם הפרויקט שלך"
+  },
+  "githubUsernameLabel": {
+    "message": "שם המשתמש שלך ב-GitHub"
+  },
+  "gitlabUsernameLabel": {
+    "message": "שם המשתמש שלך ב-GitLab"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "נדרש כדי להביא את התרומות שלך"
+  },
+  "contributionsLabel": {
+    "message": "הבא את התרומות שלך עבור:"
+  },
+  "last1DayLabel": {
+    "message": "היום הקודם"
+  },
+  "lastWeekLabel": {
+    "message": "סיכום השבוע שעבר",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "מ:"
+  },
+  "endDateLabel": {
+    "message": "עד:"
+  },
+  "showOpenClosedLabel": {
+    "message": "הצג סטטוס פתוח/סגור"
+  },
+  "blockersLabel": {
+    "message": "מה מונע ממך להתקדם?"
+  },
+  "blockersPlaceholder": {
+    "message": "הזן את הסיבה שלך"
+  },
+  "scrumReportLabel": {
+    "message": "דוח סקראם"
+  },
+  "generateReportButton": {
+    "message": "צור דוח"
+  },
+  "copyReportButton": {
+    "message": "העתק דוח"
+  },
+  "insertInEmailButton": {
+    "message": "הוסף לאימייל"
+  },
+  "insertToEmailFailedError": {
+    "message": "פתח כרטיסיית אימייל כדי להכניס את הדוח"
+  },
+  "settingsOrgNameLabel": {
+    "message": "שם הארגון"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "הזן את שם הארגון"
+  },
+  "setButton": {
+    "message": "הגדר"
+  },
+  "githubTokenLabel": {
+    "message": "אסימון ה-GitHub שלך"
+  },
+  "githubTokenPlaceholder": {
+    "message": "נדרש לבקשות מאומתות"
+  },
+  "githubTokenTooltip": {
+    "message": "למה מומלץ להוסיף אסימון GitHub? Scrum Helper עובד ללא אסימון GitHub, אך הוספת אסימון גישה אישי מומלצת לחוויה טובה יותר."
+  },
+  "gitlabTokenLabel": {
+    "message": "אסימון ה-GitLab שלך"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "נדרש למאגרים פרטיים"
+  },
+  "gitlabTokenTooltip": {
+    "message": "למה מומלץ להוסיף אסימון GitLab? Scrum Helper עובד ללא אסימון GitLab לפרויקטים ציבוריים, אך הוספת אסימון גישה אישי מומלצת לחוויה טובה יותר."
+  },
+  "showCommitsLabel": {
+    "message": "הצג קומיטים ב-PR פתוחים/טיוטות PR"
+  },
+  "showCommitsTooltip": {
+    "message": "נדרש אסימון GitHub, הוסף אותו בהגדרות."
+  },
+  "onlyIssuesLabel": {
+    "message": "הכלל רק בעיות בדוח"
+  },
+  "onlyIssuesTooltip": {
+    "message": "אם מסומן, הדוח יכיל רק בעיות שנוצרו או הוקצו למשתמש."
+  },
+  "onlyPRsLabel": {
+    "message": "הכלל רק PR בדוח"
+  },
+  "onlyPRsTooltip": {
+    "message": "אם מסומן, הדוח יכיל רק pull requests שנוצרו על ידי המשתמש; PR שנסקרו יוחרגו."
+  },
+  "cacheTTLLabel": {
+    "message": "הזן TTL למטמון"
+  },
+  "cacheTTLUnit": {
+    "message": "(בדקות)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "כתוב את ה-TTL של המטמון בדקות (ברירת מחדל: 10)"
+  },
+  "refreshDataButton": {
+    "message": "רענן נתונים (עקוף מטמון)"
+  },
+  "refreshDataInfo": {
+    "message": "השתמש בכפתור זה כדי להביא נתונים טריים באופן מיידי."
+  },
+  "noteTitle": {
+    "message": "הערה:"
+  },
+  "viewCodeButton": {
+    "message": "הצג קוד"
+  },
+  "reportIssueButton": {
+    "message": "דווח על בעיה"
+  },
+  "repoFilterLabel": {
+    "message": "סנן לפי מאגרים"
+  },
+  "enableFilteringLabel": {
+    "message": "הפעל סינון"
+  },
+  "tokenRequiredWarning": {
+    "message": "נדרש אסימון GitHub לסינון מאגרים. אנא הוסף אחד בהגדרות."
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "נדרש אסימון GitHub כדי להציג קומיטים ב-PR פתוחים או טיוטות. אנא הוסף אחד בהגדרות."
+  },
+  "repoSearchPlaceholder": {
+    "message": "חפש מאגר להוספה..."
+  },
+  "repoPlaceholder": {
+    "message": "לא נבחרו מאגרים (כולם ייכללו)"
+  },
+  "repoCountNone": {
+    "message": "נבחרו 0 מאגרים"
+  },
+  "repoCount": {
+    "message": "נבחרו $1 מאגרים"
+  },
+  "clearAllBtn": {
+    "message": "נקה הכל"
+  },
+  "repoLoading": {
+    "message": "טוען מאגרים..."
+  },
+  "repoLoaded": {
+    "message": "נטענו $1 מאגרים."
+  },
+  "repoNotFound": {
+    "message": "לא נמצאו מאגרים"
+  },
+  "repoRefetching": {
+    "message": "מביא מחדש מאגרים..."
+  },
+  "repoLoadFailed": {
+    "message": "נכשל בטעינת מאגרים."
+  },
+  "repoTokenPrivate": {
+    "message": "האסימון אינו חוקי או שאין לו הרשאות למאגרים פרטיים."
+  },
+  "repoRefetchFailed": {
+    "message": "נכשל בהבאה מחדש של מאגרים."
+  },
+  "orgSetMessage": {
+    "message": "הארגון הוגדר בהצלחה."
+  },
+  "orgClearedMessage": {
+    "message": "הארגון נוקה. לחץ על 'צור דוח' כדי להביא את כל הפעילויות."
+  },
+  "orgNotFoundMessage": {
+    "message": "הארגון לא נמצא ב-GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "שגיאה באימות הארגון."
+  },
+  "refreshingButton": {
+    "message": "מרענן..."
+  },
+  "cacheClearFailed": {
+    "message": "ניקוי המטמון נכשל."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "יוצר..."
+  },
+  "copiedButton": {
+    "message": "הועתק!"
+  },
+  "orgChangedMessage": {
+    "message": "הארגון השתנה. לחץ על 'צור דוח' כדי להביא פעילויות GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "המטמון נוקה בהצלחה. לחץ על 'צור דוח' כדי להביא נתונים טריים."
+  },
+  "cacheExpiredMessage": {
+    "message": "המטמון פג תוקף. לחץ על \"צור\" כדי להביא נתונים חדשים."
+  },
+  "cacheClearedButton": {
+    "message": "המטמון נוקה!"
+  },
+  "extensionDisabledMessage": {
+    "message": "ההרחבה מושבתת. הפעל אותה מההגדרות כדי ליצור דוחות סקראם."
+  },
+  "notePoint1": {
+    "message": "בקשות משיכה (Pull requests) מאוחזרות על סמך פעילות הסקירה האחרונה של כל תורם, לא רק שלך. אנא בדוק והתאם את דוח ה-SCRUM שנוצר כדי לוודא שהוא משקף במדויק את עבודתך לפני השיתוף."
+  },
+  "noteSeeIssue": {
+    "message": "ראה בעיה זו"
+  },
+  "platformLabel": {
+    "message": "פלטפורמה"
+  },
+  "usernameLabel": {
+    "message": "שם המשתמש שלך"
+  },
+  "onlyRevPRsLabel": {
+    "message": "כלול בדוח רק PR שנבדקו על ידך"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "אם מסומן, הדוח יכלול רק PR שנבדקו על ידך."
+  },
+  "onlyMergedPRsLabel": {
+    "message": "כלול רק PRs ממוזגים בדוח"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "אם מסומן, הדוח יכלול רק PRs שמוזגו. נדרש אסימון GitHub."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "נדרש אסימון GitHub כדי לסנן לפי PRs ממוזגים. אנא הוסף אחד בהגדרות."
+  },
+  "usernameRequiredError": {
+    "message": "אנא הזן את שם המשתמש שלך כדי ליצור דוח."
+  },
+  "unknownPlatformError": {
+    "message": "נבחרה פלטפורמה לא מוכרת."
+  },
+  "gitlabFetchingError": {
+    "message": "אירעה שגיאה בעת אחזור נתוני GitLab."
+  },
+  "reportGenerationError": {
+    "message": "אירעה שגיאה בעת יצירת הדוח."
+  },
+  "githubUserNotFoundError": {
+    "message": "משתמש GitHub \"$1\" לא נמצא (404). אנא בדוק את שם המשתמש ונסה שוב."
+  },
+  "githubUserValidationError": {
+    "message": "שגיאה באימות משתמש GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "שאילתת חיפוש או טווח תאריכים לא תקינים. אנא בדוק את פורמט טווח התאריכים ונסה שוב."
+  },
+  "githubIssuesFetchError": {
+    "message": "שגיאה באחזור Issues מ-GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "שגיאה באחזור נתוני סקירת PR מ-GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "שגיאה באחזור נתוני משתמש GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "טוקן GitHub לא תקין או שפג תוקפו. אנא בדוק את הטוקן שלך בהגדרות Scrum Helper ונסה שוב."
+  },
+  "displayModeNotice": {
+    "message": "ההרחבה תיפתח במצב $1 בהפעלה הבאה."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "סינון מאגרים זמין רק עבור GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "טעינת מאגרים זמינה רק עבור GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "אחזור מאגרים זמין רק עבור GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "טוען מאגרים באופן אוטומטי.."
+  },
+  "gitlabUserFetchError": {
+    "message": "שגיאה באחזור משתמש GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "משתמש GitLab '$1' לא נמצא"
+  },
+  "gitlabMembershipError": {
+    "message": "שגיאה באחזור פרויקטי חברות ב-GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "שגיאה באחזור פרויקטים שאליהם המשתמש תרם ב-GitLab: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "שם משתמש נדרש."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "מייצר דוח..."
+  },
+  "copyingReportNotification": {
+    "message": "מעתיק דוח..."
+  },
+  "copiedReportNotification": {
+    "message": "הדוח הועתק!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "מוסיף דוח לאימייל..."
+  },
+  "insertedInEmailNotification": {
+    "message": "הדוח הוכנס לאימייל!"
+  }
 }

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "एक चयनित अवधि के लिए अपनी Git गतिविधि को स्वतः प्राप्त करके अपनी विकास प्रगति की रिपोर्ट करें।"
-    },
-    "disableLabel": {
-        "message": "अक्षम करें"
-    },
-    "enableLabel": {
-        "message": "सक्षम करें"
-    },
-    "projectNameLabel": {
-        "message": "ईमेल विषय"
-    },
-    "projectNamePlaceholder": {
-        "message": "अपनी परियोजना का नाम दर्ज करें"
-    },
-    "githubUsernameLabel": {
-        "message": "आपका GitHub उपयोगकर्ता नाम"
-    },
-    "gitlabUsernameLabel": {
-        "message": "आपका GitLab उपयोगकर्ता नाम"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "आपके योगदानों को प्राप्त करने के लिए आवश्यक"
-    },
-    "contributionsLabel": {
-        "message": "इस अवधि के योगदान प्राप्त करें:"
-    },
-    "last1DayLabel": {
-        "message": "पिछला दिन"
-    },
-    "startDateLabel": {
-        "message": "प्रारंभ तिथि:"
-    },
-    "endDateLabel": {
-        "message": "अंतिम तिथि:"
-    },
-    "showOpenClosedLabel": {
-        "message": "खुला/बंद स्थिति दिखाएं"
-    },
-    "blockersLabel": {
-        "message": "आपको प्रगति करने से क्या रोक रहा है?"
-    },
-    "blockersPlaceholder": {
-        "message": "अपना कारण दर्ज करें"
-    },
-    "scrumReportLabel": {
-        "message": "स्क्रम रिपोर्ट"
-    },
-    "generateReportButton": {
-        "message": "जनरेट"
-    },
-    "copyReportButton": {
-        "message": "कॉपी"
-    },
-    "insertInEmailButton": {
-        "message": "ईमेल में डालें"
-    },
-    "insertToEmailFailedError": {
-        "message": "रिपोर्ट को ईमेल में डालने के लिए एक ईमेल टैब खोलें"
-    },
-    "settingsOrgNameLabel": {
-        "message": "संगठन का नाम"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "संगठन का नाम दर्ज करें"
-    },
-    "setButton": {
-        "message": "सेट करें"
-    },
-    "githubTokenLabel": {
-        "message": "आपका GitHub टोकन"
-    },
-    "githubTokenPlaceholder": {
-        "message": "प्रमाणित अनुरोधों के लिए आवश्यक"
-    },
-    "githubTokenTooltip": {
-        "message": "GitHub टोकन जोड़ने की सिफारिश क्यों की जाती है? Scrum Helper बिना GitHub टोकन के काम करता है, लेकिन बेहतर अनुभव के लिए व्यक्तिगत एक्सेस टोकन जोड़ने की सिफारिश की जाती है।"
-    },
-    "gitlabTokenLabel": {
-        "message": "आपका GitLab टोकन"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "निजी रेपो के लिए आवश्यक"
-    },
-    "gitlabTokenTooltip": {
-        "message": "GitLab टोकन जोड़ने की सिफारिश क्यों की जाती है? Scrum Helper सार्वजनिक परियोजनाओं के लिए बिना GitLab टोकन के काम करता है, लेकिन बेहतर अनुभव के लिए व्यक्तिगत एक्सेस टोकन जोड़ने की सिफारिश की जाती है।"
-    },
-    "showCommitsLabel": {
-        "message": "खुले पीआर/ ड्राफ्ट पीआर पर कमिट दिखाएं"
-    },
-    "showCommitsTooltip": {
-        "message": "गिटहब टोकन आवश्यक है, इसे सेटिंग्स में जोड़ें।"
-    },
-    "onlyIssuesLabel": {
-        "message": "रिपोर्ट में केवल समस्याएं शामिल करें"
-    },
-    "onlyIssuesTooltip": {
-        "message": "यदि चेक किया गया है, तो रिपोर्ट में केवल उपयोगकर्ता द्वारा बनाए गए या सौंपे गए मुद्दे शामिल होंगे।"
-    },
-    "onlyPRsLabel": {
-        "message": "रिपोर्ट में केवल PRs शामिल करें"
-    },
-    "onlyPRsTooltip": {
-        "message": "चेक करने पर रिपोर्ट में केवल उपयोगकर्ता द्वारा बनाई गई PRs शामिल होंगी; समीक्षित PRs बाहर रखी जाएँगी."
-    },
-    "cacheTTLLabel": {
-        "message": "कैश टीटीएल दर्ज करें"
-    },
-    "cacheTTLUnit": {
-        "message": "(मिनटों में)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "कैश TTL मिनटों में लिखें (डिफ़ॉल्ट: 10)"
-    },
-    "refreshDataButton": {
-        "message": "डेटा रीफ्रेश करें (कैश को बायपास करें)"
-    },
-    "refreshDataInfo": {
-        "message": "ताज़ा डेटा तुरंत प्राप्त करने के लिए इस बटन का उपयोग करें।"
-    },
-    "noteTitle": {
-        "message": "ध्यान दें:"
-    },
-    "viewCodeButton": {
-        "message": "कोड देखें"
-    },
-    "reportIssueButton": {
-        "message": "समस्या की रिपोर्ट करें"
-    },
-    "repoFilterLabel": {
-        "message": "रिपॉजिटरी द्वारा फ़िल्टर करें"
-    },
-    "enableFilteringLabel": {
-        "message": "फ़िल्टरिंग सक्षम करें"
-    },
-    "tokenRequiredWarning": {
-        "message": "रिपॉजिटरी फ़िल्टरिंग के लिए एक GitHub टोकन आवश्यक है। कृपया सेटिंग्स में एक जोड़ें।"
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "ओपन या ड्राफ्ट PRs पर कमिट दिखाने के लिए एक GitHub टोकन आवश्यक है। कृपया सेटिंग्स में एक जोड़ें।"
-    },
-    "repoSearchPlaceholder": {
-        "message": "जोड़ने के लिए एक रिपॉजिटरी खोजें..."
-    },
-    "repoPlaceholder": {
-        "message": "कोई रिपॉजिटरी चयनित नहीं (सभी शामिल होंगी)"
-    },
-    "repoCountNone": {
-        "message": "0 रिपॉजिटरी चयनित"
-    },
-    "repoCount": {
-        "message": "$1 रिपॉजिटरी चयनित"
-    },
-    "clearAllBtn": {
-        "message": "सभी हटाएं"
-    },
-    "repoLoading": {
-        "message": "रिपॉजिटरी लोड हो रही हैं..."
-    },
-    "repoLoaded": {
-        "message": "$1 रिपॉजिटरी लोड हो गईं।"
-    },
-    "repoNotFound": {
-        "message": "कोई रिपॉजिटरी नहीं मिली"
-    },
-    "repoRefetching": {
-        "message": "रिपॉजिटरी फिर से लोड हो रही हैं..."
-    },
-    "repoLoadFailed": {
-        "message": "रिपॉजिटरी लोड करने में विफल।"
-    },
-    "repoTokenPrivate": {
-        "message": "टोकन अमान्य है या निजी रिपॉजिटरी के लिए अधिकार नहीं हैं।"
-    },
-    "repoRefetchFailed": {
-        "message": "रिपॉजिटरी फिर से लोड करने में विफल।"
-    },
-    "orgSetMessage": {
-        "message": "संगठन सफलतापूर्वक सेट हो गया।"
-    },
-    "orgClearedMessage": {
-        "message": "संगठन साफ़ हो गया। सभी गतिविधियाँ प्राप्त करने के लिए 'रिपोर्ट बनाएं' पर क्लिक करें।"
-    },
-    "orgNotFoundMessage": {
-        "message": "GitHub पर संगठन नहीं मिला।"
-    },
-    "orgValidationErrorMessage": {
-        "message": "संगठन को मान्य करने में त्रुटि।"
-    },
-    "refreshingButton": {
-        "message": "रीफ्रेश हो रहा है..."
-    },
-    "cacheClearFailed": {
-        "message": "कैश साफ़ करने में विफल।"
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "बनाया जा रहा है..."
-    },
-    "copiedButton": {
-        "message": "कॉपी किया गया!"
-    },
-    "orgChangedMessage": {
-        "message": "संगठन बदल गया है। GitHub गतिविधियाँ प्राप्त करने के लिए 'रिपोर्ट बनाएं' बटन पर क्लिक करें।"
-    },
-    "cacheClearedMessage": {
-        "message": "कैश सफलतापूर्वक साफ़ हो गया। ताज़ा डेटा प्राप्त करने के लिए 'रिपोर्ट बनाएं' पर क्लिक करें।"
-    },
-    "cacheExpiredMessage": {
-        "message": "कैश समाप्त हो गया। नया डेटा प्राप्त करने के लिए \"रिपोर्ट बनाएं\" पर क्लिक करें।"
-    },
-    "cacheClearedButton": {
-        "message": "कैश साफ़ हो गया!"
-    },
-    "extensionDisabledMessage": {
-        "message": "एक्सटेंशन अक्षम है। स्क्रम रिपोर्ट बनाने के लिए इसे विकल्पों से सक्षम करें।"
-    },
-    "notePoint1": {
-        "message": "पुल रिक्वेस्ट किसी भी योगदानकर्ता की सबसे हालिया समीक्षा गतिविधि के आधार पर प्राप्त की जाती हैं, न कि केवल आपकी अपनी। कृपया साझा करने से पहले उत्पन्न SCRUM रिपोर्ट की समीक्षा करें और उसे समायोजित करें ताकि यह सुनिश्चित हो सके कि यह आपके काम को सटीक रूप से दर्शाती है।"
-    },
-    "noteSeeIssue": {
-        "message": "यह समस्या देखें"
-    },
-    "platformLabel": {
-        "message": "प्लेटफ़ॉर्म"
-    },
-    "usernameLabel": {
-        "message": "आपका उपयोगकर्ता नाम"
-    },
-    "onlyRevPRsLabel": {
-        "message": "रिपोर्ट में केवल समीक्षित PRs शामिल करें"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "यदि चेक किया गया है, तो रिपोर्ट में केवल आपके द्वारा समीक्षित PRs शामिल होंगे।"
-    },
-    "onlyMergedPRsLabel": {
-        "message": "रिपोर्ट में केवल merged PRs शामिल करें"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "यदि चेक किया गया है, तो रिपोर्ट में केवल merged PRs शामिल होंगे। एक GitHub टोकन आवश्यक है।"
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "merged PRs द्वारा फ़िल्टर करने के लिए एक GitHub टोकन आवश्यक है। कृपया सेटिंग्स में एक जोड़ें।"
-    },
-    "usernameRequiredError": {
-        "message": "रिपोर्ट बनाने के लिए कृपया अपना उपयोगकर्ता नाम दर्ज करें।"
-    },
-    "unknownPlatformError": {
-        "message": "अज्ञात प्लेटफ़ॉर्म चुना गया है।"
-    },
-    "gitlabFetchingError": {
-        "message": "GitLab डेटा प्राप्त करते समय एक त्रुटि हुई।"
-    },
-    "reportGenerationError": {
-        "message": "रिपोर्ट तैयार करते समय एक त्रुटि हुई।"
-    },
-    "githubUserNotFoundError": {
-        "message": "GitHub उपयोगकर्ता \"$1\" नहीं मिला (404)। कृपया उपयोगकर्ता नाम जांचें और पुनः प्रयास करें।"
-    },
-    "githubUserValidationError": {
-        "message": "GitHub उपयोगकर्ता सत्यापित करते समय त्रुटि: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "अमान्य खोज क्वेरी या दिनांक सीमा। कृपया अपनी दिनांक सीमा का प्रारूप जांचें और पुनः प्रयास करें।"
-    },
-    "githubIssuesFetchError": {
-        "message": "GitHub issues प्राप्त करते समय त्रुटि: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "GitHub PR समीक्षा डेटा प्राप्त करते समय त्रुटि: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "GitHub उपयोगकर्ता डेटा प्राप्त करते समय त्रुटि: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "अमान्य या समाप्त हो चुका GitHub टोकन। कृपया Scrum Helper सेटिंग्स में अपना टोकन जांचें और पुनः प्रयास करें।"
-    },
-    "displayModeNotice": {
-        "message": "एक्सटेंशन अगली बार शुरू होने पर $1 मोड में खुलेगा।"
-    },
-    "repoFilteringGithubOnly": {
-        "message": "रिपॉज़िटरी फ़िल्टरिंग केवल GitHub के लिए उपलब्ध है।"
-    },
-    "repoLoadingGithubOnly": {
-        "message": "रिपॉज़िटरी लोडिंग केवल GitHub के लिए उपलब्ध है।"
-    },
-    "repoFetchingGithubOnly": {
-        "message": "रिपॉज़िटरी प्राप्त करना केवल GitHub के लिए उपलब्ध है।"
-    },
-    "loadingReposAutomatically": {
-        "message": "रिपॉज़िटरी स्वचालित रूप से लोड हो रही हैं.."
-    },
-    "gitlabUserFetchError": {
-        "message": "GitLab उपयोगकर्ता प्राप्त करते समय त्रुटि: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "GitLab उपयोगकर्ता '$1' नहीं मिला"
-    },
-    "gitlabMembershipError": {
-        "message": "GitLab सदस्यता प्रोजेक्ट्स प्राप्त करते समय त्रुटि: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "GitLab योगदान किए गए प्रोजेक्ट्स प्राप्त करते समय त्रुटि: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "उपयोगकर्ता नाम आवश्यक है।"
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "रिपोर्ट तैयार हो रही है..."
-    },
-    "copyingReportNotification": {
-        "message": "रिपोर्ट कॉपी की जा रही है..."
-    },
-    "copiedReportNotification": {
-        "message": "रिपोर्ट कॉपी हो गई!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "रिपोर्ट ईमेल में डाली जा रही है..."
-    },
-    "insertedInEmailNotification": {
-        "message": "रिपोर्ट ईमेल में डाल दी गई!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "एक चयनित अवधि के लिए अपनी Git गतिविधि को स्वतः प्राप्त करके अपनी विकास प्रगति की रिपोर्ट करें।"
+  },
+  "disableLabel": {
+    "message": "अक्षम करें"
+  },
+  "enableLabel": {
+    "message": "सक्षम करें"
+  },
+  "projectNameLabel": {
+    "message": "ईमेल विषय"
+  },
+  "projectNamePlaceholder": {
+    "message": "अपनी परियोजना का नाम दर्ज करें"
+  },
+  "githubUsernameLabel": {
+    "message": "आपका GitHub उपयोगकर्ता नाम"
+  },
+  "gitlabUsernameLabel": {
+    "message": "आपका GitLab उपयोगकर्ता नाम"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "आपके योगदानों को प्राप्त करने के लिए आवश्यक"
+  },
+  "contributionsLabel": {
+    "message": "इस अवधि के योगदान प्राप्त करें:"
+  },
+  "last1DayLabel": {
+    "message": "पिछला दिन"
+  },
+  "lastWeekLabel": {
+    "message": "पिछले सप्ताह का सारांश",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "प्रारंभ तिथि:"
+  },
+  "endDateLabel": {
+    "message": "अंतिम तिथि:"
+  },
+  "showOpenClosedLabel": {
+    "message": "खुला/बंद स्थिति दिखाएं"
+  },
+  "blockersLabel": {
+    "message": "आपको प्रगति करने से क्या रोक रहा है?"
+  },
+  "blockersPlaceholder": {
+    "message": "अपना कारण दर्ज करें"
+  },
+  "scrumReportLabel": {
+    "message": "स्क्रम रिपोर्ट"
+  },
+  "generateReportButton": {
+    "message": "जनरेट"
+  },
+  "copyReportButton": {
+    "message": "कॉपी"
+  },
+  "insertInEmailButton": {
+    "message": "ईमेल में डालें"
+  },
+  "insertToEmailFailedError": {
+    "message": "रिपोर्ट को ईमेल में डालने के लिए एक ईमेल टैब खोलें"
+  },
+  "settingsOrgNameLabel": {
+    "message": "संगठन का नाम"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "संगठन का नाम दर्ज करें"
+  },
+  "setButton": {
+    "message": "सेट करें"
+  },
+  "githubTokenLabel": {
+    "message": "आपका GitHub टोकन"
+  },
+  "githubTokenPlaceholder": {
+    "message": "प्रमाणित अनुरोधों के लिए आवश्यक"
+  },
+  "githubTokenTooltip": {
+    "message": "GitHub टोकन जोड़ने की सिफारिश क्यों की जाती है? Scrum Helper बिना GitHub टोकन के काम करता है, लेकिन बेहतर अनुभव के लिए व्यक्तिगत एक्सेस टोकन जोड़ने की सिफारिश की जाती है।"
+  },
+  "gitlabTokenLabel": {
+    "message": "आपका GitLab टोकन"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "निजी रेपो के लिए आवश्यक"
+  },
+  "gitlabTokenTooltip": {
+    "message": "GitLab टोकन जोड़ने की सिफारिश क्यों की जाती है? Scrum Helper सार्वजनिक परियोजनाओं के लिए बिना GitLab टोकन के काम करता है, लेकिन बेहतर अनुभव के लिए व्यक्तिगत एक्सेस टोकन जोड़ने की सिफारिश की जाती है।"
+  },
+  "showCommitsLabel": {
+    "message": "खुले पीआर/ ड्राफ्ट पीआर पर कमिट दिखाएं"
+  },
+  "showCommitsTooltip": {
+    "message": "गिटहब टोकन आवश्यक है, इसे सेटिंग्स में जोड़ें।"
+  },
+  "onlyIssuesLabel": {
+    "message": "रिपोर्ट में केवल समस्याएं शामिल करें"
+  },
+  "onlyIssuesTooltip": {
+    "message": "यदि चेक किया गया है, तो रिपोर्ट में केवल उपयोगकर्ता द्वारा बनाए गए या सौंपे गए मुद्दे शामिल होंगे।"
+  },
+  "onlyPRsLabel": {
+    "message": "रिपोर्ट में केवल PRs शामिल करें"
+  },
+  "onlyPRsTooltip": {
+    "message": "चेक करने पर रिपोर्ट में केवल उपयोगकर्ता द्वारा बनाई गई PRs शामिल होंगी; समीक्षित PRs बाहर रखी जाएँगी."
+  },
+  "cacheTTLLabel": {
+    "message": "कैश टीटीएल दर्ज करें"
+  },
+  "cacheTTLUnit": {
+    "message": "(मिनटों में)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "कैश TTL मिनटों में लिखें (डिफ़ॉल्ट: 10)"
+  },
+  "refreshDataButton": {
+    "message": "डेटा रीफ्रेश करें (कैश को बायपास करें)"
+  },
+  "refreshDataInfo": {
+    "message": "ताज़ा डेटा तुरंत प्राप्त करने के लिए इस बटन का उपयोग करें।"
+  },
+  "noteTitle": {
+    "message": "ध्यान दें:"
+  },
+  "viewCodeButton": {
+    "message": "कोड देखें"
+  },
+  "reportIssueButton": {
+    "message": "समस्या की रिपोर्ट करें"
+  },
+  "repoFilterLabel": {
+    "message": "रिपॉजिटरी द्वारा फ़िल्टर करें"
+  },
+  "enableFilteringLabel": {
+    "message": "फ़िल्टरिंग सक्षम करें"
+  },
+  "tokenRequiredWarning": {
+    "message": "रिपॉजिटरी फ़िल्टरिंग के लिए एक GitHub टोकन आवश्यक है। कृपया सेटिंग्स में एक जोड़ें।"
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "ओपन या ड्राफ्ट PRs पर कमिट दिखाने के लिए एक GitHub टोकन आवश्यक है। कृपया सेटिंग्स में एक जोड़ें।"
+  },
+  "repoSearchPlaceholder": {
+    "message": "जोड़ने के लिए एक रिपॉजिटरी खोजें..."
+  },
+  "repoPlaceholder": {
+    "message": "कोई रिपॉजिटरी चयनित नहीं (सभी शामिल होंगी)"
+  },
+  "repoCountNone": {
+    "message": "0 रिपॉजिटरी चयनित"
+  },
+  "repoCount": {
+    "message": "$1 रिपॉजिटरी चयनित"
+  },
+  "clearAllBtn": {
+    "message": "सभी हटाएं"
+  },
+  "repoLoading": {
+    "message": "रिपॉजिटरी लोड हो रही हैं..."
+  },
+  "repoLoaded": {
+    "message": "$1 रिपॉजिटरी लोड हो गईं।"
+  },
+  "repoNotFound": {
+    "message": "कोई रिपॉजिटरी नहीं मिली"
+  },
+  "repoRefetching": {
+    "message": "रिपॉजिटरी फिर से लोड हो रही हैं..."
+  },
+  "repoLoadFailed": {
+    "message": "रिपॉजिटरी लोड करने में विफल।"
+  },
+  "repoTokenPrivate": {
+    "message": "टोकन अमान्य है या निजी रिपॉजिटरी के लिए अधिकार नहीं हैं।"
+  },
+  "repoRefetchFailed": {
+    "message": "रिपॉजिटरी फिर से लोड करने में विफल।"
+  },
+  "orgSetMessage": {
+    "message": "संगठन सफलतापूर्वक सेट हो गया।"
+  },
+  "orgClearedMessage": {
+    "message": "संगठन साफ़ हो गया। सभी गतिविधियाँ प्राप्त करने के लिए 'रिपोर्ट बनाएं' पर क्लिक करें।"
+  },
+  "orgNotFoundMessage": {
+    "message": "GitHub पर संगठन नहीं मिला।"
+  },
+  "orgValidationErrorMessage": {
+    "message": "संगठन को मान्य करने में त्रुटि।"
+  },
+  "refreshingButton": {
+    "message": "रीफ्रेश हो रहा है..."
+  },
+  "cacheClearFailed": {
+    "message": "कैश साफ़ करने में विफल।"
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "बनाया जा रहा है..."
+  },
+  "copiedButton": {
+    "message": "कॉपी किया गया!"
+  },
+  "orgChangedMessage": {
+    "message": "संगठन बदल गया है। GitHub गतिविधियाँ प्राप्त करने के लिए 'रिपोर्ट बनाएं' बटन पर क्लिक करें।"
+  },
+  "cacheClearedMessage": {
+    "message": "कैश सफलतापूर्वक साफ़ हो गया। ताज़ा डेटा प्राप्त करने के लिए 'रिपोर्ट बनाएं' पर क्लिक करें।"
+  },
+  "cacheExpiredMessage": {
+    "message": "कैश समाप्त हो गया। नया डेटा प्राप्त करने के लिए \"रिपोर्ट बनाएं\" पर क्लिक करें।"
+  },
+  "cacheClearedButton": {
+    "message": "कैश साफ़ हो गया!"
+  },
+  "extensionDisabledMessage": {
+    "message": "एक्सटेंशन अक्षम है। स्क्रम रिपोर्ट बनाने के लिए इसे विकल्पों से सक्षम करें।"
+  },
+  "notePoint1": {
+    "message": "पुल रिक्वेस्ट किसी भी योगदानकर्ता की सबसे हालिया समीक्षा गतिविधि के आधार पर प्राप्त की जाती हैं, न कि केवल आपकी अपनी। कृपया साझा करने से पहले उत्पन्न SCRUM रिपोर्ट की समीक्षा करें और उसे समायोजित करें ताकि यह सुनिश्चित हो सके कि यह आपके काम को सटीक रूप से दर्शाती है।"
+  },
+  "noteSeeIssue": {
+    "message": "यह समस्या देखें"
+  },
+  "platformLabel": {
+    "message": "प्लेटफ़ॉर्म"
+  },
+  "usernameLabel": {
+    "message": "आपका उपयोगकर्ता नाम"
+  },
+  "onlyRevPRsLabel": {
+    "message": "रिपोर्ट में केवल समीक्षित PRs शामिल करें"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "यदि चेक किया गया है, तो रिपोर्ट में केवल आपके द्वारा समीक्षित PRs शामिल होंगे।"
+  },
+  "onlyMergedPRsLabel": {
+    "message": "रिपोर्ट में केवल merged PRs शामिल करें"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "यदि चेक किया गया है, तो रिपोर्ट में केवल merged PRs शामिल होंगे। एक GitHub टोकन आवश्यक है।"
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "merged PRs द्वारा फ़िल्टर करने के लिए एक GitHub टोकन आवश्यक है। कृपया सेटिंग्स में एक जोड़ें।"
+  },
+  "usernameRequiredError": {
+    "message": "रिपोर्ट बनाने के लिए कृपया अपना उपयोगकर्ता नाम दर्ज करें।"
+  },
+  "unknownPlatformError": {
+    "message": "अज्ञात प्लेटफ़ॉर्म चुना गया है।"
+  },
+  "gitlabFetchingError": {
+    "message": "GitLab डेटा प्राप्त करते समय एक त्रुटि हुई।"
+  },
+  "reportGenerationError": {
+    "message": "रिपोर्ट तैयार करते समय एक त्रुटि हुई।"
+  },
+  "githubUserNotFoundError": {
+    "message": "GitHub उपयोगकर्ता \"$1\" नहीं मिला (404)। कृपया उपयोगकर्ता नाम जांचें और पुनः प्रयास करें।"
+  },
+  "githubUserValidationError": {
+    "message": "GitHub उपयोगकर्ता सत्यापित करते समय त्रुटि: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "अमान्य खोज क्वेरी या दिनांक सीमा। कृपया अपनी दिनांक सीमा का प्रारूप जांचें और पुनः प्रयास करें।"
+  },
+  "githubIssuesFetchError": {
+    "message": "GitHub issues प्राप्त करते समय त्रुटि: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "GitHub PR समीक्षा डेटा प्राप्त करते समय त्रुटि: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "GitHub उपयोगकर्ता डेटा प्राप्त करते समय त्रुटि: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "अमान्य या समाप्त हो चुका GitHub टोकन। कृपया Scrum Helper सेटिंग्स में अपना टोकन जांचें और पुनः प्रयास करें।"
+  },
+  "displayModeNotice": {
+    "message": "एक्सटेंशन अगली बार शुरू होने पर $1 मोड में खुलेगा।"
+  },
+  "repoFilteringGithubOnly": {
+    "message": "रिपॉज़िटरी फ़िल्टरिंग केवल GitHub के लिए उपलब्ध है।"
+  },
+  "repoLoadingGithubOnly": {
+    "message": "रिपॉज़िटरी लोडिंग केवल GitHub के लिए उपलब्ध है।"
+  },
+  "repoFetchingGithubOnly": {
+    "message": "रिपॉज़िटरी प्राप्त करना केवल GitHub के लिए उपलब्ध है।"
+  },
+  "loadingReposAutomatically": {
+    "message": "रिपॉज़िटरी स्वचालित रूप से लोड हो रही हैं.."
+  },
+  "gitlabUserFetchError": {
+    "message": "GitLab उपयोगकर्ता प्राप्त करते समय त्रुटि: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "GitLab उपयोगकर्ता '$1' नहीं मिला"
+  },
+  "gitlabMembershipError": {
+    "message": "GitLab सदस्यता प्रोजेक्ट्स प्राप्त करते समय त्रुटि: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "GitLab योगदान किए गए प्रोजेक्ट्स प्राप्त करते समय त्रुटि: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "उपयोगकर्ता नाम आवश्यक है।"
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "रिपोर्ट तैयार हो रही है..."
+  },
+  "copyingReportNotification": {
+    "message": "रिपोर्ट कॉपी की जा रही है..."
+  },
+  "copiedReportNotification": {
+    "message": "रिपोर्ट कॉपी हो गई!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "रिपोर्ट ईमेल में डाली जा रही है..."
+  },
+  "insertedInEmailNotification": {
+    "message": "रिपोर्ट ईमेल में डाल दी गई!"
+  }
 }

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Laporkan kemajuan pengembangan Anda dengan mengambil aktivitas Git Anda secara otomatis untuk periode yang dipilih."
-    },
-    "disableLabel": {
-        "message": "Nonaktifkan"
-    },
-    "enableLabel": {
-        "message": "Aktifkan"
-    },
-    "projectNameLabel": {
-        "message": "Nama Proyek (digunakan di subjek email)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Masukkan nama proyek Anda"
-    },
-    "githubUsernameLabel": {
-        "message": "Nama Pengguna GitHub Anda"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Nama Pengguna GitLab Anda"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Diperlukan untuk mengambil kontribusi Anda"
-    },
-    "contributionsLabel": {
-        "message": "Ambil kontribusi Anda untuk:"
-    },
-    "last1DayLabel": {
-        "message": "Hari sebelumnya"
-    },
-    "startDateLabel": {
-        "message": "Dari:"
-    },
-    "endDateLabel": {
-        "message": "Hingga:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Tampilkan status Buka/Tutup"
-    },
-    "blockersLabel": {
-        "message": "Apa yang menghalangi kemajuan Anda?"
-    },
-    "blockersPlaceholder": {
-        "message": "Masukkan alasan Anda"
-    },
-    "scrumReportLabel": {
-        "message": "Laporan Scrum"
-    },
-    "generateReportButton": {
-        "message": "Buat"
-    },
-    "copyReportButton": {
-        "message": "Salin"
-    },
-    "insertInEmailButton": {
-        "message": "Sisipkan ke Email"
-    },
-    "insertToEmailFailedError": {
-        "message": "Buka tab email untuk memasukkan laporan"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nama Organisasi"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Masukkan nama organisasi"
-    },
-    "setButton": {
-        "message": "Atur"
-    },
-    "githubTokenLabel": {
-        "message": "Token GitHub Anda"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Diperlukan untuk permintaan terotentikasi"
-    },
-    "githubTokenTooltip": {
-        "message": "Mengapa disarankan untuk menambahkan token GitHub? Scrum Helper berfungsi tanpa token GitHub, tetapi menambahkan token akses pribadi disarankan untuk pengalaman yang lebih baik."
-    },
-    "gitlabTokenLabel": {
-        "message": "Token GitLab Anda"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Diperlukan untuk repo pribadi"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Mengapa disarankan untuk menambahkan token GitLab? Scrum Helper berfungsi tanpa token GitLab untuk proyek publik, tetapi menambahkan token akses pribadi disarankan untuk pengalaman yang lebih baik."
-    },
-    "showCommitsLabel": {
-        "message": "Tampilkan commit pada PR terbuka/ draf PR"
-    },
-    "showCommitsTooltip": {
-        "message": "Token Github diperlukan, tambahkan di pengaturan."
-    },
-    "onlyIssuesLabel": {
-        "message": "Hanya sertakan masalah dalam laporan"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Jika dicentang, laporan hanya akan menyertakan masalah yang dibuat atau ditugaskan kepada pengguna."
-    },
-    "onlyPRsLabel": {
-        "message": "Hanya sertakan PR dalam laporan"
-    },
-    "onlyPRsTooltip": {
-        "message": "Jika dicentang, laporan hanya akan menyertakan PR yang dibuat oleh pengguna; PR yang telah ditinjau akan dikecualikan."
-    },
-    "cacheTTLLabel": {
-        "message": "Masukkan TTL cache"
-    },
-    "cacheTTLUnit": {
-        "message": "(dalam menit)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Tulis TTL Cache dalam menit (Default: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Segarkan Data (abaikan cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Gunakan tombol ini untuk mengambil data baru segera."
-    },
-    "noteTitle": {
-        "message": "Catatan:"
-    },
-    "viewCodeButton": {
-        "message": "Lihat Kode"
-    },
-    "reportIssueButton": {
-        "message": "Laporkan Masalah"
-    },
-    "repoFilterLabel": {
-        "message": "Filter berdasarkan repositori"
-    },
-    "enableFilteringLabel": {
-        "message": "Aktifkan pemfilteran"
-    },
-    "tokenRequiredWarning": {
-        "message": "Token GitHub diperlukan untuk pemfilteran repositori. Harap tambahkan di pengaturan."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "Token GitHub diperlukan untuk menampilkan commit pada PR terbuka atau draf. Silakan tambahkan di pengaturan."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Cari repositori untuk ditambahkan..."
-    },
-    "repoPlaceholder": {
-        "message": "Tidak ada repositori yang dipilih (semua akan disertakan)"
-    },
-    "repoCountNone": {
-        "message": "0 repositori dipilih"
-    },
-    "repoCount": {
-        "message": "$1 repositori dipilih"
-    },
-    "clearAllBtn": {
-        "message": "Hapus Semua"
-    },
-    "repoLoading": {
-        "message": "Memuat repositori..."
-    },
-    "repoLoaded": {
-        "message": "$1 repositori dimuat."
-    },
-    "repoNotFound": {
-        "message": "Tidak ada repositori ditemukan"
-    },
-    "repoRefetching": {
-        "message": "Memuat ulang repositori..."
-    },
-    "repoLoadFailed": {
-        "message": "Gagal memuat repositori."
-    },
-    "repoTokenPrivate": {
-        "message": "Token tidak valid atau tidak memiliki hak untuk repo pribadi."
-    },
-    "repoRefetchFailed": {
-        "message": "Gagal memuat ulang repositori."
-    },
-    "orgSetMessage": {
-        "message": "Organisasi berhasil diatur."
-    },
-    "orgClearedMessage": {
-        "message": "Organisasi dihapus. Klik 'Buat Laporan' untuk mengambil semua aktivitas."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organisasi tidak ditemukan di GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Gagal memvalidasi organisasi."
-    },
-    "refreshingButton": {
-        "message": "Menyegarkan..."
-    },
-    "cacheClearFailed": {
-        "message": "Gagal membersihkan cache."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Membuat..."
-    },
-    "copiedButton": {
-        "message": "Tersalin!"
-    },
-    "orgChangedMessage": {
-        "message": "Organisasi diubah. Klik tombol 'Buat Laporan' untuk mengambil aktivitas GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache berhasil dihapus. Klik 'Buat Laporan' untuk mengambil data baru."
-    },
-    "cacheExpiredMessage": {
-        "message": "Cache telah kedaluwarsa. Klik \"Buat\" untuk mengambil data baru."
-    },
-    "cacheClearedButton": {
-        "message": "Cache Dihapus!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Ekstensi dinonaktifkan. Aktifkan dari opsi untuk membuat laporan scrum."
-    },
-    "notePoint1": {
-        "message": "Pull request diambil berdasarkan aktivitas review terbaru oleh kontributor mana pun, bukan hanya milik Anda. Harap tinjau dan sesuaikan laporan SCRUM yang dihasilkan untuk memastikan laporan tersebut secara akurat mencerminkan pekerjaan Anda sebelum dibagikan."
-    },
-    "noteSeeIssue": {
-        "message": "Lihat masalah ini"
-    },
-    "platformLabel": {
-        "message": "Platform"
-    },
-    "usernameLabel": {
-        "message": "Nama pengguna Anda"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Hanya sertakan PR yang ditinjau dalam laporan"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Jika dicentang, laporan hanya akan menyertakan PR yang ditinjau oleh Anda."
-    },
-    "onlyMergedPRsLabel": {
-        "message": "Sertakan hanya PR yang telah digabungkan (merged) dalam laporan"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "Jika dicentang, laporan hanya akan menyertakan PR yang telah digabungkan. Token GitHub diperlukan."
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "Token GitHub diperlukan untuk memfilter berdasarkan PR yang telah digabungkan. Silakan tambahkan di pengaturan."
-    },
-    "usernameRequiredError": {
-        "message": "Silakan masukkan nama pengguna Anda untuk membuat laporan."
-    },
-    "unknownPlatformError": {
-        "message": "Platform yang dipilih tidak dikenal."
-    },
-    "gitlabFetchingError": {
-        "message": "Terjadi kesalahan saat mengambil data GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Terjadi kesalahan saat membuat laporan."
-    },
-    "githubUserNotFoundError": {
-        "message": "Pengguna GitHub \"$1\" tidak ditemukan (404). Silakan periksa nama pengguna dan coba lagi."
-    },
-    "githubUserValidationError": {
-        "message": "Kesalahan saat memvalidasi pengguna GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Kueri pencarian atau rentang tanggal tidak valid. Silakan periksa format rentang tanggal Anda dan coba lagi."
-    },
-    "githubIssuesFetchError": {
-        "message": "Kesalahan saat mengambil issue GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Kesalahan saat mengambil data ulasan PR GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Kesalahan saat mengambil data pengguna GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Token GitHub tidak valid atau telah kedaluwarsa. Silakan periksa token Anda di pengaturan Scrum Helper dan coba lagi."
-    },
-    "displayModeNotice": {
-        "message": "Ekstensi akan terbuka dalam mode $1 pada peluncuran berikutnya."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Pemfilteran repositori hanya tersedia untuk GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Pemuatan repositori hanya tersedia untuk GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Pengambilan repositori hanya tersedia untuk GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Memuat repositori secara otomatis.."
-    },
-    "gitlabUserFetchError": {
-        "message": "Kesalahan saat mengambil pengguna GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Pengguna GitLab '$1' tidak ditemukan"
-    },
-    "gitlabMembershipError": {
-        "message": "Kesalahan saat mengambil proyek keanggotaan GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Kesalahan saat mengambil proyek kontribusi GitLab: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Nama pengguna diperlukan."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Membuat laporan..."
-    },
-    "copyingReportNotification": {
-        "message": "Menyalin laporan..."
-    },
-    "copiedReportNotification": {
-        "message": "Laporan disalin!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Menyisipkan laporan ke email..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Laporan disisipkan ke email!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Laporkan kemajuan pengembangan Anda dengan mengambil aktivitas Git Anda secara otomatis untuk periode yang dipilih."
+  },
+  "disableLabel": {
+    "message": "Nonaktifkan"
+  },
+  "enableLabel": {
+    "message": "Aktifkan"
+  },
+  "projectNameLabel": {
+    "message": "Nama Proyek (digunakan di subjek email)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Masukkan nama proyek Anda"
+  },
+  "githubUsernameLabel": {
+    "message": "Nama Pengguna GitHub Anda"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Nama Pengguna GitLab Anda"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Diperlukan untuk mengambil kontribusi Anda"
+  },
+  "contributionsLabel": {
+    "message": "Ambil kontribusi Anda untuk:"
+  },
+  "last1DayLabel": {
+    "message": "Hari sebelumnya"
+  },
+  "lastWeekLabel": {
+    "message": "Ringkasan minggu lalu",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "Dari:"
+  },
+  "endDateLabel": {
+    "message": "Hingga:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Tampilkan status Buka/Tutup"
+  },
+  "blockersLabel": {
+    "message": "Apa yang menghalangi kemajuan Anda?"
+  },
+  "blockersPlaceholder": {
+    "message": "Masukkan alasan Anda"
+  },
+  "scrumReportLabel": {
+    "message": "Laporan Scrum"
+  },
+  "generateReportButton": {
+    "message": "Buat"
+  },
+  "copyReportButton": {
+    "message": "Salin"
+  },
+  "insertInEmailButton": {
+    "message": "Sisipkan ke Email"
+  },
+  "insertToEmailFailedError": {
+    "message": "Buka tab email untuk memasukkan laporan"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Nama Organisasi"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Masukkan nama organisasi"
+  },
+  "setButton": {
+    "message": "Atur"
+  },
+  "githubTokenLabel": {
+    "message": "Token GitHub Anda"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Diperlukan untuk permintaan terotentikasi"
+  },
+  "githubTokenTooltip": {
+    "message": "Mengapa disarankan untuk menambahkan token GitHub? Scrum Helper berfungsi tanpa token GitHub, tetapi menambahkan token akses pribadi disarankan untuk pengalaman yang lebih baik."
+  },
+  "gitlabTokenLabel": {
+    "message": "Token GitLab Anda"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Diperlukan untuk repo pribadi"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Mengapa disarankan untuk menambahkan token GitLab? Scrum Helper berfungsi tanpa token GitLab untuk proyek publik, tetapi menambahkan token akses pribadi disarankan untuk pengalaman yang lebih baik."
+  },
+  "showCommitsLabel": {
+    "message": "Tampilkan commit pada PR terbuka/ draf PR"
+  },
+  "showCommitsTooltip": {
+    "message": "Token Github diperlukan, tambahkan di pengaturan."
+  },
+  "onlyIssuesLabel": {
+    "message": "Hanya sertakan masalah dalam laporan"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Jika dicentang, laporan hanya akan menyertakan masalah yang dibuat atau ditugaskan kepada pengguna."
+  },
+  "onlyPRsLabel": {
+    "message": "Hanya sertakan PR dalam laporan"
+  },
+  "onlyPRsTooltip": {
+    "message": "Jika dicentang, laporan hanya akan menyertakan PR yang dibuat oleh pengguna; PR yang telah ditinjau akan dikecualikan."
+  },
+  "cacheTTLLabel": {
+    "message": "Masukkan TTL cache"
+  },
+  "cacheTTLUnit": {
+    "message": "(dalam menit)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Tulis TTL Cache dalam menit (Default: 10)"
+  },
+  "refreshDataButton": {
+    "message": "Segarkan Data (abaikan cache)"
+  },
+  "refreshDataInfo": {
+    "message": "Gunakan tombol ini untuk mengambil data baru segera."
+  },
+  "noteTitle": {
+    "message": "Catatan:"
+  },
+  "viewCodeButton": {
+    "message": "Lihat Kode"
+  },
+  "reportIssueButton": {
+    "message": "Laporkan Masalah"
+  },
+  "repoFilterLabel": {
+    "message": "Filter berdasarkan repositori"
+  },
+  "enableFilteringLabel": {
+    "message": "Aktifkan pemfilteran"
+  },
+  "tokenRequiredWarning": {
+    "message": "Token GitHub diperlukan untuk pemfilteran repositori. Harap tambahkan di pengaturan."
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "Token GitHub diperlukan untuk menampilkan commit pada PR terbuka atau draf. Silakan tambahkan di pengaturan."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Cari repositori untuk ditambahkan..."
+  },
+  "repoPlaceholder": {
+    "message": "Tidak ada repositori yang dipilih (semua akan disertakan)"
+  },
+  "repoCountNone": {
+    "message": "0 repositori dipilih"
+  },
+  "repoCount": {
+    "message": "$1 repositori dipilih"
+  },
+  "clearAllBtn": {
+    "message": "Hapus Semua"
+  },
+  "repoLoading": {
+    "message": "Memuat repositori..."
+  },
+  "repoLoaded": {
+    "message": "$1 repositori dimuat."
+  },
+  "repoNotFound": {
+    "message": "Tidak ada repositori ditemukan"
+  },
+  "repoRefetching": {
+    "message": "Memuat ulang repositori..."
+  },
+  "repoLoadFailed": {
+    "message": "Gagal memuat repositori."
+  },
+  "repoTokenPrivate": {
+    "message": "Token tidak valid atau tidak memiliki hak untuk repo pribadi."
+  },
+  "repoRefetchFailed": {
+    "message": "Gagal memuat ulang repositori."
+  },
+  "orgSetMessage": {
+    "message": "Organisasi berhasil diatur."
+  },
+  "orgClearedMessage": {
+    "message": "Organisasi dihapus. Klik 'Buat Laporan' untuk mengambil semua aktivitas."
+  },
+  "orgNotFoundMessage": {
+    "message": "Organisasi tidak ditemukan di GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Gagal memvalidasi organisasi."
+  },
+  "refreshingButton": {
+    "message": "Menyegarkan..."
+  },
+  "cacheClearFailed": {
+    "message": "Gagal membersihkan cache."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Membuat..."
+  },
+  "copiedButton": {
+    "message": "Tersalin!"
+  },
+  "orgChangedMessage": {
+    "message": "Organisasi diubah. Klik tombol 'Buat Laporan' untuk mengambil aktivitas GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Cache berhasil dihapus. Klik 'Buat Laporan' untuk mengambil data baru."
+  },
+  "cacheExpiredMessage": {
+    "message": "Cache telah kedaluwarsa. Klik \"Buat\" untuk mengambil data baru."
+  },
+  "cacheClearedButton": {
+    "message": "Cache Dihapus!"
+  },
+  "extensionDisabledMessage": {
+    "message": "Ekstensi dinonaktifkan. Aktifkan dari opsi untuk membuat laporan scrum."
+  },
+  "notePoint1": {
+    "message": "Pull request diambil berdasarkan aktivitas review terbaru oleh kontributor mana pun, bukan hanya milik Anda. Harap tinjau dan sesuaikan laporan SCRUM yang dihasilkan untuk memastikan laporan tersebut secara akurat mencerminkan pekerjaan Anda sebelum dibagikan."
+  },
+  "noteSeeIssue": {
+    "message": "Lihat masalah ini"
+  },
+  "platformLabel": {
+    "message": "Platform"
+  },
+  "usernameLabel": {
+    "message": "Nama pengguna Anda"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Hanya sertakan PR yang ditinjau dalam laporan"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Jika dicentang, laporan hanya akan menyertakan PR yang ditinjau oleh Anda."
+  },
+  "onlyMergedPRsLabel": {
+    "message": "Sertakan hanya PR yang telah digabungkan (merged) dalam laporan"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "Jika dicentang, laporan hanya akan menyertakan PR yang telah digabungkan. Token GitHub diperlukan."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "Token GitHub diperlukan untuk memfilter berdasarkan PR yang telah digabungkan. Silakan tambahkan di pengaturan."
+  },
+  "usernameRequiredError": {
+    "message": "Silakan masukkan nama pengguna Anda untuk membuat laporan."
+  },
+  "unknownPlatformError": {
+    "message": "Platform yang dipilih tidak dikenal."
+  },
+  "gitlabFetchingError": {
+    "message": "Terjadi kesalahan saat mengambil data GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Terjadi kesalahan saat membuat laporan."
+  },
+  "githubUserNotFoundError": {
+    "message": "Pengguna GitHub \"$1\" tidak ditemukan (404). Silakan periksa nama pengguna dan coba lagi."
+  },
+  "githubUserValidationError": {
+    "message": "Kesalahan saat memvalidasi pengguna GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Kueri pencarian atau rentang tanggal tidak valid. Silakan periksa format rentang tanggal Anda dan coba lagi."
+  },
+  "githubIssuesFetchError": {
+    "message": "Kesalahan saat mengambil issue GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Kesalahan saat mengambil data ulasan PR GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Kesalahan saat mengambil data pengguna GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Token GitHub tidak valid atau telah kedaluwarsa. Silakan periksa token Anda di pengaturan Scrum Helper dan coba lagi."
+  },
+  "displayModeNotice": {
+    "message": "Ekstensi akan terbuka dalam mode $1 pada peluncuran berikutnya."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Pemfilteran repositori hanya tersedia untuk GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Pemuatan repositori hanya tersedia untuk GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Pengambilan repositori hanya tersedia untuk GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Memuat repositori secara otomatis.."
+  },
+  "gitlabUserFetchError": {
+    "message": "Kesalahan saat mengambil pengguna GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Pengguna GitLab '$1' tidak ditemukan"
+  },
+  "gitlabMembershipError": {
+    "message": "Kesalahan saat mengambil proyek keanggotaan GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Kesalahan saat mengambil proyek kontribusi GitLab: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Nama pengguna diperlukan."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Membuat laporan..."
+  },
+  "copyingReportNotification": {
+    "message": "Menyalin laporan..."
+  },
+  "copiedReportNotification": {
+    "message": "Laporan disalin!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Menyisipkan laporan ke email..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Laporan disisipkan ke email!"
+  }
 }

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Segnala i tuoi progressi di sviluppo recuperando automaticamente la tua attività Git per un periodo selezionato."
-    },
-    "disableLabel": {
-        "message": "Disabilita"
-    },
-    "enableLabel": {
-        "message": "Abilita"
-    },
-    "projectNameLabel": {
-        "message": "Nome del progetto (usato nell'oggetto dell'email)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Inserisci il nome del tuo progetto"
-    },
-    "githubUsernameLabel": {
-        "message": "Il tuo nome utente GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Il tuo nome utente GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Richiesto per recuperare i tuoi contributi"
-    },
-    "contributionsLabel": {
-        "message": "Recupera i tuoi contributi per:"
-    },
-    "last1DayLabel": {
-        "message": "Giorno precedente"
-    },
-    "startDateLabel": {
-        "message": "Da:"
-    },
-    "endDateLabel": {
-        "message": "A:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Mostra stato Aperto/Chiuso"
-    },
-    "blockersLabel": {
-        "message": "Cosa ti impedisce di progredire?"
-    },
-    "blockersPlaceholder": {
-        "message": "Inserisci il motivo"
-    },
-    "scrumReportLabel": {
-        "message": "Rapporto Scrum"
-    },
-    "generateReportButton": {
-        "message": "Genera Rapporto"
-    },
-    "copyReportButton": {
-        "message": "Copia Rapporto"
-    },
-    "insertInEmailButton": {
-        "message": "Inserisci nell'email"
-    },
-    "insertToEmailFailedError": {
-        "message": "Apri una scheda email per inserire il report"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nome dell'organizzazione"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Inserisci il nome dell'organizzazione"
-    },
-    "setButton": {
-        "message": "Imposta"
-    },
-    "githubTokenLabel": {
-        "message": "Il tuo token GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Richiesto per richieste autenticate"
-    },
-    "githubTokenTooltip": {
-        "message": "Perché è consigliato aggiungere un token GitHub? Scrum Helper funziona senza un token GitHub, ma aggiungere un token di accesso personale è consigliato per un'esperienza migliore."
-    },
-    "gitlabTokenLabel": {
-        "message": "Il tuo token GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Richiesto per repo privati"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Perché è consigliato aggiungere un token GitLab? Scrum Helper funziona senza un token GitLab per progetti pubblici, ma aggiungere un token di accesso personale è consigliato per un'esperienza migliore."
-    },
-    "showCommitsLabel": {
-        "message": "Mostra commit su PR aperti/ bozze di PR"
-    },
-    "showCommitsTooltip": {
-        "message": "Token GitHub richiesto, aggiungilo nelle impostazioni."
-    },
-    "onlyIssuesLabel": {
-        "message": "Includi solo i problemi nel report"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Se selezionato, il report includerà solo i problemi creati o assegnati all'utente."
-    },
-    "onlyPRsLabel": {
-        "message": "Includi solo le PR nel report"
-    },
-    "onlyPRsTooltip": {
-        "message": "Se selezionato, il report includerà solo le pull request create dall'utente; le PR revisionate saranno escluse."
-    },
-    "cacheTTLLabel": {
-        "message": "Inserisci TTL della cache"
-    },
-    "cacheTTLUnit": {
-        "message": "(in minuti)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Scrivi il TTL della cache in minuti (Predefinito: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Aggiorna dati (ignora cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Usa questo pulsante per recuperare immediatamente dati aggiornati."
-    },
-    "noteTitle": {
-        "message": "Nota:"
-    },
-    "viewCodeButton": {
-        "message": "Visualizza Codice"
-    },
-    "reportIssueButton": {
-        "message": "Segnala un problema"
-    },
-    "repoFilterLabel": {
-        "message": "Filtra per repository"
-    },
-    "enableFilteringLabel": {
-        "message": "Abilita filtro"
-    },
-    "tokenRequiredWarning": {
-        "message": "È richiesto un token GitHub per filtrare i repository. Aggiungine uno nelle impostazioni."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "È richiesto un token GitHub per mostrare i commit sui PR aperti o bozze. Aggiungine uno nelle impostazioni."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Cerca un repository da aggiungere..."
-    },
-    "repoPlaceholder": {
-        "message": "Nessun repository selezionato (tutti saranno inclusi)"
-    },
-    "repoCountNone": {
-        "message": "0 repository selezionati"
-    },
-    "repoCount": {
-        "message": "$1 repository selezionati"
-    },
-    "clearAllBtn": {
-        "message": "Cancella tutto"
-    },
-    "repoLoading": {
-        "message": "Caricamento repository..."
-    },
-    "repoLoaded": {
-        "message": "Caricati $1 repository."
-    },
-    "repoNotFound": {
-        "message": "Nessun repository trovato"
-    },
-    "repoRefetching": {
-        "message": "Recupero repository in corso..."
-    },
-    "repoLoadFailed": {
-        "message": "Caricamento repository fallito."
-    },
-    "repoTokenPrivate": {
-        "message": "Il token non è valido o non ha i permessi per i repository privati."
-    },
-    "repoRefetchFailed": {
-        "message": "Recupero repository fallito."
-    },
-    "orgSetMessage": {
-        "message": "Organizzazione impostata con successo."
-    },
-    "orgClearedMessage": {
-        "message": "Organizzazione rimossa. Clicca 'Genera Rapporto' per recuperare tutte le attività."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organizzazione non trovata su GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Errore durante la convalida dell'organizzazione."
-    },
-    "refreshingButton": {
-        "message": "Aggiornamento..."
-    },
-    "cacheClearFailed": {
-        "message": "Pulizia della cache fallita."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Generazione in corso..."
-    },
-    "copiedButton": {
-        "message": "Copiato!"
-    },
-    "orgChangedMessage": {
-        "message": "Organizzazione modificata. Clicca 'Genera Rapporto' per recuperare le attività di GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache svuotata con successo. Clicca 'Genera Rapporto' per recuperare dati aggiornati."
-    },
-    "cacheExpiredMessage": {
-        "message": "Cache scaduta. Clicca \"Genera\" per recuperare dati aggiornati."
-    },
-    "cacheClearedButton": {
-        "message": "Cache Svuotata!"
-    },
-    "extensionDisabledMessage": {
-        "message": "L'estensione è disabilitata. Abilitala dalle impostazioni per generare rapporti scrum."
-    },
-    "notePoint1": {
-        "message": "Le pull request vengono recuperate in base all'attività di revisione più recente di qualsiasi contributore, non solo la tua. Si prega di rivedere e modificare il rapporto SCRUM generato per assicurarsi che rifletta accuratamente il proprio lavoro prima di condividerlo."
-    },
-    "noteSeeIssue": {
-        "message": "Vedi questo problema"
-    },
-    "platformLabel": {
-        "message": "Piattaforma"
-    },
-    "usernameLabel": {
-        "message": "Il tuo nome utente"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Includi solo le PR revisionate nel report"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Se selezionato, il report includerà solo le PR revisionate da te."
-    },
-    "onlyMergedPRsLabel": {
-        "message": "Includi solo i PR uniti (merged) nel report"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "Se selezionato, il report includerà solo i PR che sono stati uniti. È richiesto un token GitHub."
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "È richiesto un token GitHub per filtrare in base ai PR uniti. Aggiungine uno nelle impostazioni."
-    },
-    "usernameRequiredError": {
-        "message": "Inserisci il tuo nome utente per generare un report."
-    },
-    "unknownPlatformError": {
-        "message": "Piattaforma selezionata sconosciuta."
-    },
-    "gitlabFetchingError": {
-        "message": "Si è verificato un errore durante il recupero dei dati di GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Si è verificato un errore durante la generazione del report."
-    },
-    "githubUserNotFoundError": {
-        "message": "Utente GitHub \"$1\" non trovato (404). Verifica il nome utente e riprova."
-    },
-    "githubUserValidationError": {
-        "message": "Errore durante la convalida dell'utente GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Query di ricerca o intervallo di date non valido. Verifica il formato dell'intervallo di date e riprova."
-    },
-    "githubIssuesFetchError": {
-        "message": "Errore durante il recupero delle issue di GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Errore durante il recupero dei dati di revisione PR di GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Errore durante il recupero dei dati dell'utente GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Token GitHub non valido o scaduto. Verifica il tuo token nelle impostazioni di Scrum Helper e riprova."
-    },
-    "displayModeNotice": {
-        "message": "L'estensione si aprirà in modalità $1 al prossimo avvio."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Il filtro dei repository è disponibile solo per GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Il caricamento dei repository è disponibile solo per GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Il recupero dei repository è disponibile solo per GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Caricamento automatico dei repository.."
-    },
-    "gitlabUserFetchError": {
-        "message": "Errore durante il recupero dell'utente GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Utente GitLab '$1' non trovato"
-    },
-    "gitlabMembershipError": {
-        "message": "Errore durante il recupero dei progetti di appartenenza GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Errore durante il recupero dei progetti a cui l'utente ha contribuito su GitLab: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Nome utente richiesto."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Generazione del report..."
-    },
-    "copyingReportNotification": {
-        "message": "Copia del report..."
-    },
-    "copiedReportNotification": {
-        "message": "Report copiato!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Inserimento del report nell'email..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Report inserito nell'email!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Segnala i tuoi progressi di sviluppo recuperando automaticamente la tua attività Git per un periodo selezionato."
+  },
+  "disableLabel": {
+    "message": "Disabilita"
+  },
+  "enableLabel": {
+    "message": "Abilita"
+  },
+  "projectNameLabel": {
+    "message": "Nome del progetto (usato nell'oggetto dell'email)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Inserisci il nome del tuo progetto"
+  },
+  "githubUsernameLabel": {
+    "message": "Il tuo nome utente GitHub"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Il tuo nome utente GitLab"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Richiesto per recuperare i tuoi contributi"
+  },
+  "contributionsLabel": {
+    "message": "Recupera i tuoi contributi per:"
+  },
+  "last1DayLabel": {
+    "message": "Giorno precedente"
+  },
+  "lastWeekLabel": {
+    "message": "Riepilogo della settimana precedente",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "Da:"
+  },
+  "endDateLabel": {
+    "message": "A:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Mostra stato Aperto/Chiuso"
+  },
+  "blockersLabel": {
+    "message": "Cosa ti impedisce di progredire?"
+  },
+  "blockersPlaceholder": {
+    "message": "Inserisci il motivo"
+  },
+  "scrumReportLabel": {
+    "message": "Rapporto Scrum"
+  },
+  "generateReportButton": {
+    "message": "Genera Rapporto"
+  },
+  "copyReportButton": {
+    "message": "Copia Rapporto"
+  },
+  "insertInEmailButton": {
+    "message": "Inserisci nell'email"
+  },
+  "insertToEmailFailedError": {
+    "message": "Apri una scheda email per inserire il report"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Nome dell'organizzazione"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Inserisci il nome dell'organizzazione"
+  },
+  "setButton": {
+    "message": "Imposta"
+  },
+  "githubTokenLabel": {
+    "message": "Il tuo token GitHub"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Richiesto per richieste autenticate"
+  },
+  "githubTokenTooltip": {
+    "message": "Perché è consigliato aggiungere un token GitHub? Scrum Helper funziona senza un token GitHub, ma aggiungere un token di accesso personale è consigliato per un'esperienza migliore."
+  },
+  "gitlabTokenLabel": {
+    "message": "Il tuo token GitLab"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Richiesto per repo privati"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Perché è consigliato aggiungere un token GitLab? Scrum Helper funziona senza un token GitLab per progetti pubblici, ma aggiungere un token di accesso personale è consigliato per un'esperienza migliore."
+  },
+  "showCommitsLabel": {
+    "message": "Mostra commit su PR aperti/ bozze di PR"
+  },
+  "showCommitsTooltip": {
+    "message": "Token GitHub richiesto, aggiungilo nelle impostazioni."
+  },
+  "onlyIssuesLabel": {
+    "message": "Includi solo i problemi nel report"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Se selezionato, il report includerà solo i problemi creati o assegnati all'utente."
+  },
+  "onlyPRsLabel": {
+    "message": "Includi solo le PR nel report"
+  },
+  "onlyPRsTooltip": {
+    "message": "Se selezionato, il report includerà solo le pull request create dall'utente; le PR revisionate saranno escluse."
+  },
+  "cacheTTLLabel": {
+    "message": "Inserisci TTL della cache"
+  },
+  "cacheTTLUnit": {
+    "message": "(in minuti)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Scrivi il TTL della cache in minuti (Predefinito: 10)"
+  },
+  "refreshDataButton": {
+    "message": "Aggiorna dati (ignora cache)"
+  },
+  "refreshDataInfo": {
+    "message": "Usa questo pulsante per recuperare immediatamente dati aggiornati."
+  },
+  "noteTitle": {
+    "message": "Nota:"
+  },
+  "viewCodeButton": {
+    "message": "Visualizza Codice"
+  },
+  "reportIssueButton": {
+    "message": "Segnala un problema"
+  },
+  "repoFilterLabel": {
+    "message": "Filtra per repository"
+  },
+  "enableFilteringLabel": {
+    "message": "Abilita filtro"
+  },
+  "tokenRequiredWarning": {
+    "message": "È richiesto un token GitHub per filtrare i repository. Aggiungine uno nelle impostazioni."
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "È richiesto un token GitHub per mostrare i commit sui PR aperti o bozze. Aggiungine uno nelle impostazioni."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Cerca un repository da aggiungere..."
+  },
+  "repoPlaceholder": {
+    "message": "Nessun repository selezionato (tutti saranno inclusi)"
+  },
+  "repoCountNone": {
+    "message": "0 repository selezionati"
+  },
+  "repoCount": {
+    "message": "$1 repository selezionati"
+  },
+  "clearAllBtn": {
+    "message": "Cancella tutto"
+  },
+  "repoLoading": {
+    "message": "Caricamento repository..."
+  },
+  "repoLoaded": {
+    "message": "Caricati $1 repository."
+  },
+  "repoNotFound": {
+    "message": "Nessun repository trovato"
+  },
+  "repoRefetching": {
+    "message": "Recupero repository in corso..."
+  },
+  "repoLoadFailed": {
+    "message": "Caricamento repository fallito."
+  },
+  "repoTokenPrivate": {
+    "message": "Il token non è valido o non ha i permessi per i repository privati."
+  },
+  "repoRefetchFailed": {
+    "message": "Recupero repository fallito."
+  },
+  "orgSetMessage": {
+    "message": "Organizzazione impostata con successo."
+  },
+  "orgClearedMessage": {
+    "message": "Organizzazione rimossa. Clicca 'Genera Rapporto' per recuperare tutte le attività."
+  },
+  "orgNotFoundMessage": {
+    "message": "Organizzazione non trovata su GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Errore durante la convalida dell'organizzazione."
+  },
+  "refreshingButton": {
+    "message": "Aggiornamento..."
+  },
+  "cacheClearFailed": {
+    "message": "Pulizia della cache fallita."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Generazione in corso..."
+  },
+  "copiedButton": {
+    "message": "Copiato!"
+  },
+  "orgChangedMessage": {
+    "message": "Organizzazione modificata. Clicca 'Genera Rapporto' per recuperare le attività di GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Cache svuotata con successo. Clicca 'Genera Rapporto' per recuperare dati aggiornati."
+  },
+  "cacheExpiredMessage": {
+    "message": "Cache scaduta. Clicca \"Genera\" per recuperare dati aggiornati."
+  },
+  "cacheClearedButton": {
+    "message": "Cache Svuotata!"
+  },
+  "extensionDisabledMessage": {
+    "message": "L'estensione è disabilitata. Abilitala dalle impostazioni per generare rapporti scrum."
+  },
+  "notePoint1": {
+    "message": "Le pull request vengono recuperate in base all'attività di revisione più recente di qualsiasi contributore, non solo la tua. Si prega di rivedere e modificare il rapporto SCRUM generato per assicurarsi che rifletta accuratamente il proprio lavoro prima di condividerlo."
+  },
+  "noteSeeIssue": {
+    "message": "Vedi questo problema"
+  },
+  "platformLabel": {
+    "message": "Piattaforma"
+  },
+  "usernameLabel": {
+    "message": "Il tuo nome utente"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Includi solo le PR revisionate nel report"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Se selezionato, il report includerà solo le PR revisionate da te."
+  },
+  "onlyMergedPRsLabel": {
+    "message": "Includi solo i PR uniti (merged) nel report"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "Se selezionato, il report includerà solo i PR che sono stati uniti. È richiesto un token GitHub."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "È richiesto un token GitHub per filtrare in base ai PR uniti. Aggiungine uno nelle impostazioni."
+  },
+  "usernameRequiredError": {
+    "message": "Inserisci il tuo nome utente per generare un report."
+  },
+  "unknownPlatformError": {
+    "message": "Piattaforma selezionata sconosciuta."
+  },
+  "gitlabFetchingError": {
+    "message": "Si è verificato un errore durante il recupero dei dati di GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Si è verificato un errore durante la generazione del report."
+  },
+  "githubUserNotFoundError": {
+    "message": "Utente GitHub \"$1\" non trovato (404). Verifica il nome utente e riprova."
+  },
+  "githubUserValidationError": {
+    "message": "Errore durante la convalida dell'utente GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Query di ricerca o intervallo di date non valido. Verifica il formato dell'intervallo di date e riprova."
+  },
+  "githubIssuesFetchError": {
+    "message": "Errore durante il recupero delle issue di GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Errore durante il recupero dei dati di revisione PR di GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Errore durante il recupero dei dati dell'utente GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Token GitHub non valido o scaduto. Verifica il tuo token nelle impostazioni di Scrum Helper e riprova."
+  },
+  "displayModeNotice": {
+    "message": "L'estensione si aprirà in modalità $1 al prossimo avvio."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Il filtro dei repository è disponibile solo per GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Il caricamento dei repository è disponibile solo per GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Il recupero dei repository è disponibile solo per GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Caricamento automatico dei repository.."
+  },
+  "gitlabUserFetchError": {
+    "message": "Errore durante il recupero dell'utente GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Utente GitLab '$1' non trovato"
+  },
+  "gitlabMembershipError": {
+    "message": "Errore durante il recupero dei progetti di appartenenza GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Errore durante il recupero dei progetti a cui l'utente ha contribuito su GitLab: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Nome utente richiesto."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Generazione del report..."
+  },
+  "copyingReportNotification": {
+    "message": "Copia del report..."
+  },
+  "copiedReportNotification": {
+    "message": "Report copiato!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Inserimento del report nell'email..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Report inserito nell'email!"
+  }
 }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "選択した期間のGitアクティビティを自動的に取得して、開発の進捗を報告します。"
-    },
-    "disableLabel": {
-        "message": "無効にする"
-    },
-    "enableLabel": {
-        "message": "有効にする"
-    },
-    "projectNameLabel": {
-        "message": "プロジェクト名（メールの件名に使用）"
-    },
-    "projectNamePlaceholder": {
-        "message": "メール件名"
-    },
-    "githubUsernameLabel": {
-        "message": "GitHubユーザー名"
-    },
-    "gitlabUsernameLabel": {
-        "message": "GitLabユーザー名"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "コントリビューションの取得に必要です"
-    },
-    "contributionsLabel": {
-        "message": "取得するコントリビューションの期間："
-    },
-    "last1DayLabel": {
-        "message": "前日"
-    },
-    "startDateLabel": {
-        "message": "開始:"
-    },
-    "endDateLabel": {
-        "message": "終了:"
-    },
-    "showOpenClosedLabel": {
-        "message": "オープン/クローズ状態を表示"
-    },
-    "blockersLabel": {
-        "message": "進捗の妨げになっているものは何ですか？"
-    },
-    "blockersPlaceholder": {
-        "message": "理由を入力してください"
-    },
-    "scrumReportLabel": {
-        "message": "スクラムレポート"
-    },
-    "generateReportButton": {
-        "message": "レポートを生成"
-    },
-    "copyReportButton": {
-        "message": "レポートをコピー"
-    },
-    "insertInEmailButton": {
-        "message": "メールに挿入"
-    },
-    "insertToEmailFailedError": {
-        "message": "レポートを挿入するにはメールタブを開いてください"
-    },
-    "settingsOrgNameLabel": {
-        "message": "組織名"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "組織名を入力してください"
-    },
-    "setButton": {
-        "message": "設定"
-    },
-    "githubTokenLabel": {
-        "message": "GitHubトークン"
-    },
-    "githubTokenPlaceholder": {
-        "message": "認証済みリクエストに必要です"
-    },
-    "githubTokenTooltip": {
-        "message": "GitHubトークンを追加することをお勧めするのはなぜですか？Scrum HelperはGitHubトークンなしで機能しますが、より良いエクスペリエンスのためにパーソナルアクセストークンを追加することをお勧めします。"
-    },
-    "gitlabTokenLabel": {
-        "message": "GitLabトークン"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "プライベートプロジェクトへのアクセスに必要です"
-    },
-    "gitlabTokenTooltip": {
-        "message": "GitLabトークンを追加することをお勧めするのはなぜですか？Scrum HelperはパブリックプロジェクトのGitLabトークンなしで機能しますが、より良いエクスペリエンスのためにパーソナルアクセストークンを追加することをお勧めします。"
-    },
-    "showCommitsLabel": {
-        "message": "オープンなPR/ドラフトPRのコミットを表示"
-    },
-    "showCommitsTooltip": {
-        "message": "GitHubトークンが必要です。設定で追加してください。"
-    },
-    "onlyIssuesLabel": {
-        "message": "レポートに課題のみを含める"
-    },
-    "onlyIssuesTooltip": {
-        "message": "チェックした場合、レポートにはユーザーが作成または割り当てられた課題のみが含まれます。"
-    },
-    "onlyPRsLabel": {
-        "message": "レポートにPRのみを含める"
-    },
-    "onlyPRsTooltip": {
-        "message": "チェックすると、レポートにはユーザーが作成したPRのみが含まれ、レビュー済みのPRは除外されます。"
-    },
-    "cacheTTLLabel": {
-        "message": "キャッシュTTLを入力"
-    },
-    "cacheTTLUnit": {
-        "message": "（分）"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "キャッシュTTLを分単位で入力 (デフォルト: 10)"
-    },
-    "refreshDataButton": {
-        "message": "データを更新 (キャッシュを無視)"
-    },
-    "refreshDataInfo": {
-        "message": "このボタンで最新のデータをすぐに取得します。"
-    },
-    "noteTitle": {
-        "message": "注："
-    },
-    "viewCodeButton": {
-        "message": "コードを見る"
-    },
-    "reportIssueButton": {
-        "message": "問題を報告"
-    },
-    "repoFilterLabel": {
-        "message": "リポジトリでフィルタリング"
-    },
-    "enableFilteringLabel": {
-        "message": "フィルタリングを有効にする"
-    },
-    "tokenRequiredWarning": {
-        "message": "リポジトリのフィルタリングにはGitHubトークンが必要です。設定で追加してください。"
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "オープンまたはドラフトPRのコミットを表示するには、GitHubトークンが必要です。設定で追加してください。"
-    },
-    "repoSearchPlaceholder": {
-        "message": "追加するリポジトリを検索..."
-    },
-    "repoPlaceholder": {
-        "message": "リポジトリが選択されていません（すべて含まれます）"
-    },
-    "repoCountNone": {
-        "message": "0件のリポジトリが選択されています"
-    },
-    "repoCount": {
-        "message": "$1件のリポジトリが選択されています"
-    },
-    "clearAllBtn": {
-        "message": "すべてクリア"
-    },
-    "repoLoading": {
-        "message": "リポジトリを読み込み中..."
-    },
-    "repoLoaded": {
-        "message": "$1件のリポジトリを読み込みました。"
-    },
-    "repoNotFound": {
-        "message": "リポジトリが見つかりません"
-    },
-    "repoRefetching": {
-        "message": "リポジトリを再読み込み中..."
-    },
-    "repoLoadFailed": {
-        "message": "リポジトリの読み込みに失敗しました。"
-    },
-    "repoTokenPrivate": {
-        "message": "トークンが無効か、プライベートリポジトリへの権限がありません。"
-    },
-    "repoRefetchFailed": {
-        "message": "リポジトリの再読み込みに失敗しました。"
-    },
-    "orgSetMessage": {
-        "message": "組織が正常に設定されました。"
-    },
-    "orgClearedMessage": {
-        "message": "組織がクリアされました。「レポートを生成」をクリックしてすべてのアクティビティを取得してください。"
-    },
-    "orgNotFoundMessage": {
-        "message": "GitHubで組織が見つかりません。"
-    },
-    "orgValidationErrorMessage": {
-        "message": "組織の検証中にエラーが発生しました。"
-    },
-    "refreshingButton": {
-        "message": "更新中..."
-    },
-    "cacheClearFailed": {
-        "message": "キャッシュのクリアに失敗しました。"
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "生成中..."
-    },
-    "copiedButton": {
-        "message": "コピーしました！"
-    },
-    "orgChangedMessage": {
-        "message": "組織が変更されました。「レポートを生成」ボタンをクリックしてGitHubアクティビティを取得してください。"
-    },
-    "cacheClearedMessage": {
-        "message": "キャッシュが正常にクリアされました。「レポートを生成」をクリックして新しいデータを取得してください。"
-    },
-    "cacheExpiredMessage": {
-        "message": "キャッシュの有効期限が切れました。「生成」をクリックして最新のデータを取得してください。"
-    },
-    "cacheClearedButton": {
-        "message": "キャッシュクリア！"
-    },
-    "extensionDisabledMessage": {
-        "message": "拡張機能が無効です。スクラムレポートを生成するには、オプションから有効にしてください。"
-    },
-    "notePoint1": {
-        "message": "プルリクエストは、自分だけでなく、任意のコントリビューターによる最新のレビューアクティビティに基づいて取得されます。共有する前に、生成されたSCRUMレポートを確認および調整して、作業が正確に反映されていることを確認してください。"
-    },
-    "noteSeeIssue": {
-        "message": "このIssueを参照"
-    },
-    "platformLabel": {
-        "message": "プラットフォーム"
-    },
-    "usernameLabel": {
-        "message": "あなたのユーザー名"
-    },
-    "onlyRevPRsLabel": {
-        "message": "レポートにレビュー済みのPRのみを含める"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "チェックした場合、レポートにはあなたがレビューしたPRのみが含まれます。"
-    },
-    "onlyMergedPRsLabel": {
-        "message": "マージされたPRのみをレポートに含める"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "チェックすると、マージされたPRのみがレポートに含まれます。GitHubトークンが必要です。"
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "マージされたPRでフィルターするには、GitHubトークンが必要です。設定で追加してください。"
-    },
-    "usernameRequiredError": {
-        "message": "レポートを生成するには、ユーザー名を入力してください。"
-    },
-    "unknownPlatformError": {
-        "message": "不明なプラットフォームが選択されました。"
-    },
-    "gitlabFetchingError": {
-        "message": "GitLabデータの取得中にエラーが発生しました。"
-    },
-    "reportGenerationError": {
-        "message": "レポートの生成中にエラーが発生しました。"
-    },
-    "githubUserNotFoundError": {
-        "message": "GitHubユーザー \"$1\" が見つかりませんでした (404)。ユーザー名を確認して再試行してください。"
-    },
-    "githubUserValidationError": {
-        "message": "GitHubユーザーの検証中にエラーが発生しました: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "無効な検索クエリまたは日付範囲です。日付範囲の形式を確認して再試行してください。"
-    },
-    "githubIssuesFetchError": {
-        "message": "GitHubのIssue取得中にエラーが発生しました: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "GitHubのPRレビュー データ取得中にエラーが発生しました: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "GitHubユーザーデータ取得中にエラーが発生しました: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "GitHubトークンが無効または期限切れです。Scrum Helperの設定でトークンを確認し、再試行してください。"
-    },
-    "displayModeNotice": {
-        "message": "拡張機能は次回起動時に $1 モードで開きます。"
-    },
-    "repoFilteringGithubOnly": {
-        "message": "リポジトリのフィルタリングはGitHubでのみ利用可能です。"
-    },
-    "repoLoadingGithubOnly": {
-        "message": "リポジトリの読み込みはGitHubでのみ利用可能です。"
-    },
-    "repoFetchingGithubOnly": {
-        "message": "リポジトリの取得はGitHubでのみ利用可能です。"
-    },
-    "loadingReposAutomatically": {
-        "message": "リポジトリを自動的に読み込み中.."
-    },
-    "gitlabUserFetchError": {
-        "message": "GitLabユーザー取得中にエラーが発生しました: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "GitLabユーザー '$1' が見つかりませんでした"
-    },
-    "gitlabMembershipError": {
-        "message": "GitLabのメンバーシッププロジェクト取得中にエラーが発生しました: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "GitLabの貢献プロジェクト取得中にエラーが発生しました: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "ユーザー名が必要です。"
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "レポートを生成中..."
-    },
-    "copyingReportNotification": {
-        "message": "レポートをコピー中..."
-    },
-    "copiedReportNotification": {
-        "message": "レポートがコピーされました！"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "レポートをメールに挿入中..."
-    },
-    "insertedInEmailNotification": {
-        "message": "レポートをメールに挿入しました！"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "選択した期間のGitアクティビティを自動的に取得して、開発の進捗を報告します。"
+  },
+  "disableLabel": {
+    "message": "無効にする"
+  },
+  "enableLabel": {
+    "message": "有効にする"
+  },
+  "projectNameLabel": {
+    "message": "プロジェクト名（メールの件名に使用）"
+  },
+  "projectNamePlaceholder": {
+    "message": "メール件名"
+  },
+  "githubUsernameLabel": {
+    "message": "GitHubユーザー名"
+  },
+  "gitlabUsernameLabel": {
+    "message": "GitLabユーザー名"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "コントリビューションの取得に必要です"
+  },
+  "contributionsLabel": {
+    "message": "取得するコントリビューションの期間："
+  },
+  "last1DayLabel": {
+    "message": "前日"
+  },
+  "lastWeekLabel": {
+    "message": "前週の概要",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "開始:"
+  },
+  "endDateLabel": {
+    "message": "終了:"
+  },
+  "showOpenClosedLabel": {
+    "message": "オープン/クローズ状態を表示"
+  },
+  "blockersLabel": {
+    "message": "進捗の妨げになっているものは何ですか？"
+  },
+  "blockersPlaceholder": {
+    "message": "理由を入力してください"
+  },
+  "scrumReportLabel": {
+    "message": "スクラムレポート"
+  },
+  "generateReportButton": {
+    "message": "レポートを生成"
+  },
+  "copyReportButton": {
+    "message": "レポートをコピー"
+  },
+  "insertInEmailButton": {
+    "message": "メールに挿入"
+  },
+  "insertToEmailFailedError": {
+    "message": "レポートを挿入するにはメールタブを開いてください"
+  },
+  "settingsOrgNameLabel": {
+    "message": "組織名"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "組織名を入力してください"
+  },
+  "setButton": {
+    "message": "設定"
+  },
+  "githubTokenLabel": {
+    "message": "GitHubトークン"
+  },
+  "githubTokenPlaceholder": {
+    "message": "認証済みリクエストに必要です"
+  },
+  "githubTokenTooltip": {
+    "message": "GitHubトークンを追加することをお勧めするのはなぜですか？Scrum HelperはGitHubトークンなしで機能しますが、より良いエクスペリエンスのためにパーソナルアクセストークンを追加することをお勧めします。"
+  },
+  "gitlabTokenLabel": {
+    "message": "GitLabトークン"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "プライベートプロジェクトへのアクセスに必要です"
+  },
+  "gitlabTokenTooltip": {
+    "message": "GitLabトークンを追加することをお勧めするのはなぜですか？Scrum HelperはパブリックプロジェクトのGitLabトークンなしで機能しますが、より良いエクスペリエンスのためにパーソナルアクセストークンを追加することをお勧めします。"
+  },
+  "showCommitsLabel": {
+    "message": "オープンなPR/ドラフトPRのコミットを表示"
+  },
+  "showCommitsTooltip": {
+    "message": "GitHubトークンが必要です。設定で追加してください。"
+  },
+  "onlyIssuesLabel": {
+    "message": "レポートに課題のみを含める"
+  },
+  "onlyIssuesTooltip": {
+    "message": "チェックした場合、レポートにはユーザーが作成または割り当てられた課題のみが含まれます。"
+  },
+  "onlyPRsLabel": {
+    "message": "レポートにPRのみを含める"
+  },
+  "onlyPRsTooltip": {
+    "message": "チェックすると、レポートにはユーザーが作成したPRのみが含まれ、レビュー済みのPRは除外されます。"
+  },
+  "cacheTTLLabel": {
+    "message": "キャッシュTTLを入力"
+  },
+  "cacheTTLUnit": {
+    "message": "（分）"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "キャッシュTTLを分単位で入力 (デフォルト: 10)"
+  },
+  "refreshDataButton": {
+    "message": "データを更新 (キャッシュを無視)"
+  },
+  "refreshDataInfo": {
+    "message": "このボタンで最新のデータをすぐに取得します。"
+  },
+  "noteTitle": {
+    "message": "注："
+  },
+  "viewCodeButton": {
+    "message": "コードを見る"
+  },
+  "reportIssueButton": {
+    "message": "問題を報告"
+  },
+  "repoFilterLabel": {
+    "message": "リポジトリでフィルタリング"
+  },
+  "enableFilteringLabel": {
+    "message": "フィルタリングを有効にする"
+  },
+  "tokenRequiredWarning": {
+    "message": "リポジトリのフィルタリングにはGitHubトークンが必要です。設定で追加してください。"
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "オープンまたはドラフトPRのコミットを表示するには、GitHubトークンが必要です。設定で追加してください。"
+  },
+  "repoSearchPlaceholder": {
+    "message": "追加するリポジトリを検索..."
+  },
+  "repoPlaceholder": {
+    "message": "リポジトリが選択されていません（すべて含まれます）"
+  },
+  "repoCountNone": {
+    "message": "0件のリポジトリが選択されています"
+  },
+  "repoCount": {
+    "message": "$1件のリポジトリが選択されています"
+  },
+  "clearAllBtn": {
+    "message": "すべてクリア"
+  },
+  "repoLoading": {
+    "message": "リポジトリを読み込み中..."
+  },
+  "repoLoaded": {
+    "message": "$1件のリポジトリを読み込みました。"
+  },
+  "repoNotFound": {
+    "message": "リポジトリが見つかりません"
+  },
+  "repoRefetching": {
+    "message": "リポジトリを再読み込み中..."
+  },
+  "repoLoadFailed": {
+    "message": "リポジトリの読み込みに失敗しました。"
+  },
+  "repoTokenPrivate": {
+    "message": "トークンが無効か、プライベートリポジトリへの権限がありません。"
+  },
+  "repoRefetchFailed": {
+    "message": "リポジトリの再読み込みに失敗しました。"
+  },
+  "orgSetMessage": {
+    "message": "組織が正常に設定されました。"
+  },
+  "orgClearedMessage": {
+    "message": "組織がクリアされました。「レポートを生成」をクリックしてすべてのアクティビティを取得してください。"
+  },
+  "orgNotFoundMessage": {
+    "message": "GitHubで組織が見つかりません。"
+  },
+  "orgValidationErrorMessage": {
+    "message": "組織の検証中にエラーが発生しました。"
+  },
+  "refreshingButton": {
+    "message": "更新中..."
+  },
+  "cacheClearFailed": {
+    "message": "キャッシュのクリアに失敗しました。"
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "生成中..."
+  },
+  "copiedButton": {
+    "message": "コピーしました！"
+  },
+  "orgChangedMessage": {
+    "message": "組織が変更されました。「レポートを生成」ボタンをクリックしてGitHubアクティビティを取得してください。"
+  },
+  "cacheClearedMessage": {
+    "message": "キャッシュが正常にクリアされました。「レポートを生成」をクリックして新しいデータを取得してください。"
+  },
+  "cacheExpiredMessage": {
+    "message": "キャッシュの有効期限が切れました。「生成」をクリックして最新のデータを取得してください。"
+  },
+  "cacheClearedButton": {
+    "message": "キャッシュクリア！"
+  },
+  "extensionDisabledMessage": {
+    "message": "拡張機能が無効です。スクラムレポートを生成するには、オプションから有効にしてください。"
+  },
+  "notePoint1": {
+    "message": "プルリクエストは、自分だけでなく、任意のコントリビューターによる最新のレビューアクティビティに基づいて取得されます。共有する前に、生成されたSCRUMレポートを確認および調整して、作業が正確に反映されていることを確認してください。"
+  },
+  "noteSeeIssue": {
+    "message": "このIssueを参照"
+  },
+  "platformLabel": {
+    "message": "プラットフォーム"
+  },
+  "usernameLabel": {
+    "message": "あなたのユーザー名"
+  },
+  "onlyRevPRsLabel": {
+    "message": "レポートにレビュー済みのPRのみを含める"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "チェックした場合、レポートにはあなたがレビューしたPRのみが含まれます。"
+  },
+  "onlyMergedPRsLabel": {
+    "message": "マージされたPRのみをレポートに含める"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "チェックすると、マージされたPRのみがレポートに含まれます。GitHubトークンが必要です。"
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "マージされたPRでフィルターするには、GitHubトークンが必要です。設定で追加してください。"
+  },
+  "usernameRequiredError": {
+    "message": "レポートを生成するには、ユーザー名を入力してください。"
+  },
+  "unknownPlatformError": {
+    "message": "不明なプラットフォームが選択されました。"
+  },
+  "gitlabFetchingError": {
+    "message": "GitLabデータの取得中にエラーが発生しました。"
+  },
+  "reportGenerationError": {
+    "message": "レポートの生成中にエラーが発生しました。"
+  },
+  "githubUserNotFoundError": {
+    "message": "GitHubユーザー \"$1\" が見つかりませんでした (404)。ユーザー名を確認して再試行してください。"
+  },
+  "githubUserValidationError": {
+    "message": "GitHubユーザーの検証中にエラーが発生しました: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "無効な検索クエリまたは日付範囲です。日付範囲の形式を確認して再試行してください。"
+  },
+  "githubIssuesFetchError": {
+    "message": "GitHubのIssue取得中にエラーが発生しました: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "GitHubのPRレビュー データ取得中にエラーが発生しました: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "GitHubユーザーデータ取得中にエラーが発生しました: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "GitHubトークンが無効または期限切れです。Scrum Helperの設定でトークンを確認し、再試行してください。"
+  },
+  "displayModeNotice": {
+    "message": "拡張機能は次回起動時に $1 モードで開きます。"
+  },
+  "repoFilteringGithubOnly": {
+    "message": "リポジトリのフィルタリングはGitHubでのみ利用可能です。"
+  },
+  "repoLoadingGithubOnly": {
+    "message": "リポジトリの読み込みはGitHubでのみ利用可能です。"
+  },
+  "repoFetchingGithubOnly": {
+    "message": "リポジトリの取得はGitHubでのみ利用可能です。"
+  },
+  "loadingReposAutomatically": {
+    "message": "リポジトリを自動的に読み込み中.."
+  },
+  "gitlabUserFetchError": {
+    "message": "GitLabユーザー取得中にエラーが発生しました: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "GitLabユーザー '$1' が見つかりませんでした"
+  },
+  "gitlabMembershipError": {
+    "message": "GitLabのメンバーシッププロジェクト取得中にエラーが発生しました: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "GitLabの貢献プロジェクト取得中にエラーが発生しました: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "ユーザー名が必要です。"
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "レポートを生成中..."
+  },
+  "copyingReportNotification": {
+    "message": "レポートをコピー中..."
+  },
+  "copiedReportNotification": {
+    "message": "レポートがコピーされました！"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "レポートをメールに挿入中..."
+  },
+  "insertedInEmailNotification": {
+    "message": "レポートをメールに挿入しました！"
+  }
 }

--- a/src/_locales/ml/messages.json
+++ b/src/_locales/ml/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "തിരഞ്ഞെടുത്ത കാലയളവിലെ നിങ്ങളുടെ Git പ്രവർത്തനങ്ങൾ സ്വയമേവ ശേഖരിച്ചു നിങ്ങളുടെ വികസന പുരോഗതി റിപ്പോർട്ട് ചെയ്യുക"
-    },
-    "disableLabel": {
-        "message": "അപ്രാപ്തമാക്കുക"
-    },
-    "enableLabel": {
-        "message": "സജീവമാക്കുക"
-    },
-    "projectNameLabel": {
-        "message": "പ്രോജക്ട് പേര് (ഇമെയിൽ വിഷയം ആയി ഉപയോഗിക്കും)"
-    },
-    "projectNamePlaceholder": {
-        "message": "നിങ്ങളുടെ പ്രോജക്ട് പേര് നൽകുക"
-    },
-    "githubUsernameLabel": {
-        "message": "നിങ്ങളുടെ GitHub ഉപയോക്തൃനാമം"
-    },
-    "gitlabUsernameLabel": {
-        "message": "നിങ്ങളുടെ GitLab ഉപയോക്തൃനാമം"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "നിങ്ങളുടെ സംഭാവനകൾ ശേഖരിക്കാൻ ആവശ്യമാണ്"
-    },
-    "contributionsLabel": {
-        "message": "ഈ സമയപരിധിക്കുള്ളിൽ നിങ്ങളുടെ സംഭാവനകൾ ശേഖരിക്കുക:"
-    },
-    "last1DayLabel": {
-        "message": "മുൻ ദിവസം"
-    },
-    "startDateLabel": {
-        "message": "മുതൽ:"
-    },
-    "endDateLabel": {
-        "message": "വരെ:"
-    },
-    "showOpenClosedLabel": {
-        "message": "PR ലേബലുകൾ കാണിക്കുക"
-    },
-    "blockersLabel": {
-        "message": "നിങ്ങളുടെ പുരോഗതിയെ തടയുന്നത് എന്താണ്?"
-    },
-    "blockersPlaceholder": {
-        "message": "നിങ്ങളുടെ കാരണം നൽകുക"
-    },
-    "scrumReportLabel": {
-        "message": "സ്ക്രം റിപ്പോർട്ട്"
-    },
-    "generateReportButton": {
-        "message": "റിപ്പോർട്ട് സൃഷ്ടിക്കുക"
-    },
-    "copyReportButton": {
-        "message": "റിപ്പോർട്ട് പകർത്തുക"
-    },
-    "insertInEmailButton": {
-        "message": "ഇമെയിലിൽ ചേർക്കുക"
-    },
-    "insertToEmailFailedError": {
-        "message": "റിപ്പോർട്ട് ചേർക്കാൻ ഒരു ഇമെയിൽ ടാബ് തുറക്കുക"
-    },
-    "settingsOrgNameLabel": {
-        "message": "സ്ഥാപനത്തിന്റെ പേര്"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "സ്ഥാപനത്തിന്റെ പേര് നൽകുക"
-    },
-    "setButton": {
-        "message": "സെറ്റ് ചെയ്യുക"
-    },
-    "githubTokenLabel": {
-        "message": "നിങ്ങളുടെ GitHub ടോക്കൺ"
-    },
-    "githubTokenPlaceholder": {
-        "message": "ഓതന്റിക്കേറ്റഡ് അഭ്യർത്ഥനകൾക്കായി ആവശ്യമാണ്"
-    },
-    "githubTokenTooltip": {
-        "message": "GitHub ടോക്കൻ ചേർക്കാൻ എന്ത് ശുപാർശ ചെയ്യുന്നത്? സ്ക്രം ഹെൽപർ GitHub ടോക്കൻ ഇല്ലാതെ പ്രവർത്തിക്കുന്നു, എന്നാൽ നല്ലതായ അനുഭവത്തിന് പ്രത്യക്ഷ ആക്സസ് ടോക്കൻ ചേർക്കാൻ ശുപാർശ ചെയ്യുന്നു."
-    },
-    "gitlabTokenLabel": {
-        "message": "നിങ്ങളുടെ GitLab ടോക്കൺ"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "സ്വകാര്യ പ്രോജക്ടുകൾ ആക്സസ് ചെയ്യാൻ ആവശ്യമാണ്"
-    },
-    "gitlabTokenTooltip": {
-        "message": "GitLab ടോക്കൻ ചേർക്കാൻ എന്ത് ശുപാർശ ചെയ്യുന്നത്? സ്ക്രം ഹെൽപർ പബ്ലിക് പ്രോജക്ടുകൾക്കായി GitLab ടോക്കൻ ഇല്ലാതെ പ്രവർത്തിക്കുന്നു, എന്നാൽ നല്ലതായ അനുഭവത്തിന് പ്രത്യക്ഷ ആക്സസ് ടോക്കൻ ചേർക്കാൻ ശുപാർശ ചെയ്യുന്നു."
-    },
-    "showCommitsLabel": {
-        "message": "ഓപ്പൺ / ഡ്രാഫ്റ്റ് PRകളിലെ കമ്മിറ്റുകൾ കാണിക്കുക"
-    },
-    "showCommitsTooltip": {
-        "message": "GitHub ടോക്കൺ ആവശ്യമാണ്, ദയവായി സെറ്റിംഗ്സിൽ ചേർക്കുക."
-    },
-    "onlyIssuesLabel": {
-        "message": "റിപ്പോർട്ടിൽ ഇഷ്യൂകൾ മാത്രം ഉൾപ്പെടുത്തുക"
-    },
-    "onlyIssuesTooltip": {
-        "message": "തിരഞ്ഞെടുത്താൽ, ഉപയോക്താവ് സൃഷ്ടിച്ചതോ ഏൽപ്പിച്ചതോ ആയ ഇഷ്യൂകൾ മാത്രം റിപ്പോർട്ടിൽ ഉൾപ്പെടും."
-    },
-    "onlyPRsLabel": {
-        "message": "റിപ്പോർട്ടിൽ PRകൾ മാത്രം ഉൾപ്പെടുത്തുക"
-    },
-    "onlyPRsTooltip": {
-        "message": "തിരഞ്ഞെടുത്താൽ, നിങ്ങൾ സൃഷ്ടിച്ച PRകൾ മാത്രം റിപ്പോർട്ടിൽ ഉൾപ്പെടും. റിവ്യൂ ചെയ്ത PRകൾ ഒഴിവാക്കപ്പെടും."
-    },
-    "cacheTTLLabel": {
-        "message": "കാഷ് TTL നൽകുക"
-    },
-    "cacheTTLUnit": {
-        "message": "(മിനിറ്റുകളിൽ)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "കാഷ് TTL മിനിറ്റുകളിൽ നൽകുക (ഡിഫോൾട്ട് 10 മിനിറ്റ്)"
-    },
-    "refreshDataButton": {
-        "message": "ഡാറ്റ പുതുക്കുക (കാഷ് ഒഴിവാക്കി)"
-    },
-    "refreshDataInfo": {
-        "message": "പുതിയ ഡാറ്റ ഉടൻ ശേഖരിക്കാൻ ഈ ബട്ടൺ ഉപയോഗിക്കുക."
-    },
-    "noteTitle": {
-        "message": "കുറിപ്പ്:"
-    },
-    "viewCodeButton": {
-        "message": "കോഡ് കാണുക"
-    },
-    "reportIssueButton": {
-        "message": "പ്രശ്നം റിപ്പോർട്ട് ചെയ്യുക"
-    },
-    "repoFilterLabel": {
-        "message": "റിപ്പോസിറ്ററികളിലൂടെ ഫിൽറ്റർ ചെയ്യുക"
-    },
-    "enableFilteringLabel": {
-        "message": "ഫിൽറ്ററിംഗ് സജീവമാക്കുക"
-    },
-    "tokenRequiredWarning": {
-        "message": "റിപ്പോസിറ്ററി ഫിൽറ്ററിംഗിന് GitHub ടോക്കൺ ആവശ്യമാണ്. ദയവായി സെറ്റിംഗ്സിൽ ചേർക്കുക."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "ഓപ്പൺ അല്ലെങ്കിൽ ഡ്രാഫ്റ്റ് പിആർ-കളിലെ കമ്മിറ്റുകൾ കാണിക്കാൻ ഒരു GitHub ടോക്കൺ ആവശ്യമാണ്. ദയവായി ക്രമീകരണങ്ങളിൽ ഒന്ന് ചേർക്കുക."
-    },
-    "repoSearchPlaceholder": {
-        "message": "ചേർക്കാനുള്ള റിപ്പോസിറ്ററി തിരയുക..."
-    },
-    "repoPlaceholder": {
-        "message": "റിപ്പോസിറ്ററികളൊന്നും തിരഞ്ഞെടുത്തിട്ടില്ല (എല്ലാം ഉൾപ്പെടും)"
-    },
-    "repoCountNone": {
-        "message": "0 റിപ്പോസിറ്ററികൾ തിരഞ്ഞെടുത്തു"
-    },
-    "repoCount": {
-        "message": "$1 റിപ്പോസിറ്ററികൾ തിരഞ്ഞെടുത്തു"
-    },
-    "clearAllBtn": {
-        "message": "എല്ലാം മായ്ക്കുക"
-    },
-    "repoLoading": {
-        "message": "റിപ്പോസിറ്ററികൾ ലോഡ് ചെയ്യുന്നു..."
-    },
-    "repoLoaded": {
-        "message": "$1 റിപ്പോസിറ്ററികൾ ലോഡ് ചെയ്തു."
-    },
-    "repoNotFound": {
-        "message": "റിപ്പോസിറ്ററികൾ കണ്ടെത്തിയില്ല"
-    },
-    "repoRefetching": {
-        "message": "റിപ്പോസിറ്ററികൾ വീണ്ടും ശേഖരിക്കുന്നു..."
-    },
-    "repoLoadFailed": {
-        "message": "റിപ്പോസിറ്ററികൾ ലോഡ് ചെയ്യാൻ പരാജയപ്പെട്ടു."
-    },
-    "repoTokenPrivate": {
-        "message": "ടോക്കൺ അസാധുവാണ് അല്ലെങ്കിൽ സ്വകാര്യ റിപ്പോസിറ്ററികൾക്ക് അനുമതിയില്ല."
-    },
-    "repoRefetchFailed": {
-        "message": "റിപ്പോസിറ്ററികൾ വീണ്ടും ശേഖരിക്കാൻ പരാജയപ്പെട്ടു."
-    },
-    "orgSetMessage": {
-        "message": "സ്ഥാപനം വിജയകരമായി സെറ്റ് ചെയ്തു."
-    },
-    "orgClearedMessage": {
-        "message": "സ്ഥാപനം നീക്കം ചെയ്തു. എല്ലാ പ്രവർത്തനങ്ങളും ശേഖരിക്കാൻ 'റിപ്പോർട്ട് സൃഷ്ടിക്കുക' ക്ലിക്ക് ചെയ്യുക."
-    },
-    "orgNotFoundMessage": {
-        "message": "GitHub-ൽ സ്ഥാപനം കണ്ടെത്തിയില്ല."
-    },
-    "orgValidationErrorMessage": {
-        "message": "സ്ഥാപനം സ്ഥിരീകരിക്കുന്നതിൽ പിശക്."
-    },
-    "refreshingButton": {
-        "message": "പുതുക്കുന്നു..."
-    },
-    "cacheClearFailed": {
-        "message": "കാഷ് ക്ലിയർ ചെയ്യൽ പരാജയപ്പെട്ടു."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "സൃഷ്ടിക്കുന്നു..."
-    },
-    "copiedButton": {
-        "message": "പകർത്തി!"
-    },
-    "orgChangedMessage": {
-        "message": "സംഘടന മാറി. GitHub പ്രവർത്തനങ്ങൾ ശേഖരിക്കാൻ റിപ്പോർട്ട് സൃഷ്ടിക്കുക ബട്ടൺ ക്ലിക്ക് ചെയ്യുക."
-    },
-    "cacheClearedMessage": {
-        "message": "കാഷ് വിജയകരമായി ക്ലിയർ ചെയ്തു. പുതിയ ഡാറ്റയ്ക്കായി \"റിപ്പോർട്ട് സൃഷ്ടിക്കുക\" ക്ലിക്ക് ചെയ്യുക."
-    },
-    "cacheExpiredMessage": {
-        "message": "കാഷ് കാലഹരണപ്പെട്ടു. പുതിയ ഡാറ്റ ലഭിക്കാൻ \"റിപ്പോർട്ട് സൃഷ്ടിക്കുക\" ക്ലിക്ക് ചെയ്യുക."
-    },
-    "cacheClearedButton": {
-        "message": "കാഷ് ക്ലിയർ ചെയ്തു!"
-    },
-    "extensionDisabledMessage": {
-        "message": "എക്സ്റ്റെൻഷൻ അപ്രാപ്തമാണ്. സ്ക്രം റിപ്പോർട്ടുകൾ സൃഷ്ടിക്കാൻ ഓപ്ഷനുകളിൽ നിന്ന് സജീവമാക്കുക."
-    },
-    "notePoint1": {
-        "message": "Pull request-കൾ നിങ്ങൾ മാത്രമല്ല, മറ്റ് സംഭാവനകർത്താക്കളുടെ ഏറ്റവും പുതിയ റിവ്യൂ പ്രവർത്തനത്തെ അടിസ്ഥാനമാക്കിയാണ് ശേഖരിക്കുന്നത്. പങ്കിടുന്നതിന് മുമ്പ് സൃഷ്ടിച്ച SCRUM റിപ്പോർട്ട് നിങ്ങളുടെ പ്രവർത്തനം ശരിയായി പ്രതിഫലിപ്പിക്കുന്നുവെന്ന് ഉറപ്പാക്കാൻ പരിശോധിച്ച് തിരുത്തുക."
-    },
-    "noteSeeIssue": {
-        "message": "ഈ ഇഷ്യൂ കാണുക"
-    },
-    "platformLabel": {
-        "message": "പ്ലാറ്റ്ഫോം"
-    },
-    "usernameLabel": {
-        "message": "നിങ്ങളുടെ ഉപയോക്തൃനാമം"
-    },
-    "onlyRevPRsLabel": {
-        "message": "റിപ്പോർട്ടിൽ റിവ്യൂ ചെയ്ത PRകൾ മാത്രം ഉൾപ്പെടുത്തുക"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "തിരഞ്ഞെടുത്താൽ, നിങ്ങൾ റിവ്യൂ ചെയ്ത PRകൾ മാത്രം റിപ്പോർട്ടിൽ ഉൾപ്പെടും."
-    },
-    "onlyMergedPRsLabel": {
-        "message": "ലയിപ്പിച്ച (merged) പിആറുകൾ മാത്രം റിപ്പോർട്ടിൽ ഉൾപ്പെടുത്തുക"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "തിരഞ്ഞെടുത്താൽ, ലയിപ്പിച്ച പിആറുകൾ മാത്രമേ റിപ്പോർട്ടിൽ ഉൾപ്പെടുത്തൂ. ഒരു GitHub ടോക്കൺ ആവശ്യമാണ്."
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "ലയിപ്പിച്ച പിആറുകൾ അനുസരിച്ച് ഫിൽട്ടർ ചെയ്യാൻ ഒരു GitHub ടോക്കൺ ആവശ്യമാണ്. ദയവായി ക്രമീകരണങ്ങളിൽ ഒന്ന് ചേർക്കുക."
-    },
-    "usernameRequiredError": {
-        "message": "റിപ്പോർട്ട് സൃഷ്ടിക്കാൻ നിങ്ങളുടെ ഉപയോക്തൃനാമം നൽകുക."
-    },
-    "unknownPlatformError": {
-        "message": "അജ്ഞാതമായ പ്ലാറ്റ്ഫോം തിരഞ്ഞെടുത്തു."
-    },
-    "gitlabFetchingError": {
-        "message": "GitLab ഡാറ്റ ശേഖരിക്കുന്നതിൽ പിശകുണ്ടായി."
-    },
-    "reportGenerationError": {
-        "message": "റിപ്പോർട്ട് സൃഷ്ടിക്കുന്നതിൽ പിശകുണ്ടായി."
-    },
-    "githubUserNotFoundError": {
-        "message": "GitHub ഉപയോക്താവ് \"$1\" കണ്ടെത്തിയില്ല (404). ഉപയോക്തൃനാമം പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
-    },
-    "githubUserValidationError": {
-        "message": "GitHub ഉപയോക്താവ് സ്ഥിരീകരിക്കുന്നതിൽ പിശക്: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "അസാധുവായ തിരയൽ ക്വറി അല്ലെങ്കിൽ തീയതി പരിധി. നിങ്ങളുടെ തീയതി പരിധി ഫോർമാറ്റ് പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
-    },
-    "githubIssuesFetchError": {
-        "message": "GitHub ഇഷ്യൂകൾ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "GitHub PR റിവ്യൂ ഡാറ്റ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "GitHub ഉപയോക്തൃ ഡാറ്റ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "അസാധുവായ അല്ലെങ്കിൽ കാലഹരണപ്പെട്ട GitHub ടോക്കൺ. Scrum Helper സെറ്റിംഗ്സിൽ നിങ്ങളുടെ ടോക്കൺ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
-    },
-    "displayModeNotice": {
-        "message": "അടുത്ത സമാരംഭത്തിൽ എക്സ്റ്റെൻഷൻ $1 മോഡിൽ തുറക്കും."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "റിപ്പോസിറ്ററി ഫിൽറ്ററിംഗ് GitHub-ന് മാത്രമേ ലഭ്യമാകൂ."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "റിപ്പോസിറ്ററി ലോഡിംഗ് GitHub-ന് മാത്രമേ ലഭ്യമാകൂ."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "റിപ്പോസിറ്ററി ശേഖരണം GitHub-ന് മാത്രമേ ലഭ്യമാകൂ."
-    },
-    "loadingReposAutomatically": {
-        "message": "റിപ്പോസിറ്ററികൾ സ്വയമേവ ലോഡ് ചെയ്യുന്നു..."
-    },
-    "gitlabUserFetchError": {
-        "message": "GitLab ഉപയോക്താവിനെ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "GitLab ഉപയോക്താവ് '$1' കണ്ടെത്തിയില്ല"
-    },
-    "gitlabMembershipError": {
-        "message": "GitLab അംഗത്വ പ്രോജക്ടുകൾ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "GitLab സംഭാവന പ്രോജക്ടുകൾ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "ഉപയോക്തൃനാമം ആവശ്യമാണ്."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "റിപ്പോർട്ട് തയ്യാറാക്കുന്നു..."
-    },
-    "copyingReportNotification": {
-        "message": "റിപ്പോർട്ട് പകർത്തുന്നു..."
-    },
-    "copiedReportNotification": {
-        "message": "റിപ്പോർട്ട് കോപ്പി ചെയ്തു!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "റിപ്പോർട്ട് ഇമെയിലിൽ ചേർക്കുന്നു..."
-    },
-    "insertedInEmailNotification": {
-        "message": "റിപ്പോർട്ട് ഇമെയിലിൽ ചേർത്തു!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "തിരഞ്ഞെടുത്ത കാലയളവിലെ നിങ്ങളുടെ Git പ്രവർത്തനങ്ങൾ സ്വയമേവ ശേഖരിച്ചു നിങ്ങളുടെ വികസന പുരോഗതി റിപ്പോർട്ട് ചെയ്യുക"
+  },
+  "disableLabel": {
+    "message": "അപ്രാപ്തമാക്കുക"
+  },
+  "enableLabel": {
+    "message": "സജീവമാക്കുക"
+  },
+  "projectNameLabel": {
+    "message": "പ്രോജക്ട് പേര് (ഇമെയിൽ വിഷയം ആയി ഉപയോഗിക്കും)"
+  },
+  "projectNamePlaceholder": {
+    "message": "നിങ്ങളുടെ പ്രോജക്ട് പേര് നൽകുക"
+  },
+  "githubUsernameLabel": {
+    "message": "നിങ്ങളുടെ GitHub ഉപയോക്തൃനാമം"
+  },
+  "gitlabUsernameLabel": {
+    "message": "നിങ്ങളുടെ GitLab ഉപയോക്തൃനാമം"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "നിങ്ങളുടെ സംഭാവനകൾ ശേഖരിക്കാൻ ആവശ്യമാണ്"
+  },
+  "contributionsLabel": {
+    "message": "ഈ സമയപരിധിക്കുള്ളിൽ നിങ്ങളുടെ സംഭാവനകൾ ശേഖരിക്കുക:"
+  },
+  "last1DayLabel": {
+    "message": "മുൻ ദിവസം"
+  },
+  "lastWeekLabel": {
+    "message": "കഴിഞ്ഞ ആഴ്ചയിലെ സംഗ്രഹം",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "മുതൽ:"
+  },
+  "endDateLabel": {
+    "message": "വരെ:"
+  },
+  "showOpenClosedLabel": {
+    "message": "PR ലേബലുകൾ കാണിക്കുക"
+  },
+  "blockersLabel": {
+    "message": "നിങ്ങളുടെ പുരോഗതിയെ തടയുന്നത് എന്താണ്?"
+  },
+  "blockersPlaceholder": {
+    "message": "നിങ്ങളുടെ കാരണം നൽകുക"
+  },
+  "scrumReportLabel": {
+    "message": "സ്ക്രം റിപ്പോർട്ട്"
+  },
+  "generateReportButton": {
+    "message": "റിപ്പോർട്ട് സൃഷ്ടിക്കുക"
+  },
+  "copyReportButton": {
+    "message": "റിപ്പോർട്ട് പകർത്തുക"
+  },
+  "insertInEmailButton": {
+    "message": "ഇമെയിലിൽ ചേർക്കുക"
+  },
+  "insertToEmailFailedError": {
+    "message": "റിപ്പോർട്ട് ചേർക്കാൻ ഒരു ഇമെയിൽ ടാബ് തുറക്കുക"
+  },
+  "settingsOrgNameLabel": {
+    "message": "സ്ഥാപനത്തിന്റെ പേര്"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "സ്ഥാപനത്തിന്റെ പേര് നൽകുക"
+  },
+  "setButton": {
+    "message": "സെറ്റ് ചെയ്യുക"
+  },
+  "githubTokenLabel": {
+    "message": "നിങ്ങളുടെ GitHub ടോക്കൺ"
+  },
+  "githubTokenPlaceholder": {
+    "message": "ഓതന്റിക്കേറ്റഡ് അഭ്യർത്ഥനകൾക്കായി ആവശ്യമാണ്"
+  },
+  "githubTokenTooltip": {
+    "message": "GitHub ടോക്കൻ ചേർക്കാൻ എന്ത് ശുപാർശ ചെയ്യുന്നത്? സ്ക്രം ഹെൽപർ GitHub ടോക്കൻ ഇല്ലാതെ പ്രവർത്തിക്കുന്നു, എന്നാൽ നല്ലതായ അനുഭവത്തിന് പ്രത്യക്ഷ ആക്സസ് ടോക്കൻ ചേർക്കാൻ ശുപാർശ ചെയ്യുന്നു."
+  },
+  "gitlabTokenLabel": {
+    "message": "നിങ്ങളുടെ GitLab ടോക്കൺ"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "സ്വകാര്യ പ്രോജക്ടുകൾ ആക്സസ് ചെയ്യാൻ ആവശ്യമാണ്"
+  },
+  "gitlabTokenTooltip": {
+    "message": "GitLab ടോക്കൻ ചേർക്കാൻ എന്ത് ശുപാർശ ചെയ്യുന്നത്? സ്ക്രം ഹെൽപർ പബ്ലിക് പ്രോജക്ടുകൾക്കായി GitLab ടോക്കൻ ഇല്ലാതെ പ്രവർത്തിക്കുന്നു, എന്നാൽ നല്ലതായ അനുഭവത്തിന് പ്രത്യക്ഷ ആക്സസ് ടോക്കൻ ചേർക്കാൻ ശുപാർശ ചെയ്യുന്നു."
+  },
+  "showCommitsLabel": {
+    "message": "ഓപ്പൺ / ഡ്രാഫ്റ്റ് PRകളിലെ കമ്മിറ്റുകൾ കാണിക്കുക"
+  },
+  "showCommitsTooltip": {
+    "message": "GitHub ടോക്കൺ ആവശ്യമാണ്, ദയവായി സെറ്റിംഗ്സിൽ ചേർക്കുക."
+  },
+  "onlyIssuesLabel": {
+    "message": "റിപ്പോർട്ടിൽ ഇഷ്യൂകൾ മാത്രം ഉൾപ്പെടുത്തുക"
+  },
+  "onlyIssuesTooltip": {
+    "message": "തിരഞ്ഞെടുത്താൽ, ഉപയോക്താവ് സൃഷ്ടിച്ചതോ ഏൽപ്പിച്ചതോ ആയ ഇഷ്യൂകൾ മാത്രം റിപ്പോർട്ടിൽ ഉൾപ്പെടും."
+  },
+  "onlyPRsLabel": {
+    "message": "റിപ്പോർട്ടിൽ PRകൾ മാത്രം ഉൾപ്പെടുത്തുക"
+  },
+  "onlyPRsTooltip": {
+    "message": "തിരഞ്ഞെടുത്താൽ, നിങ്ങൾ സൃഷ്ടിച്ച PRകൾ മാത്രം റിപ്പോർട്ടിൽ ഉൾപ്പെടും. റിവ്യൂ ചെയ്ത PRകൾ ഒഴിവാക്കപ്പെടും."
+  },
+  "cacheTTLLabel": {
+    "message": "കാഷ് TTL നൽകുക"
+  },
+  "cacheTTLUnit": {
+    "message": "(മിനിറ്റുകളിൽ)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "കാഷ് TTL മിനിറ്റുകളിൽ നൽകുക (ഡിഫോൾട്ട് 10 മിനിറ്റ്)"
+  },
+  "refreshDataButton": {
+    "message": "ഡാറ്റ പുതുക്കുക (കാഷ് ഒഴിവാക്കി)"
+  },
+  "refreshDataInfo": {
+    "message": "പുതിയ ഡാറ്റ ഉടൻ ശേഖരിക്കാൻ ഈ ബട്ടൺ ഉപയോഗിക്കുക."
+  },
+  "noteTitle": {
+    "message": "കുറിപ്പ്:"
+  },
+  "viewCodeButton": {
+    "message": "കോഡ് കാണുക"
+  },
+  "reportIssueButton": {
+    "message": "പ്രശ്നം റിപ്പോർട്ട് ചെയ്യുക"
+  },
+  "repoFilterLabel": {
+    "message": "റിപ്പോസിറ്ററികളിലൂടെ ഫിൽറ്റർ ചെയ്യുക"
+  },
+  "enableFilteringLabel": {
+    "message": "ഫിൽറ്ററിംഗ് സജീവമാക്കുക"
+  },
+  "tokenRequiredWarning": {
+    "message": "റിപ്പോസിറ്ററി ഫിൽറ്ററിംഗിന് GitHub ടോക്കൺ ആവശ്യമാണ്. ദയവായി സെറ്റിംഗ്സിൽ ചേർക്കുക."
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "ഓപ്പൺ അല്ലെങ്കിൽ ഡ്രാഫ്റ്റ് പിആർ-കളിലെ കമ്മിറ്റുകൾ കാണിക്കാൻ ഒരു GitHub ടോക്കൺ ആവശ്യമാണ്. ദയവായി ക്രമീകരണങ്ങളിൽ ഒന്ന് ചേർക്കുക."
+  },
+  "repoSearchPlaceholder": {
+    "message": "ചേർക്കാനുള്ള റിപ്പോസിറ്ററി തിരയുക..."
+  },
+  "repoPlaceholder": {
+    "message": "റിപ്പോസിറ്ററികളൊന്നും തിരഞ്ഞെടുത്തിട്ടില്ല (എല്ലാം ഉൾപ്പെടും)"
+  },
+  "repoCountNone": {
+    "message": "0 റിപ്പോസിറ്ററികൾ തിരഞ്ഞെടുത്തു"
+  },
+  "repoCount": {
+    "message": "$1 റിപ്പോസിറ്ററികൾ തിരഞ്ഞെടുത്തു"
+  },
+  "clearAllBtn": {
+    "message": "എല്ലാം മായ്ക്കുക"
+  },
+  "repoLoading": {
+    "message": "റിപ്പോസിറ്ററികൾ ലോഡ് ചെയ്യുന്നു..."
+  },
+  "repoLoaded": {
+    "message": "$1 റിപ്പോസിറ്ററികൾ ലോഡ് ചെയ്തു."
+  },
+  "repoNotFound": {
+    "message": "റിപ്പോസിറ്ററികൾ കണ്ടെത്തിയില്ല"
+  },
+  "repoRefetching": {
+    "message": "റിപ്പോസിറ്ററികൾ വീണ്ടും ശേഖരിക്കുന്നു..."
+  },
+  "repoLoadFailed": {
+    "message": "റിപ്പോസിറ്ററികൾ ലോഡ് ചെയ്യാൻ പരാജയപ്പെട്ടു."
+  },
+  "repoTokenPrivate": {
+    "message": "ടോക്കൺ അസാധുവാണ് അല്ലെങ്കിൽ സ്വകാര്യ റിപ്പോസിറ്ററികൾക്ക് അനുമതിയില്ല."
+  },
+  "repoRefetchFailed": {
+    "message": "റിപ്പോസിറ്ററികൾ വീണ്ടും ശേഖരിക്കാൻ പരാജയപ്പെട്ടു."
+  },
+  "orgSetMessage": {
+    "message": "സ്ഥാപനം വിജയകരമായി സെറ്റ് ചെയ്തു."
+  },
+  "orgClearedMessage": {
+    "message": "സ്ഥാപനം നീക്കം ചെയ്തു. എല്ലാ പ്രവർത്തനങ്ങളും ശേഖരിക്കാൻ 'റിപ്പോർട്ട് സൃഷ്ടിക്കുക' ക്ലിക്ക് ചെയ്യുക."
+  },
+  "orgNotFoundMessage": {
+    "message": "GitHub-ൽ സ്ഥാപനം കണ്ടെത്തിയില്ല."
+  },
+  "orgValidationErrorMessage": {
+    "message": "സ്ഥാപനം സ്ഥിരീകരിക്കുന്നതിൽ പിശക്."
+  },
+  "refreshingButton": {
+    "message": "പുതുക്കുന്നു..."
+  },
+  "cacheClearFailed": {
+    "message": "കാഷ് ക്ലിയർ ചെയ്യൽ പരാജയപ്പെട്ടു."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "സൃഷ്ടിക്കുന്നു..."
+  },
+  "copiedButton": {
+    "message": "പകർത്തി!"
+  },
+  "orgChangedMessage": {
+    "message": "സംഘടന മാറി. GitHub പ്രവർത്തനങ്ങൾ ശേഖരിക്കാൻ റിപ്പോർട്ട് സൃഷ്ടിക്കുക ബട്ടൺ ക്ലിക്ക് ചെയ്യുക."
+  },
+  "cacheClearedMessage": {
+    "message": "കാഷ് വിജയകരമായി ക്ലിയർ ചെയ്തു. പുതിയ ഡാറ്റയ്ക്കായി \"റിപ്പോർട്ട് സൃഷ്ടിക്കുക\" ക്ലിക്ക് ചെയ്യുക."
+  },
+  "cacheExpiredMessage": {
+    "message": "കാഷ് കാലഹരണപ്പെട്ടു. പുതിയ ഡാറ്റ ലഭിക്കാൻ \"റിപ്പോർട്ട് സൃഷ്ടിക്കുക\" ക്ലിക്ക് ചെയ്യുക."
+  },
+  "cacheClearedButton": {
+    "message": "കാഷ് ക്ലിയർ ചെയ്തു!"
+  },
+  "extensionDisabledMessage": {
+    "message": "എക്സ്റ്റെൻഷൻ അപ്രാപ്തമാണ്. സ്ക്രം റിപ്പോർട്ടുകൾ സൃഷ്ടിക്കാൻ ഓപ്ഷനുകളിൽ നിന്ന് സജീവമാക്കുക."
+  },
+  "notePoint1": {
+    "message": "Pull request-കൾ നിങ്ങൾ മാത്രമല്ല, മറ്റ് സംഭാവനകർത്താക്കളുടെ ഏറ്റവും പുതിയ റിവ്യൂ പ്രവർത്തനത്തെ അടിസ്ഥാനമാക്കിയാണ് ശേഖരിക്കുന്നത്. പങ്കിടുന്നതിന് മുമ്പ് സൃഷ്ടിച്ച SCRUM റിപ്പോർട്ട് നിങ്ങളുടെ പ്രവർത്തനം ശരിയായി പ്രതിഫലിപ്പിക്കുന്നുവെന്ന് ഉറപ്പാക്കാൻ പരിശോധിച്ച് തിരുത്തുക."
+  },
+  "noteSeeIssue": {
+    "message": "ഈ ഇഷ്യൂ കാണുക"
+  },
+  "platformLabel": {
+    "message": "പ്ലാറ്റ്ഫോം"
+  },
+  "usernameLabel": {
+    "message": "നിങ്ങളുടെ ഉപയോക്തൃനാമം"
+  },
+  "onlyRevPRsLabel": {
+    "message": "റിപ്പോർട്ടിൽ റിവ്യൂ ചെയ്ത PRകൾ മാത്രം ഉൾപ്പെടുത്തുക"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "തിരഞ്ഞെടുത്താൽ, നിങ്ങൾ റിവ്യൂ ചെയ്ത PRകൾ മാത്രം റിപ്പോർട്ടിൽ ഉൾപ്പെടും."
+  },
+  "onlyMergedPRsLabel": {
+    "message": "ലയിപ്പിച്ച (merged) പിആറുകൾ മാത്രം റിപ്പോർട്ടിൽ ഉൾപ്പെടുത്തുക"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "തിരഞ്ഞെടുത്താൽ, ലയിപ്പിച്ച പിആറുകൾ മാത്രമേ റിപ്പോർട്ടിൽ ഉൾപ്പെടുത്തൂ. ഒരു GitHub ടോക്കൺ ആവശ്യമാണ്."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "ലയിപ്പിച്ച പിആറുകൾ അനുസരിച്ച് ഫിൽട്ടർ ചെയ്യാൻ ഒരു GitHub ടോക്കൺ ആവശ്യമാണ്. ദയവായി ക്രമീകരണങ്ങളിൽ ഒന്ന് ചേർക്കുക."
+  },
+  "usernameRequiredError": {
+    "message": "റിപ്പോർട്ട് സൃഷ്ടിക്കാൻ നിങ്ങളുടെ ഉപയോക്തൃനാമം നൽകുക."
+  },
+  "unknownPlatformError": {
+    "message": "അജ്ഞാതമായ പ്ലാറ്റ്ഫോം തിരഞ്ഞെടുത്തു."
+  },
+  "gitlabFetchingError": {
+    "message": "GitLab ഡാറ്റ ശേഖരിക്കുന്നതിൽ പിശകുണ്ടായി."
+  },
+  "reportGenerationError": {
+    "message": "റിപ്പോർട്ട് സൃഷ്ടിക്കുന്നതിൽ പിശകുണ്ടായി."
+  },
+  "githubUserNotFoundError": {
+    "message": "GitHub ഉപയോക്താവ് \"$1\" കണ്ടെത്തിയില്ല (404). ഉപയോക്തൃനാമം പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
+  },
+  "githubUserValidationError": {
+    "message": "GitHub ഉപയോക്താവ് സ്ഥിരീകരിക്കുന്നതിൽ പിശക്: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "അസാധുവായ തിരയൽ ക്വറി അല്ലെങ്കിൽ തീയതി പരിധി. നിങ്ങളുടെ തീയതി പരിധി ഫോർമാറ്റ് പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
+  },
+  "githubIssuesFetchError": {
+    "message": "GitHub ഇഷ്യൂകൾ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "GitHub PR റിവ്യൂ ഡാറ്റ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "GitHub ഉപയോക്തൃ ഡാറ്റ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "അസാധുവായ അല്ലെങ്കിൽ കാലഹരണപ്പെട്ട GitHub ടോക്കൺ. Scrum Helper സെറ്റിംഗ്സിൽ നിങ്ങളുടെ ടോക്കൺ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
+  },
+  "displayModeNotice": {
+    "message": "അടുത്ത സമാരംഭത്തിൽ എക്സ്റ്റെൻഷൻ $1 മോഡിൽ തുറക്കും."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "റിപ്പോസിറ്ററി ഫിൽറ്ററിംഗ് GitHub-ന് മാത്രമേ ലഭ്യമാകൂ."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "റിപ്പോസിറ്ററി ലോഡിംഗ് GitHub-ന് മാത്രമേ ലഭ്യമാകൂ."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "റിപ്പോസിറ്ററി ശേഖരണം GitHub-ന് മാത്രമേ ലഭ്യമാകൂ."
+  },
+  "loadingReposAutomatically": {
+    "message": "റിപ്പോസിറ്ററികൾ സ്വയമേവ ലോഡ് ചെയ്യുന്നു..."
+  },
+  "gitlabUserFetchError": {
+    "message": "GitLab ഉപയോക്താവിനെ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "GitLab ഉപയോക്താവ് '$1' കണ്ടെത്തിയില്ല"
+  },
+  "gitlabMembershipError": {
+    "message": "GitLab അംഗത്വ പ്രോജക്ടുകൾ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "GitLab സംഭാവന പ്രോജക്ടുകൾ ശേഖരിക്കുന്നതിൽ പിശക്: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "ഉപയോക്തൃനാമം ആവശ്യമാണ്."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "റിപ്പോർട്ട് തയ്യാറാക്കുന്നു..."
+  },
+  "copyingReportNotification": {
+    "message": "റിപ്പോർട്ട് പകർത്തുന്നു..."
+  },
+  "copiedReportNotification": {
+    "message": "റിപ്പോർട്ട് കോപ്പി ചെയ്തു!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "റിപ്പോർട്ട് ഇമെയിലിൽ ചേർക്കുന്നു..."
+  },
+  "insertedInEmailNotification": {
+    "message": "റിപ്പോർട്ട് ഇമെയിലിൽ ചേർത്തു!"
+  }
 }

--- a/src/_locales/my/messages.json
+++ b/src/_locales/my/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "ရွေးချယ်ထားသောကာလတစ်ခုအတွက် သင်၏ Git လုပ်ဆောင်ချက်ကို အလိုအလျောက်ရယူခြင်းဖြင့် သင်၏ဖွံ့ဖြိုးတိုးတက်မှုကို အစီရင်ခံပါ။"
-    },
-    "disableLabel": {
-        "message": "ပိတ်ပါ။"
-    },
-    "enableLabel": {
-        "message": "ဖွင့်ပါ။"
-    },
-    "projectNameLabel": {
-        "message": "ပရောဂျက်အမည် (အီးမေးလ်အကြောင်းအရာတွင်သုံးသည်)။"
-    },
-    "projectNamePlaceholder": {
-        "message": "သင့်ပရောဂျက်အမည်ကို ထည့်သွင်းပါ။"
-    },
-    "githubUsernameLabel": {
-        "message": "သင်၏ Github အသုံးပြုသူအမည်"
-    },
-    "gitlabUsernameLabel": {
-        "message": "သင်၏ Gitlab အသုံးပြုသူအမည်"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "သင်၏ contributions များကို ရယူရန်အတွက် လိုအပ်ပါသည်။"
-    },
-    "contributionsLabel": {
-        "message": "contributionsရရှိမည့်ကြာချိန် ："
-    },
-    "last1DayLabel": {
-        "message": "အရင်နေ့"
-    },
-    "startDateLabel": {
-        "message": "မှ :"
-    },
-    "endDateLabel": {
-        "message": "အထိ :"
-    },
-    "showOpenClosedLabel": {
-        "message": "PRs labelsကို ပြပါ။"
-    },
-    "blockersLabel": {
-        "message": "သင့်တိုးတက်မှုကို ရပ်တန့်စေသောအရာများ။"
-    },
-    "blockersPlaceholder": {
-        "message": "သင်၏တိုးတက်မှုကို ရပ်တန့်စေသောအရာများကိုထည့်ပါ။"
-    },
-    "scrumReportLabel": {
-        "message": "Scrum အစီရင်ခံစာ"
-    },
-    "generateReportButton": {
-        "message": "အစီရင်ခံစာထုတ်ပါ။"
-    },
-    "copyReportButton": {
-        "message": "အစီရင်ခံစာကူးယူပါ။"
-    },
-    "insertInEmailButton": {
-        "message": "အီးမေးလ်သို့ ထည့်ပါ"
-    },
-    "insertToEmailFailedError": {
-        "message": "အစီရင်ခံစာထည့်သွင်းရန် အီးမေးလ်တက်ဘ်တစ်ခုကို ဖွင့်ပါ"
-    },
-    "settingsOrgNameLabel": {
-        "message": "အဖွဲ့အစည်းအမည်"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "အဖွဲ့အစည်းအမည်ကိုထည့်ပါ။"
-    },
-    "setButton": {
-        "message": "သတ်မှတ်မည်။"
-    },
-    "githubTokenLabel": {
-        "message": "သင်၏ Github တိုကင်"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Authenticated requests ပြုလုပ်ရန်အတွက် လိုအပ်ပါသည်။"
-    },
-    "githubTokenTooltip": {
-        "message": "GitHub တိုကင်ထည့်ရန် အဘယ်ကြောင့် အကြံပြုရသနည်း။ Scrum Helper သည် GitHub တိုကင်မပါဘဲ အလုပ်လုပ်သော်လည်း ပိုမိုကောင်းမွန်သော အတွေ့အကြုံအတွက် ကိုယ်ပိုင်အသုံးပြုခွင့် တိုကင်တစ်ခုထည့်ခြင်းကို အကြံပြုပါသည်။"
-    },
-    "gitlabTokenLabel": {
-        "message": "သင်၏ Gitlab တိုကင်"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "ပုဂ္ဂလိကပရောဂျက်များကို ဝင်ရောက်အသုံးပြုရန် လိုအပ်ပါသည်။"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Gitlab တိုကင်ထည့်ရန် အဘယ်ကြောင့် အကြံပြုရသနည်း။ Scrum Helper သည် အများပြည်သူကြည့်ရှုနိုင်သော ပရောဂျက်များအတွက် Gitlab တိုကင်မပါဘဲ အလုပ်လုပ်သော်လည်း၊ သီးခြား (ပုဂ္ဂလိက) ပရောဂျက်များနှင့် ပိုမိုကောင်းမွန်သော အတွေ့အကြုံအတွက် ကိုယ်ပိုင်အသုံးပြုခွင့် တိုကင်တစ်ခုထည့်ရန် အကြံပြုပါသည်။"
-    },
-    "showCommitsLabel": {
-        "message": "OpenPRများ/DraftPR များပေါ်မှ commits များကို ပြပါ။"
-    },
-    "showCommitsTooltip": {
-        "message": "Github Token လိုအပ်သည်၊ ၎င်းကို settingတွင် ရှာတွေ့နိုင်ပါသည်။"
-    },
-    "onlyIssuesLabel": {
-        "message": "အစီရင်ခံစာတွင် issuesများသာ ပါဝင်ပါသည်။"
-    },
-    "onlyIssuesTooltip": {
-        "message": "စစ်ဆေးပြီး ကြည့်ရှုပါက အစီရင်ခံစာတွင် အသုံးပြုသူအတွက် ဖန်တီးထားသော သို့မဟုတ် သတ်မှတ်ပေးထားသည့် ပြဿနာများသာ ပါဝင်မည်ဖြစ်သည်။"
-    },
-    "onlyPRsLabel": {
-        "message": "အစီရင်ခံစာတွင် PR များသာပါဝင်သည်။"
-    },
-    "onlyPRsTooltip": {
-        "message": "စစ်ဆေးပါက အစီရင်ခံစာတွင် အသုံးပြုသူ ဖန်တီးထားသည့် PR များသာ ပါဝင်မည်ဖြစ်သည်။ သုံးသပ်ထားသော PR များကို ဖယ်ထုတ်ထားပါမည်။"
-    },
-    "cacheTTLLabel": {
-        "message": "cache TTL ကိုထည့်ပါ။"
-    },
-    "cacheTTLUnit": {
-        "message": "(မိနစ်)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "cache TTL ထည့်သွင်းရာတွင် မိနစ်ကို အသုံးပြုပါ။ (ပုံသေ 10 မိနစ်)"
-    },
-    "refreshDataButton": {
-        "message": "ဒေတာကို ပြန်လည်စတင်ပါ (bypass cache)"
-    },
-    "refreshDataInfo": {
-        "message": "ဒေတာအသစ်များကို ချက်ချင်းရယူရန် ဤခလုတ်ကို အသုံးပြုပါ။"
-    },
-    "noteTitle": {
-        "message": "မှတ်စု မှတ်သားရန် :"
-    },
-    "viewCodeButton": {
-        "message": "Code ကြည့်ရန်"
-    },
-    "reportIssueButton": {
-        "message": "ပြဿနာကို သတင်းပို့ရန်"
-    },
-    "repoFilterLabel": {
-        "message": "repositoriesများအလိုက် စစ်ထုတ်ပါ။"
-    },
-    "enableFilteringLabel": {
-        "message": "filterကို enableလုပ်ပါ။"
-    },
-    "tokenRequiredWarning": {
-        "message": "Filteringအတွက် GitHub တိုကင်တစ်ခု လိုအပ်သည်။ settingတွင် တစ်ခုထည့်ပါ။"
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "ဖွင့်ထားသော သို့မဟုတ် မူကြမ်း PR များတွင် commit များကို ပြသရန် GitHub တိုကင်တစ်ခု လိုအပ်သည်။ ဆက်တင်များတွင် တစ်ခုထည့်ပါ။"
-    },
-    "repoSearchPlaceholder": {
-        "message": "ထည့်သွင်းလိုသော repository ကိုရှာဖွေရန်..."
-    },
-    "repoPlaceholder": {
-        "message": "filterရန်အတွက် ရွေးချယ်ထားသော repository မရှိပါ။(all will be included)"
-    },
-    "repoCountNone": {
-        "message": "ရွေးချယ်ထားသော repositoryအရေအတွက်သည် 0 ဖြစ်သည်။"
-    },
-    "repoCount": {
-        "message": "ရွေးချယ်ထားသော repositoryအရေအတွက်သည် $1 ဖြစ်သည်။"
-    },
-    "clearAllBtn": {
-        "message": "အားလုံးရှင်းပါ"
-    },
-    "repoLoading": {
-        "message": "repositoryကို ဖွင့်နေသည်....."
-    },
-    "repoLoaded": {
-        "message": "$1 repositoryကို ဖွင့်ပြီးပြီ။"
-    },
-    "repoNotFound": {
-        "message": "repository မတွေ့ပါ။"
-    },
-    "repoRefetching": {
-        "message": "repositoryများကို ပြန်လည်ရယူနေသည်..."
-    },
-    "repoLoadFailed": {
-        "message": "ဖွင့်၍မရပါ။"
-    },
-    "repoTokenPrivate": {
-        "message": "တိုကင်သည် မမှန်ကန်ပါ သို့မဟုတ် သီးသန့် repos အတွက် လုပ်ပိုင်ခွင့်မရှိပါ။"
-    },
-    "repoRefetchFailed": {
-        "message": "repositoryများကို ပြန်ယူရန် မအောင်မြင်ပါ။"
-    },
-    "orgSetMessage": {
-        "message": "အဖွဲ့အစည်းသတ်မှတ်ခြင်းသည် အောင်မြင်သည်။"
-    },
-    "orgClearedMessage": {
-        "message": "အဖွဲ့အစည်း ရှင်းလင်းပြီးသည်။ activitiesအားလုံးကိုရယူရန် 'အစီရင်ခံစာထုတ်လုပ်ရန်' ကိုနှိပ်ပါ။"
-    },
-    "orgNotFoundMessage": {
-        "message": "အဖွဲ့အစည်းကို GitHub တွင် ရှာမတွေ့ပါ။"
-    },
-    "orgValidationErrorMessage": {
-        "message": "အဖွဲ့အစည်းကို အတည်ပြုရာတွင် အမှားအယွင်းရှိသည်။"
-    },
-    "refreshingButton": {
-        "message": "refresh လုပ်နေသည်..."
-    },
-    "cacheClearFailed": {
-        "message": "cache ရှင်းလင်းခြင်း မအောင်မြင်ပါ။"
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "generate လုပ်နေသည်..."
-    },
-    "copiedButton": {
-        "message": "copyကူးယူပြီးပါပြီ!"
-    },
-    "orgChangedMessage": {
-        "message": "အဖွဲ့အစည်းပြောင်းသွားသည်။ GitHub လုပ်ဆောင်ချက်များကို ရယူရန် Generate ခလုတ်ကို နှိပ်ပါ။"
-    },
-    "cacheClearedMessage": {
-        "message": "cacheကို အောင်မြင်စွာ ရှင်းလင်းပြီးပါပြီ။ ဒေတာအသစ်ရယူရန် \"အစီရင်ခံစာကို ထုတ်လုပ်ပါ\" ကိုနှိပ်ပါ။"
-    },
-    "cacheExpiredMessage": {
-        "message": "ကက်ရှ်သက်တမ်းကုန်သွားပါပြီ။ အချက်အလက်သစ်များ ရယူရန် \"ထုတ်ရန်\" ကို နှိပ်ပါ။"
-    },
-    "cacheClearedButton": {
-        "message": "cache ရှင်းလင်းပြီးပါပြီ!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Extensionကို ပိတ်ထားသည်။ scrum အစီရင်ခံစာများထုတ်လုပ်ရန် optionsမှ ၎င်းကိုဖွင့်ပါ။"
-    },
-    "notePoint1": {
-        "message": "PR ရယူခြင်းသည် သင်အပါအဝင် contributorများ၏ အနီးဆုံး လုပ်ဆောင်ချက်ပေါ်တွင် မူတည်သည်။ ကျေးဇူးပြု၍ မမျှဝေမီ SCRUM အစီရင်ခံစာကို သင်လိုချင်တဲ့အလုပ် မှန်မမှန် အတွက်ပြန်လည်သုံးသပ်ပြီး ချိန်ညှိပါ။"
-    },
-    "noteSeeIssue": {
-        "message": "ဒီissueကို ကြည့်ပါ။"
-    },
-    "platformLabel": {
-        "message": "Platform"
-    },
-    "usernameLabel": {
-        "message": "သင်၏အသုံးပြုသူအမည်"
-    },
-    "onlyRevPRsLabel": {
-        "message": "အစီရင်ခံစာတွင် သုံးသပ်ထားသော PR များသာ ပါဝင်ပါသည်။"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "၎င်းကိုစစ်ဆေးပါက၊ အစီရင်ခံစာတွင် သင်သုံးသပ်ထားသော PR များသာ ပါဝင်မည်ဖြစ်သည်။"
-    },
-    "onlyMergedPRsLabel": {
-        "message": "ပေါင်းစည်းထားသော (merged) PR များကိုသာ အစီရင်ခံစာတွင် ထည့်သွင်းပါ"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "အမှန်ခြစ်ပေးပါက ပေါင်းစည်းပြီးသား PR များကိုသာ အစီရင်ခံစာတွင် ထည့်သွင်းပါမည်။ GitHub တိုကင်တစ်ခု လိုအပ်သည်။"
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "ပေါင်းစည်းထားသော PR များအလိုက် စစ်ထုတ်ရန် GitHub တိုကင်တစ်ခု လိုအပ်သည်။ ဆက်တင်များတွင် တစ်ခုထည့်ပါ။"
-    },
-    "usernameRequiredError": {
-        "message": "အစီရင်ခံစာထုတ်လုပ်ရန် သင်၏အသုံးပြုသူအမည်ကို ထည့်သွင်းပါ။"
-    },
-    "unknownPlatformError": {
-        "message": "အမျိုးအမည်မသိ platformကို ရွေးချယ်ထားသည်။"
-    },
-    "gitlabFetchingError": {
-        "message": "GitLab ဒေတာကို ရယူနေစဉ် အမှားအယွင်းတစ်ခု ဖြစ်ပွားခဲ့သည်။"
-    },
-    "reportGenerationError": {
-        "message": "အစီရင်ခံစာကို ထုတ်လုပ်နေစဉ် အမှားအယွင်းတစ်ခု ဖြစ်ပွားခဲ့သည်။"
-    },
-    "githubUserNotFoundError": {
-        "message": "GitHub အသုံးပြုသူ \"$1\" ကို ရှာမတွေ့ပါ (404)။ အသုံးပြုသူအမည်ကို စစ်ဆေးပြီး ပြန်လည်ကြိုးစားပါ။"
-    },
-    "githubUserValidationError": {
-        "message": "GitHub အသုံးပြုသူကို အတည်ပြုရာတွင် အမှား: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "မမှန်ကန်သော ရှာဖွေမှုမေးခွန်း သို့မဟုတ် ရက်စွဲအပိုင်းအခြား။ သင်၏ ရက်စွဲအပိုင်းအခြား ပုံစံကို အတည်ပြုပြီး ပြန်လည်ကြိုးစားပါ။"
-    },
-    "githubIssuesFetchError": {
-        "message": "GitHub issueများကို ရယူရာတွင် အမှား: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "GitHub PR သုံးသပ်ချက် ဒေတာကို ရယူရာတွင် အမှား: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "GitHub အသုံးပြုသူ ဒေတာကို ရယူရာတွင် အမှား: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "မမှန်ကန်သော သို့မဟုတ် သက်တမ်းကုန်ဆုံးသွားသော GitHub တိုကင်။ Scrum Helper ဆက်တင်များတွင် သင်၏တိုကင်ကို စစ်ဆေးပြီး ပြန်လည်ကြိုးစားပါ။"
-    },
-    "displayModeNotice": {
-        "message": "နောက်တစ်ကြိမ် ဖွင့်လှစ်သည့်အခါ extensionသည် $1 မုဒ်ဖြင့် ဖွင့်မည်ဖြစ်သည်။"
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Repository filteringသည် GitHub အတွက်သာ ရရှိနိုင်ပါသည်။"
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Repository loadingသည် GitHub အတွက်သာ ရရှိနိုင်ပါသည်။"
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Repository ရယူခြင်းသည် GitHub အတွက်သာ ရရှိနိုင်ပါသည်။"
-    },
-    "loadingReposAutomatically": {
-        "message": "Repositoriesများကို အလိုအလျောက် ဖွင့်နေသည်..."
-    },
-    "gitlabUserFetchError": {
-        "message": "GitLab အသုံးပြုသူကို ရယူရာတွင် အမှား: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "GitLab အသုံးပြုသူ '$1' ကို ရှာမတွေ့ပါ"
-    },
-    "gitlabMembershipError": {
-        "message": "GitLab အဖွဲ့ဝင်ပရောဂျက်များကို ရယူရာတွင် အမှား: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "GitLab ပံ့ပိုးထားသော ပရောဂျက်များကို ရယူရာတွင် အမှား: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "အသုံးပြုသူအမည် လိုအပ်သည်။"
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "အစီရင်ခံစာ ထုတ်နေသည်..."
-    },
-    "copyingReportNotification": {
-        "message": "အစီရင်ခံစာကို ကူးယူနေသည်..."
-    },
-    "copiedReportNotification": {
-        "message": "အစီရင်ခံစာကို ကူးယူပြီးပါပြီ။"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "အစီရင်ခံစာကို အီးမေးလ်ထဲသို့ ထည့်နေသည်..."
-    },
-    "insertedInEmailNotification": {
-        "message": "အစီရင်ခံစာကို အီးမေးလ်ထဲသို့ ထည့်သွင်းပြီးပါပြီ။"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "ရွေးချယ်ထားသောကာလတစ်ခုအတွက် သင်၏ Git လုပ်ဆောင်ချက်ကို အလိုအလျောက်ရယူခြင်းဖြင့် သင်၏ဖွံ့ဖြိုးတိုးတက်မှုကို အစီရင်ခံပါ။"
+  },
+  "disableLabel": {
+    "message": "ပိတ်ပါ။"
+  },
+  "enableLabel": {
+    "message": "ဖွင့်ပါ။"
+  },
+  "projectNameLabel": {
+    "message": "ပရောဂျက်အမည် (အီးမေးလ်အကြောင်းအရာတွင်သုံးသည်)။"
+  },
+  "projectNamePlaceholder": {
+    "message": "သင့်ပရောဂျက်အမည်ကို ထည့်သွင်းပါ။"
+  },
+  "githubUsernameLabel": {
+    "message": "သင်၏ Github အသုံးပြုသူအမည်"
+  },
+  "gitlabUsernameLabel": {
+    "message": "သင်၏ Gitlab အသုံးပြုသူအမည်"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "သင်၏ contributions များကို ရယူရန်အတွက် လိုအပ်ပါသည်။"
+  },
+  "contributionsLabel": {
+    "message": "contributionsရရှိမည့်ကြာချိန် ："
+  },
+  "last1DayLabel": {
+    "message": "အရင်နေ့"
+  },
+  "lastWeekLabel": {
+    "message": "ပြီးခဲ့သည့်အပတ်ကအကျဉ်းချုပ်",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "မှ :"
+  },
+  "endDateLabel": {
+    "message": "အထိ :"
+  },
+  "showOpenClosedLabel": {
+    "message": "PRs labelsကို ပြပါ။"
+  },
+  "blockersLabel": {
+    "message": "သင့်တိုးတက်မှုကို ရပ်တန့်စေသောအရာများ။"
+  },
+  "blockersPlaceholder": {
+    "message": "သင်၏တိုးတက်မှုကို ရပ်တန့်စေသောအရာများကိုထည့်ပါ။"
+  },
+  "scrumReportLabel": {
+    "message": "Scrum အစီရင်ခံစာ"
+  },
+  "generateReportButton": {
+    "message": "အစီရင်ခံစာထုတ်ပါ။"
+  },
+  "copyReportButton": {
+    "message": "အစီရင်ခံစာကူးယူပါ။"
+  },
+  "insertInEmailButton": {
+    "message": "အီးမေးလ်သို့ ထည့်ပါ"
+  },
+  "insertToEmailFailedError": {
+    "message": "အစီရင်ခံစာထည့်သွင်းရန် အီးမေးလ်တက်ဘ်တစ်ခုကို ဖွင့်ပါ"
+  },
+  "settingsOrgNameLabel": {
+    "message": "အဖွဲ့အစည်းအမည်"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "အဖွဲ့အစည်းအမည်ကိုထည့်ပါ။"
+  },
+  "setButton": {
+    "message": "သတ်မှတ်မည်။"
+  },
+  "githubTokenLabel": {
+    "message": "သင်၏ Github တိုကင်"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Authenticated requests ပြုလုပ်ရန်အတွက် လိုအပ်ပါသည်။"
+  },
+  "githubTokenTooltip": {
+    "message": "GitHub တိုကင်ထည့်ရန် အဘယ်ကြောင့် အကြံပြုရသနည်း။ Scrum Helper သည် GitHub တိုကင်မပါဘဲ အလုပ်လုပ်သော်လည်း ပိုမိုကောင်းမွန်သော အတွေ့အကြုံအတွက် ကိုယ်ပိုင်အသုံးပြုခွင့် တိုကင်တစ်ခုထည့်ခြင်းကို အကြံပြုပါသည်။"
+  },
+  "gitlabTokenLabel": {
+    "message": "သင်၏ Gitlab တိုကင်"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "ပုဂ္ဂလိကပရောဂျက်များကို ဝင်ရောက်အသုံးပြုရန် လိုအပ်ပါသည်။"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Gitlab တိုကင်ထည့်ရန် အဘယ်ကြောင့် အကြံပြုရသနည်း။ Scrum Helper သည် အများပြည်သူကြည့်ရှုနိုင်သော ပရောဂျက်များအတွက် Gitlab တိုကင်မပါဘဲ အလုပ်လုပ်သော်လည်း၊ သီးခြား (ပုဂ္ဂလိက) ပရောဂျက်များနှင့် ပိုမိုကောင်းမွန်သော အတွေ့အကြုံအတွက် ကိုယ်ပိုင်အသုံးပြုခွင့် တိုကင်တစ်ခုထည့်ရန် အကြံပြုပါသည်။"
+  },
+  "showCommitsLabel": {
+    "message": "OpenPRများ/DraftPR များပေါ်မှ commits များကို ပြပါ။"
+  },
+  "showCommitsTooltip": {
+    "message": "Github Token လိုအပ်သည်၊ ၎င်းကို settingတွင် ရှာတွေ့နိုင်ပါသည်။"
+  },
+  "onlyIssuesLabel": {
+    "message": "အစီရင်ခံစာတွင် issuesများသာ ပါဝင်ပါသည်။"
+  },
+  "onlyIssuesTooltip": {
+    "message": "စစ်ဆေးပြီး ကြည့်ရှုပါက အစီရင်ခံစာတွင် အသုံးပြုသူအတွက် ဖန်တီးထားသော သို့မဟုတ် သတ်မှတ်ပေးထားသည့် ပြဿနာများသာ ပါဝင်မည်ဖြစ်သည်။"
+  },
+  "onlyPRsLabel": {
+    "message": "အစီရင်ခံစာတွင် PR များသာပါဝင်သည်။"
+  },
+  "onlyPRsTooltip": {
+    "message": "စစ်ဆေးပါက အစီရင်ခံစာတွင် အသုံးပြုသူ ဖန်တီးထားသည့် PR များသာ ပါဝင်မည်ဖြစ်သည်။ သုံးသပ်ထားသော PR များကို ဖယ်ထုတ်ထားပါမည်။"
+  },
+  "cacheTTLLabel": {
+    "message": "cache TTL ကိုထည့်ပါ။"
+  },
+  "cacheTTLUnit": {
+    "message": "(မိနစ်)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "cache TTL ထည့်သွင်းရာတွင် မိနစ်ကို အသုံးပြုပါ။ (ပုံသေ 10 မိနစ်)"
+  },
+  "refreshDataButton": {
+    "message": "ဒေတာကို ပြန်လည်စတင်ပါ (bypass cache)"
+  },
+  "refreshDataInfo": {
+    "message": "ဒေတာအသစ်များကို ချက်ချင်းရယူရန် ဤခလုတ်ကို အသုံးပြုပါ။"
+  },
+  "noteTitle": {
+    "message": "မှတ်စု မှတ်သားရန် :"
+  },
+  "viewCodeButton": {
+    "message": "Code ကြည့်ရန်"
+  },
+  "reportIssueButton": {
+    "message": "ပြဿနာကို သတင်းပို့ရန်"
+  },
+  "repoFilterLabel": {
+    "message": "repositoriesများအလိုက် စစ်ထုတ်ပါ။"
+  },
+  "enableFilteringLabel": {
+    "message": "filterကို enableလုပ်ပါ။"
+  },
+  "tokenRequiredWarning": {
+    "message": "Filteringအတွက် GitHub တိုကင်တစ်ခု လိုအပ်သည်။ settingတွင် တစ်ခုထည့်ပါ။"
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "ဖွင့်ထားသော သို့မဟုတ် မူကြမ်း PR များတွင် commit များကို ပြသရန် GitHub တိုကင်တစ်ခု လိုအပ်သည်။ ဆက်တင်များတွင် တစ်ခုထည့်ပါ။"
+  },
+  "repoSearchPlaceholder": {
+    "message": "ထည့်သွင်းလိုသော repository ကိုရှာဖွေရန်..."
+  },
+  "repoPlaceholder": {
+    "message": "filterရန်အတွက် ရွေးချယ်ထားသော repository မရှိပါ။(all will be included)"
+  },
+  "repoCountNone": {
+    "message": "ရွေးချယ်ထားသော repositoryအရေအတွက်သည် 0 ဖြစ်သည်။"
+  },
+  "repoCount": {
+    "message": "ရွေးချယ်ထားသော repositoryအရေအတွက်သည် $1 ဖြစ်သည်။"
+  },
+  "clearAllBtn": {
+    "message": "အားလုံးရှင်းပါ"
+  },
+  "repoLoading": {
+    "message": "repositoryကို ဖွင့်နေသည်....."
+  },
+  "repoLoaded": {
+    "message": "$1 repositoryကို ဖွင့်ပြီးပြီ။"
+  },
+  "repoNotFound": {
+    "message": "repository မတွေ့ပါ။"
+  },
+  "repoRefetching": {
+    "message": "repositoryများကို ပြန်လည်ရယူနေသည်..."
+  },
+  "repoLoadFailed": {
+    "message": "ဖွင့်၍မရပါ။"
+  },
+  "repoTokenPrivate": {
+    "message": "တိုကင်သည် မမှန်ကန်ပါ သို့မဟုတ် သီးသန့် repos အတွက် လုပ်ပိုင်ခွင့်မရှိပါ။"
+  },
+  "repoRefetchFailed": {
+    "message": "repositoryများကို ပြန်ယူရန် မအောင်မြင်ပါ။"
+  },
+  "orgSetMessage": {
+    "message": "အဖွဲ့အစည်းသတ်မှတ်ခြင်းသည် အောင်မြင်သည်။"
+  },
+  "orgClearedMessage": {
+    "message": "အဖွဲ့အစည်း ရှင်းလင်းပြီးသည်။ activitiesအားလုံးကိုရယူရန် 'အစီရင်ခံစာထုတ်လုပ်ရန်' ကိုနှိပ်ပါ။"
+  },
+  "orgNotFoundMessage": {
+    "message": "အဖွဲ့အစည်းကို GitHub တွင် ရှာမတွေ့ပါ။"
+  },
+  "orgValidationErrorMessage": {
+    "message": "အဖွဲ့အစည်းကို အတည်ပြုရာတွင် အမှားအယွင်းရှိသည်။"
+  },
+  "refreshingButton": {
+    "message": "refresh လုပ်နေသည်..."
+  },
+  "cacheClearFailed": {
+    "message": "cache ရှင်းလင်းခြင်း မအောင်မြင်ပါ။"
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "generate လုပ်နေသည်..."
+  },
+  "copiedButton": {
+    "message": "copyကူးယူပြီးပါပြီ!"
+  },
+  "orgChangedMessage": {
+    "message": "အဖွဲ့အစည်းပြောင်းသွားသည်။ GitHub လုပ်ဆောင်ချက်များကို ရယူရန် Generate ခလုတ်ကို နှိပ်ပါ။"
+  },
+  "cacheClearedMessage": {
+    "message": "cacheကို အောင်မြင်စွာ ရှင်းလင်းပြီးပါပြီ။ ဒေတာအသစ်ရယူရန် \"အစီရင်ခံစာကို ထုတ်လုပ်ပါ\" ကိုနှိပ်ပါ။"
+  },
+  "cacheExpiredMessage": {
+    "message": "ကက်ရှ်သက်တမ်းကုန်သွားပါပြီ။ အချက်အလက်သစ်များ ရယူရန် \"ထုတ်ရန်\" ကို နှိပ်ပါ။"
+  },
+  "cacheClearedButton": {
+    "message": "cache ရှင်းလင်းပြီးပါပြီ!"
+  },
+  "extensionDisabledMessage": {
+    "message": "Extensionကို ပိတ်ထားသည်။ scrum အစီရင်ခံစာများထုတ်လုပ်ရန် optionsမှ ၎င်းကိုဖွင့်ပါ။"
+  },
+  "notePoint1": {
+    "message": "PR ရယူခြင်းသည် သင်အပါအဝင် contributorများ၏ အနီးဆုံး လုပ်ဆောင်ချက်ပေါ်တွင် မူတည်သည်။ ကျေးဇူးပြု၍ မမျှဝေမီ SCRUM အစီရင်ခံစာကို သင်လိုချင်တဲ့အလုပ် မှန်မမှန် အတွက်ပြန်လည်သုံးသပ်ပြီး ချိန်ညှိပါ။"
+  },
+  "noteSeeIssue": {
+    "message": "ဒီissueကို ကြည့်ပါ။"
+  },
+  "platformLabel": {
+    "message": "Platform"
+  },
+  "usernameLabel": {
+    "message": "သင်၏အသုံးပြုသူအမည်"
+  },
+  "onlyRevPRsLabel": {
+    "message": "အစီရင်ခံစာတွင် သုံးသပ်ထားသော PR များသာ ပါဝင်ပါသည်။"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "၎င်းကိုစစ်ဆေးပါက၊ အစီရင်ခံစာတွင် သင်သုံးသပ်ထားသော PR များသာ ပါဝင်မည်ဖြစ်သည်။"
+  },
+  "onlyMergedPRsLabel": {
+    "message": "ပေါင်းစည်းထားသော (merged) PR များကိုသာ အစီရင်ခံစာတွင် ထည့်သွင်းပါ"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "အမှန်ခြစ်ပေးပါက ပေါင်းစည်းပြီးသား PR များကိုသာ အစီရင်ခံစာတွင် ထည့်သွင်းပါမည်။ GitHub တိုကင်တစ်ခု လိုအပ်သည်။"
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "ပေါင်းစည်းထားသော PR များအလိုက် စစ်ထုတ်ရန် GitHub တိုကင်တစ်ခု လိုအပ်သည်။ ဆက်တင်များတွင် တစ်ခုထည့်ပါ။"
+  },
+  "usernameRequiredError": {
+    "message": "အစီရင်ခံစာထုတ်လုပ်ရန် သင်၏အသုံးပြုသူအမည်ကို ထည့်သွင်းပါ။"
+  },
+  "unknownPlatformError": {
+    "message": "အမျိုးအမည်မသိ platformကို ရွေးချယ်ထားသည်။"
+  },
+  "gitlabFetchingError": {
+    "message": "GitLab ဒေတာကို ရယူနေစဉ် အမှားအယွင်းတစ်ခု ဖြစ်ပွားခဲ့သည်။"
+  },
+  "reportGenerationError": {
+    "message": "အစီရင်ခံစာကို ထုတ်လုပ်နေစဉ် အမှားအယွင်းတစ်ခု ဖြစ်ပွားခဲ့သည်။"
+  },
+  "githubUserNotFoundError": {
+    "message": "GitHub အသုံးပြုသူ \"$1\" ကို ရှာမတွေ့ပါ (404)။ အသုံးပြုသူအမည်ကို စစ်ဆေးပြီး ပြန်လည်ကြိုးစားပါ။"
+  },
+  "githubUserValidationError": {
+    "message": "GitHub အသုံးပြုသူကို အတည်ပြုရာတွင် အမှား: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "မမှန်ကန်သော ရှာဖွေမှုမေးခွန်း သို့မဟုတ် ရက်စွဲအပိုင်းအခြား။ သင်၏ ရက်စွဲအပိုင်းအခြား ပုံစံကို အတည်ပြုပြီး ပြန်လည်ကြိုးစားပါ။"
+  },
+  "githubIssuesFetchError": {
+    "message": "GitHub issueများကို ရယူရာတွင် အမှား: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "GitHub PR သုံးသပ်ချက် ဒေတာကို ရယူရာတွင် အမှား: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "GitHub အသုံးပြုသူ ဒေတာကို ရယူရာတွင် အမှား: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "မမှန်ကန်သော သို့မဟုတ် သက်တမ်းကုန်ဆုံးသွားသော GitHub တိုကင်။ Scrum Helper ဆက်တင်များတွင် သင်၏တိုကင်ကို စစ်ဆေးပြီး ပြန်လည်ကြိုးစားပါ။"
+  },
+  "displayModeNotice": {
+    "message": "နောက်တစ်ကြိမ် ဖွင့်လှစ်သည့်အခါ extensionသည် $1 မုဒ်ဖြင့် ဖွင့်မည်ဖြစ်သည်။"
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Repository filteringသည် GitHub အတွက်သာ ရရှိနိုင်ပါသည်။"
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Repository loadingသည် GitHub အတွက်သာ ရရှိနိုင်ပါသည်။"
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Repository ရယူခြင်းသည် GitHub အတွက်သာ ရရှိနိုင်ပါသည်။"
+  },
+  "loadingReposAutomatically": {
+    "message": "Repositoriesများကို အလိုအလျောက် ဖွင့်နေသည်..."
+  },
+  "gitlabUserFetchError": {
+    "message": "GitLab အသုံးပြုသူကို ရယူရာတွင် အမှား: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "GitLab အသုံးပြုသူ '$1' ကို ရှာမတွေ့ပါ"
+  },
+  "gitlabMembershipError": {
+    "message": "GitLab အဖွဲ့ဝင်ပရောဂျက်များကို ရယူရာတွင် အမှား: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "GitLab ပံ့ပိုးထားသော ပရောဂျက်များကို ရယူရာတွင် အမှား: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "အသုံးပြုသူအမည် လိုအပ်သည်။"
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "အစီရင်ခံစာ ထုတ်နေသည်..."
+  },
+  "copyingReportNotification": {
+    "message": "အစီရင်ခံစာကို ကူးယူနေသည်..."
+  },
+  "copiedReportNotification": {
+    "message": "အစီရင်ခံစာကို ကူးယူပြီးပါပြီ။"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "အစီရင်ခံစာကို အီးမေးလ်ထဲသို့ ထည့်နေသည်..."
+  },
+  "insertedInEmailNotification": {
+    "message": "အစီရင်ခံစာကို အီးမေးလ်ထဲသို့ ထည့်သွင်းပြီးပါပြီ။"
+  }
 }

--- a/src/_locales/nb/messages.json
+++ b/src/_locales/nb/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Rapporter utviklingsfremgangen din ved å automatisk hente Git-aktiviteten din for en valgt periode."
-    },
-    "disableLabel": {
-        "message": "Deaktiver"
-    },
-    "enableLabel": {
-        "message": "Aktiver"
-    },
-    "projectNameLabel": {
-        "message": "Prosjektnavn (brukes i e-postemne)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Skriv inn prosjektnavnet ditt"
-    },
-    "githubUsernameLabel": {
-        "message": "Ditt GitHub-brukernavn"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Ditt GitLab-brukernavn"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Påkrevd for å hente bidragene dine"
-    },
-    "contributionsLabel": {
-        "message": "Hent dine bidrag for:"
-    },
-    "last1DayLabel": {
-        "message": "Forrige dag"
-    },
-    "startDateLabel": {
-        "message": "Fra:"
-    },
-    "endDateLabel": {
-        "message": "Til:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Vis Åpen/Lukket-status"
-    },
-    "blockersLabel": {
-        "message": "Hva hindrer deg i å gjøre fremgang?"
-    },
-    "blockersPlaceholder": {
-        "message": "Skriv inn din grunn"
-    },
-    "scrumReportLabel": {
-        "message": "Scrum-rapport"
-    },
-    "generateReportButton": {
-        "message": "Generer rapport"
-    },
-    "copyReportButton": {
-        "message": "Kopier rapport"
-    },
-    "insertInEmailButton": {
-        "message": "Sett inn i e-post"
-    },
-    "insertToEmailFailedError": {
-        "message": "Åpne en e-postfane for å sette inn rapporten"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Organisasjonsnavn"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Skriv inn organisasjonsnavn"
-    },
-    "setButton": {
-        "message": "Angi"
-    },
-    "githubTokenLabel": {
-        "message": "Ditt GitHub-token"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Påkrevd for autentiserte forespørsler"
-    },
-    "githubTokenTooltip": {
-        "message": "Hvorfor anbefales det å legge til et GitHub-token? Scrum Helper fungerer uten et GitHub-token, men det anbefales å legge til et personlig tilgangstoken for en bedre opplevelse."
-    },
-    "gitlabTokenLabel": {
-        "message": "Ditt GitLab-token"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Påkrevd for private repositorier"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Hvorfor anbefales det å legge til et GitLab-token? Scrum Helper fungerer uten et GitLab-token for offentlige prosjekter, men det anbefales å legge til et personlig tilgangstoken for en bedre opplevelse."
-    },
-    "showCommitsLabel": {
-        "message": "Vis commits på åpne PR-er/utkast til PR-er"
-    },
-    "showCommitsTooltip": {
-        "message": "GitHub-token kreves. Legg det til i innstillingene."
-    },
-    "onlyIssuesLabel": {
-        "message": "Inkluder kun problemer i rapporten"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Hvis valgt, vil rapporten kun inkludere problemer opprettet eller tildelt brukeren."
-    },
-    "onlyPRsLabel": {
-        "message": "Inkluder kun PR-er i rapporten"
-    },
-    "onlyPRsTooltip": {
-        "message": "Hvis valgt, vil rapporten kun inkludere PR-er opprettet av brukeren; gjennomgåtte PR-er vil utelates."
-    },
-    "cacheTTLLabel": {
-        "message": "Angi cache-TTL"
-    },
-    "cacheTTLUnit": {
-        "message": "(i minutter)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Skriv inn cache-TTL i minutter (Standard: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Oppdater data (omgå cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Bruk denne knappen for å hente ferske data umiddelbart."
-    },
-    "noteTitle": {
-        "message": "Merk:"
-    },
-    "viewCodeButton": {
-        "message": "Se kode"
-    },
-    "reportIssueButton": {
-        "message": "Rapporter et problem"
-    },
-    "repoFilterLabel": {
-        "message": "Filtrer etter repositorier"
-    },
-    "enableFilteringLabel": {
-        "message": "Aktiver filtrering"
-    },
-    "tokenRequiredWarning": {
-        "message": "Et GitHub-token er påkrevd for repositoriefiltrering. Vennligst legg til ett i innstillingene."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "En GitHub-token kreves for å vise commits på åpne eller utkast-PRer. Vennligst legg til en i innstillingene."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Søk etter et repositorium for å legge til..."
-    },
-    "repoPlaceholder": {
-        "message": "Ingen repositorier valgt (alle vil bli inkludert)"
-    },
-    "repoCountNone": {
-        "message": "0 repositorier valgt"
-    },
-    "repoCount": {
-        "message": "$1 repositorier valgt"
-    },
-    "clearAllBtn": {
-        "message": "Fjern alle"
-    },
-    "repoLoading": {
-        "message": "Laster repositorier..."
-    },
-    "repoLoaded": {
-        "message": "Lastet $1 repositorier."
-    },
-    "repoNotFound": {
-        "message": "Ingen repositorier funnet"
-    },
-    "repoRefetching": {
-        "message": "Henter repositorier på nytt..."
-    },
-    "repoLoadFailed": {
-        "message": "Kunne ikke laste repositorier."
-    },
-    "repoTokenPrivate": {
-        "message": "Tokenet er ugyldig eller har ikke rettigheter for private repositorier."
-    },
-    "repoRefetchFailed": {
-        "message": "Kunne ikke hente repositorier på nytt."
-    },
-    "orgSetMessage": {
-        "message": "Organisasjon satt."
-    },
-    "orgClearedMessage": {
-        "message": "Organisasjon fjernet. Klikk 'Generer rapport' for å hente alle aktiviteter."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organisasjon ikke funnet på GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Feil ved validering av organisasjon."
-    },
-    "refreshingButton": {
-        "message": "Oppdaterer..."
-    },
-    "cacheClearFailed": {
-        "message": "Tømming av cache mislyktes."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Genererer..."
-    },
-    "copiedButton": {
-        "message": "Kopiert!"
-    },
-    "orgChangedMessage": {
-        "message": "Organisasjon endret. Klikk 'Generer rapport' for å hente GitHub-aktiviteter."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache tømt. Klikk 'Generer rapport' for å hente ferske data."
-    },
-    "cacheExpiredMessage": {
-        "message": "Hurtigbufferen har utløpt. Klikk \"Generer\" for å hente nye data."
-    },
-    "cacheClearedButton": {
-        "message": "Cache tømt!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Utvidelsen er deaktivert. Aktiver den fra innstillingene for å generere scrum-rapporter."
-    },
-    "notePoint1": {
-        "message": "Pull-forespørsler hentes basert på den siste gjennomgangsaktiviteten til enhver bidragsyter, ikke bare din egen. Vennligst gjennomgå og juster den genererte SCRUM-rapporten for å sikre at den nøyaktig gjenspeiler arbeidet ditt før du deler den."
-    },
-    "noteSeeIssue": {
-        "message": "Se dette problemet"
-    },
-    "platformLabel": {
-        "message": "Plattform"
-    },
-    "usernameLabel": {
-        "message": "Ditt brukernavn"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Inkluder kun gjennomgåtte PR-er i rapporten"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Hvis valgt, vil rapporten kun inkludere PR-er gjennomgått av deg."
-    },
-    "onlyMergedPRsLabel": {
-        "message": "Inkluder bare sammenslåtte (merged) PRer i rapporten"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "Hvis valgt, vil rapporten bare inkludere PRer som har blitt sammenslått. En GitHub-token kreves."
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "En GitHub-token kreves for å filtrere etter sammenslåtte PRer. Vennligst legg til en i innstillingene."
-    },
-    "usernameRequiredError": {
-        "message": "Vennligst skriv inn brukernavn for å generere rapport."
-    },
-    "unknownPlatformError": {
-        "message": "Ukjent plattform valgt."
-    },
-    "gitlabFetchingError": {
-        "message": "En feil oppstod under henting av GitLab-data."
-    },
-    "reportGenerationError": {
-        "message": "En feil oppstod under generering av rapporten."
-    },
-    "githubUserNotFoundError": {
-        "message": "GitHub-bruker \"$1\" ikke funnet (404). Sjekk brukernavnet og prøv igjen."
-    },
-    "githubUserValidationError": {
-        "message": "Feil ved validering av GitHub-bruker: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Ugyldig søkespørring eller datoperiode. Sjekk formatet og prøv igjen."
-    },
-    "githubIssuesFetchError": {
-        "message": "Feil ved henting av GitHub-issues: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Feil ved henting av GitHub PR-review-data: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Feil ved henting av GitHub-brukerdata: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Ugyldig eller utløpt GitHub-token. Sjekk tokenet i Scrum Helper-innstillingene og prøv igjen."
-    },
-    "displayModeNotice": {
-        "message": "Utvidelsen åpnes i $1-modus ved neste oppstart."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Repositoriefiltrering er kun tilgjengelig for GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Repositorielasting er kun tilgjengelig for GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Repositoriehenting er kun tilgjengelig for GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Laster repositorier automatisk..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Feil ved henting av GitLab-bruker: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "GitLab-bruker '$1' ikke funnet"
-    },
-    "gitlabMembershipError": {
-        "message": "Feil ved henting av GitLab-medlemskapsprosjekter: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Feil ved henting av GitLab-bidragsprosjekter: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Brukernavn påkrevd."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Genererer rapport..."
-    },
-    "copyingReportNotification": {
-        "message": "Kopierer rapport..."
-    },
-    "copiedReportNotification": {
-        "message": "Rapport kopiert!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Setter inn rapport i e-post..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Rapport satt inn i e-post!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Rapporter utviklingsfremgangen din ved å automatisk hente Git-aktiviteten din for en valgt periode."
+  },
+  "disableLabel": {
+    "message": "Deaktiver"
+  },
+  "enableLabel": {
+    "message": "Aktiver"
+  },
+  "projectNameLabel": {
+    "message": "Prosjektnavn (brukes i e-postemne)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Skriv inn prosjektnavnet ditt"
+  },
+  "githubUsernameLabel": {
+    "message": "Ditt GitHub-brukernavn"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Ditt GitLab-brukernavn"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Påkrevd for å hente bidragene dine"
+  },
+  "contributionsLabel": {
+    "message": "Hent dine bidrag for:"
+  },
+  "last1DayLabel": {
+    "message": "Forrige dag"
+  },
+  "lastWeekLabel": {
+    "message": "Sammendrag fra forrige uke",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "Fra:"
+  },
+  "endDateLabel": {
+    "message": "Til:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Vis Åpen/Lukket-status"
+  },
+  "blockersLabel": {
+    "message": "Hva hindrer deg i å gjøre fremgang?"
+  },
+  "blockersPlaceholder": {
+    "message": "Skriv inn din grunn"
+  },
+  "scrumReportLabel": {
+    "message": "Scrum-rapport"
+  },
+  "generateReportButton": {
+    "message": "Generer rapport"
+  },
+  "copyReportButton": {
+    "message": "Kopier rapport"
+  },
+  "insertInEmailButton": {
+    "message": "Sett inn i e-post"
+  },
+  "insertToEmailFailedError": {
+    "message": "Åpne en e-postfane for å sette inn rapporten"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Organisasjonsnavn"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Skriv inn organisasjonsnavn"
+  },
+  "setButton": {
+    "message": "Angi"
+  },
+  "githubTokenLabel": {
+    "message": "Ditt GitHub-token"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Påkrevd for autentiserte forespørsler"
+  },
+  "githubTokenTooltip": {
+    "message": "Hvorfor anbefales det å legge til et GitHub-token? Scrum Helper fungerer uten et GitHub-token, men det anbefales å legge til et personlig tilgangstoken for en bedre opplevelse."
+  },
+  "gitlabTokenLabel": {
+    "message": "Ditt GitLab-token"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Påkrevd for private repositorier"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Hvorfor anbefales det å legge til et GitLab-token? Scrum Helper fungerer uten et GitLab-token for offentlige prosjekter, men det anbefales å legge til et personlig tilgangstoken for en bedre opplevelse."
+  },
+  "showCommitsLabel": {
+    "message": "Vis commits på åpne PR-er/utkast til PR-er"
+  },
+  "showCommitsTooltip": {
+    "message": "GitHub-token kreves. Legg det til i innstillingene."
+  },
+  "onlyIssuesLabel": {
+    "message": "Inkluder kun problemer i rapporten"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Hvis valgt, vil rapporten kun inkludere problemer opprettet eller tildelt brukeren."
+  },
+  "onlyPRsLabel": {
+    "message": "Inkluder kun PR-er i rapporten"
+  },
+  "onlyPRsTooltip": {
+    "message": "Hvis valgt, vil rapporten kun inkludere PR-er opprettet av brukeren; gjennomgåtte PR-er vil utelates."
+  },
+  "cacheTTLLabel": {
+    "message": "Angi cache-TTL"
+  },
+  "cacheTTLUnit": {
+    "message": "(i minutter)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Skriv inn cache-TTL i minutter (Standard: 10)"
+  },
+  "refreshDataButton": {
+    "message": "Oppdater data (omgå cache)"
+  },
+  "refreshDataInfo": {
+    "message": "Bruk denne knappen for å hente ferske data umiddelbart."
+  },
+  "noteTitle": {
+    "message": "Merk:"
+  },
+  "viewCodeButton": {
+    "message": "Se kode"
+  },
+  "reportIssueButton": {
+    "message": "Rapporter et problem"
+  },
+  "repoFilterLabel": {
+    "message": "Filtrer etter repositorier"
+  },
+  "enableFilteringLabel": {
+    "message": "Aktiver filtrering"
+  },
+  "tokenRequiredWarning": {
+    "message": "Et GitHub-token er påkrevd for repositoriefiltrering. Vennligst legg til ett i innstillingene."
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "En GitHub-token kreves for å vise commits på åpne eller utkast-PRer. Vennligst legg til en i innstillingene."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Søk etter et repositorium for å legge til..."
+  },
+  "repoPlaceholder": {
+    "message": "Ingen repositorier valgt (alle vil bli inkludert)"
+  },
+  "repoCountNone": {
+    "message": "0 repositorier valgt"
+  },
+  "repoCount": {
+    "message": "$1 repositorier valgt"
+  },
+  "clearAllBtn": {
+    "message": "Fjern alle"
+  },
+  "repoLoading": {
+    "message": "Laster repositorier..."
+  },
+  "repoLoaded": {
+    "message": "Lastet $1 repositorier."
+  },
+  "repoNotFound": {
+    "message": "Ingen repositorier funnet"
+  },
+  "repoRefetching": {
+    "message": "Henter repositorier på nytt..."
+  },
+  "repoLoadFailed": {
+    "message": "Kunne ikke laste repositorier."
+  },
+  "repoTokenPrivate": {
+    "message": "Tokenet er ugyldig eller har ikke rettigheter for private repositorier."
+  },
+  "repoRefetchFailed": {
+    "message": "Kunne ikke hente repositorier på nytt."
+  },
+  "orgSetMessage": {
+    "message": "Organisasjon satt."
+  },
+  "orgClearedMessage": {
+    "message": "Organisasjon fjernet. Klikk 'Generer rapport' for å hente alle aktiviteter."
+  },
+  "orgNotFoundMessage": {
+    "message": "Organisasjon ikke funnet på GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Feil ved validering av organisasjon."
+  },
+  "refreshingButton": {
+    "message": "Oppdaterer..."
+  },
+  "cacheClearFailed": {
+    "message": "Tømming av cache mislyktes."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Genererer..."
+  },
+  "copiedButton": {
+    "message": "Kopiert!"
+  },
+  "orgChangedMessage": {
+    "message": "Organisasjon endret. Klikk 'Generer rapport' for å hente GitHub-aktiviteter."
+  },
+  "cacheClearedMessage": {
+    "message": "Cache tømt. Klikk 'Generer rapport' for å hente ferske data."
+  },
+  "cacheExpiredMessage": {
+    "message": "Hurtigbufferen har utløpt. Klikk \"Generer\" for å hente nye data."
+  },
+  "cacheClearedButton": {
+    "message": "Cache tømt!"
+  },
+  "extensionDisabledMessage": {
+    "message": "Utvidelsen er deaktivert. Aktiver den fra innstillingene for å generere scrum-rapporter."
+  },
+  "notePoint1": {
+    "message": "Pull-forespørsler hentes basert på den siste gjennomgangsaktiviteten til enhver bidragsyter, ikke bare din egen. Vennligst gjennomgå og juster den genererte SCRUM-rapporten for å sikre at den nøyaktig gjenspeiler arbeidet ditt før du deler den."
+  },
+  "noteSeeIssue": {
+    "message": "Se dette problemet"
+  },
+  "platformLabel": {
+    "message": "Plattform"
+  },
+  "usernameLabel": {
+    "message": "Ditt brukernavn"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Inkluder kun gjennomgåtte PR-er i rapporten"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Hvis valgt, vil rapporten kun inkludere PR-er gjennomgått av deg."
+  },
+  "onlyMergedPRsLabel": {
+    "message": "Inkluder bare sammenslåtte (merged) PRer i rapporten"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "Hvis valgt, vil rapporten bare inkludere PRer som har blitt sammenslått. En GitHub-token kreves."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "En GitHub-token kreves for å filtrere etter sammenslåtte PRer. Vennligst legg til en i innstillingene."
+  },
+  "usernameRequiredError": {
+    "message": "Vennligst skriv inn brukernavn for å generere rapport."
+  },
+  "unknownPlatformError": {
+    "message": "Ukjent plattform valgt."
+  },
+  "gitlabFetchingError": {
+    "message": "En feil oppstod under henting av GitLab-data."
+  },
+  "reportGenerationError": {
+    "message": "En feil oppstod under generering av rapporten."
+  },
+  "githubUserNotFoundError": {
+    "message": "GitHub-bruker \"$1\" ikke funnet (404). Sjekk brukernavnet og prøv igjen."
+  },
+  "githubUserValidationError": {
+    "message": "Feil ved validering av GitHub-bruker: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Ugyldig søkespørring eller datoperiode. Sjekk formatet og prøv igjen."
+  },
+  "githubIssuesFetchError": {
+    "message": "Feil ved henting av GitHub-issues: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Feil ved henting av GitHub PR-review-data: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Feil ved henting av GitHub-brukerdata: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Ugyldig eller utløpt GitHub-token. Sjekk tokenet i Scrum Helper-innstillingene og prøv igjen."
+  },
+  "displayModeNotice": {
+    "message": "Utvidelsen åpnes i $1-modus ved neste oppstart."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Repositoriefiltrering er kun tilgjengelig for GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Repositorielasting er kun tilgjengelig for GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Repositoriehenting er kun tilgjengelig for GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Laster repositorier automatisk..."
+  },
+  "gitlabUserFetchError": {
+    "message": "Feil ved henting av GitLab-bruker: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "GitLab-bruker '$1' ikke funnet"
+  },
+  "gitlabMembershipError": {
+    "message": "Feil ved henting av GitLab-medlemskapsprosjekter: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Feil ved henting av GitLab-bidragsprosjekter: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Brukernavn påkrevd."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Genererer rapport..."
+  },
+  "copyingReportNotification": {
+    "message": "Kopierer rapport..."
+  },
+  "copiedReportNotification": {
+    "message": "Rapport kopiert!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Setter inn rapport i e-post..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Rapport satt inn i e-post!"
+  }
 }

--- a/src/_locales/pt/messages.json
+++ b/src/_locales/pt/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Relate o seu progresso de desenvolvimento buscando automaticamente a sua atividade no Git para um período selecionado"
-    },
-    "disableLabel": {
-        "message": "Desativar"
-    },
-    "enableLabel": {
-        "message": "Ativar"
-    },
-    "projectNameLabel": {
-        "message": "Nome do Projeto (usado no assunto do e-mail)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Digite o nome do seu projeto"
-    },
-    "githubUsernameLabel": {
-        "message": "Seu nome de usuário do GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Seu nome de usuário do GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Necessário para buscar suas contribuições"
-    },
-    "contributionsLabel": {
-        "message": "Buscar suas contribuições entre:"
-    },
-    "last1DayLabel": {
-        "message": "Dia anterior"
-    },
-    "startDateLabel": {
-        "message": "De:"
-    },
-    "endDateLabel": {
-        "message": "Até:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Mostrar Rótulo Aberto/Fechado"
-    },
-    "blockersLabel": {
-        "message": "O que está impedindo você de progredir?"
-    },
-    "blockersPlaceholder": {
-        "message": "Digite o seu motivo"
-    },
-    "scrumReportLabel": {
-        "message": "Relatório Scrum"
-    },
-    "generateReportButton": {
-        "message": "Gerar"
-    },
-    "copyReportButton": {
-        "message": "Copiar"
-    },
-    "insertInEmailButton": {
-        "message": "Inserir no email"
-    },
-    "insertToEmailFailedError": {
-        "message": "Abra uma guia de e-mail para inserir o relatório"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nome da Organização"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Digite o nome da organização"
-    },
-    "setButton": {
-        "message": "Definir"
-    },
-    "githubTokenLabel": {
-        "message": "Seu Token do GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Necessário para fazer solicitações autenticadas"
-    },
-    "githubTokenTooltip": {
-        "message": "Por que é recomendado adicionar um token do GitHub? O Scrum Helper funciona sem um token do GitHub, mas adicionar um token de acesso pessoal é recomendado para uma melhor experiência."
-    },
-    "gitlabTokenLabel": {
-        "message": "Seu Token GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Necessário para repos privados"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Por que é recomendado adicionar um token do GitLab? O Scrum Helper funciona sem um token do GitLab para projetos públicos, mas adicionar um token de acesso pessoal é recomendado para uma melhor experiência."
-    },
-    "showCommitsLabel": {
-        "message": "Mostrar commits em PRs abertos/ rascunhos de PRs"
-    },
-    "showCommitsTooltip": {
-        "message": "Token do GitHub necessário, adicione-o nas configurações."
-    },
-    "onlyIssuesLabel": {
-        "message": "Incluir apenas problemas no relatório"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas os problemas criados ou atribuídos ao usuário."
-    },
-    "onlyPRsLabel": {
-        "message": "Incluir apenas PRs no relatório"
-    },
-    "onlyPRsTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas PRs criadas pelo usuário; as PRs revisadas serão excluídas."
-    },
-    "cacheTTLLabel": {
-        "message": "Digite o TTL do cache"
-    },
-    "cacheTTLUnit": {
-        "message": "(em minutos)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Escreva o TTL do cache em minutos (Padrão 10 minutos)"
-    },
-    "refreshDataButton": {
-        "message": "Atualizar Dados (ignorar cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Use este botão para buscar dados novos imediatamente."
-    },
-    "noteTitle": {
-        "message": "Nota:"
-    },
-    "viewCodeButton": {
-        "message": "Ver Código"
-    },
-    "reportIssueButton": {
-        "message": "Relatar Problema"
-    },
-    "repoFilterLabel": {
-        "message": "Filtrar por repositórios"
-    },
-    "enableFilteringLabel": {
-        "message": "Ativar filtragem"
-    },
-    "tokenRequiredWarning": {
-        "message": "Um token do GitHub é necessário para filtragem de repositórios. Por favor, adicione um nas configurações."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "É necessário um token do GitHub para mostrar commits em PRs abertos ou em rascunho. Adicione um nas configurações."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Pesquisar um repositório para adicionar..."
-    },
-    "repoPlaceholder": {
-        "message": "Nenhum repositório selecionado (todos serão incluídos)"
-    },
-    "repoCountNone": {
-        "message": "0 repositórios selecionados"
-    },
-    "repoCount": {
-        "message": "$1 repositórios selecionados"
-    },
-    "clearAllBtn": {
-        "message": "Limpar tudo"
-    },
-    "repoLoading": {
-        "message": "Carregando repositórios..."
-    },
-    "repoLoaded": {
-        "message": "Carregados $1 repositórios."
-    },
-    "repoNotFound": {
-        "message": "Nenhum repositório encontrado"
-    },
-    "repoRefetching": {
-        "message": "Recarregando repositórios..."
-    },
-    "repoLoadFailed": {
-        "message": "Falha ao carregar repositórios."
-    },
-    "repoTokenPrivate": {
-        "message": "Token é inválido ou não tem direitos para repositórios privados."
-    },
-    "repoRefetchFailed": {
-        "message": "Falha ao recarregar repositórios."
-    },
-    "orgSetMessage": {
-        "message": "Organização configurada com sucesso."
-    },
-    "orgClearedMessage": {
-        "message": "Organização removida. Clique em 'Gerar Relatório' para buscar todas as atividades."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organização não encontrada no GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Erro ao validar a organização."
-    },
-    "refreshingButton": {
-        "message": "Atualizando..."
-    },
-    "cacheClearFailed": {
-        "message": "Falha ao limpar o cache."
-    },
-    "madeWithLoveBy": {
-        "message": "Feito com ❤️ por"
-    },
-    "generatingButton": {
-        "message": "Gerando..."
-    },
-    "copiedButton": {
-        "message": "Copiado!"
-    },
-    "orgChangedMessage": {
-        "message": "Organização alterada. Clique no botão Gerar para buscar as atividades do GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache limpo com sucesso. Clique em \"Gerar Relatório\" para buscar dados novos."
-    },
-    "cacheExpiredMessage": {
-        "message": "O cache expirou. Clique em \"Gerar\" para buscar dados novos."
-    },
-    "cacheClearedButton": {
-        "message": "Cache Limpo!"
-    },
-    "extensionDisabledMessage": {
-        "message": "A extensão está desativada. Ative-a nas opções para gerar relatórios scrum."
-    },
-    "notePoint1": {
-        "message": "As solicitações de pull são buscadas com base na atividade de revisão mais recente de qualquer contribuidor, não apenas na sua. Revise e ajuste o relatório SCRUM gerado para garantir que ele reflita com precisão o seu trabalho antes de compartilhá-lo."
-    },
-    "noteSeeIssue": {
-        "message": "Veja este problema"
-    },
-    "platformLabel": {
-        "message": "Plataforma"
-    },
-    "usernameLabel": {
-        "message": "Seu nome de usuário"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Incluir apenas PRs revisadas no relatório"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas PRs revisadas por você."
-    },
-    "onlyMergedPRsLabel": {
-        "message": "Incluir apenas PRs mesclados no relatório"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas PRs que foram mesclados. É necessário um token do GitHub."
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "É necessário um token do GitHub para filtrar por PRs mesclados. Adicione um nas configurações."
-    },
-    "usernameRequiredError": {
-        "message": "Por favor, digite seu nome de usuário para gerar o relatório."
-    },
-    "unknownPlatformError": {
-        "message": "Plataforma desconhecida selecionada."
-    },
-    "gitlabFetchingError": {
-        "message": "Ocorreu um erro ao buscar os dados do GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Ocorreu um erro ao gerar o relatório."
-    },
-    "githubUserNotFoundError": {
-        "message": "Usuário do GitHub \"$1\" não encontrado (404). Verifique o nome de usuário e tente novamente."
-    },
-    "githubUserValidationError": {
-        "message": "Erro ao validar o usuário do GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Consulta de busca ou intervalo de datas inválido. Verifique o formato e tente novamente."
-    },
-    "githubIssuesFetchError": {
-        "message": "Erro ao buscar issues do GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Erro ao buscar dados de revisão de PR do GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Erro ao buscar dados do usuário do GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Token do GitHub inválido ou expirado. Verifique seu token nas configurações do Scrum Helper e tente novamente."
-    },
-    "displayModeNotice": {
-        "message": "A extensão será aberta no modo $1 no próximo lançamento."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Filtragem de repositórios disponível apenas para o GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Carregamento de repositórios disponível apenas para o GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Busca de repositórios disponível apenas para o GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Carregando repositórios automaticamente..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Erro ao buscar usuário do GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Usuário do GitLab '$1' não encontrado"
-    },
-    "gitlabMembershipError": {
-        "message": "Erro ao buscar projetos de associação do GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Erro ao buscar projetos contribuídos do GitLab: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Nome de usuário obrigatório."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Gerando relatório..."
-    },
-    "copyingReportNotification": {
-        "message": "Copiando relatório..."
-    },
-    "copiedReportNotification": {
-        "message": "Relatório copiado!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Inserindo relatório no e-mail..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Relatório inserido no e-mail!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Relate o seu progresso de desenvolvimento buscando automaticamente a sua atividade no Git para um período selecionado"
+  },
+  "disableLabel": {
+    "message": "Desativar"
+  },
+  "enableLabel": {
+    "message": "Ativar"
+  },
+  "projectNameLabel": {
+    "message": "Nome do Projeto (usado no assunto do e-mail)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Digite o nome do seu projeto"
+  },
+  "githubUsernameLabel": {
+    "message": "Seu nome de usuário do GitHub"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Seu nome de usuário do GitLab"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Necessário para buscar suas contribuições"
+  },
+  "contributionsLabel": {
+    "message": "Buscar suas contribuições entre:"
+  },
+  "last1DayLabel": {
+    "message": "Dia anterior"
+  },
+  "lastWeekLabel": {
+    "message": "Resumo da semana anterior",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "De:"
+  },
+  "endDateLabel": {
+    "message": "Até:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Mostrar Rótulo Aberto/Fechado"
+  },
+  "blockersLabel": {
+    "message": "O que está impedindo você de progredir?"
+  },
+  "blockersPlaceholder": {
+    "message": "Digite o seu motivo"
+  },
+  "scrumReportLabel": {
+    "message": "Relatório Scrum"
+  },
+  "generateReportButton": {
+    "message": "Gerar"
+  },
+  "copyReportButton": {
+    "message": "Copiar"
+  },
+  "insertInEmailButton": {
+    "message": "Inserir no email"
+  },
+  "insertToEmailFailedError": {
+    "message": "Abra uma guia de e-mail para inserir o relatório"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Nome da Organização"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Digite o nome da organização"
+  },
+  "setButton": {
+    "message": "Definir"
+  },
+  "githubTokenLabel": {
+    "message": "Seu Token do GitHub"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Necessário para fazer solicitações autenticadas"
+  },
+  "githubTokenTooltip": {
+    "message": "Por que é recomendado adicionar um token do GitHub? O Scrum Helper funciona sem um token do GitHub, mas adicionar um token de acesso pessoal é recomendado para uma melhor experiência."
+  },
+  "gitlabTokenLabel": {
+    "message": "Seu Token GitLab"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Necessário para repos privados"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Por que é recomendado adicionar um token do GitLab? O Scrum Helper funciona sem um token do GitLab para projetos públicos, mas adicionar um token de acesso pessoal é recomendado para uma melhor experiência."
+  },
+  "showCommitsLabel": {
+    "message": "Mostrar commits em PRs abertos/ rascunhos de PRs"
+  },
+  "showCommitsTooltip": {
+    "message": "Token do GitHub necessário, adicione-o nas configurações."
+  },
+  "onlyIssuesLabel": {
+    "message": "Incluir apenas problemas no relatório"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Se marcado, o relatório incluirá apenas os problemas criados ou atribuídos ao usuário."
+  },
+  "onlyPRsLabel": {
+    "message": "Incluir apenas PRs no relatório"
+  },
+  "onlyPRsTooltip": {
+    "message": "Se marcado, o relatório incluirá apenas PRs criadas pelo usuário; as PRs revisadas serão excluídas."
+  },
+  "cacheTTLLabel": {
+    "message": "Digite o TTL do cache"
+  },
+  "cacheTTLUnit": {
+    "message": "(em minutos)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Escreva o TTL do cache em minutos (Padrão 10 minutos)"
+  },
+  "refreshDataButton": {
+    "message": "Atualizar Dados (ignorar cache)"
+  },
+  "refreshDataInfo": {
+    "message": "Use este botão para buscar dados novos imediatamente."
+  },
+  "noteTitle": {
+    "message": "Nota:"
+  },
+  "viewCodeButton": {
+    "message": "Ver Código"
+  },
+  "reportIssueButton": {
+    "message": "Relatar Problema"
+  },
+  "repoFilterLabel": {
+    "message": "Filtrar por repositórios"
+  },
+  "enableFilteringLabel": {
+    "message": "Ativar filtragem"
+  },
+  "tokenRequiredWarning": {
+    "message": "Um token do GitHub é necessário para filtragem de repositórios. Por favor, adicione um nas configurações."
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "É necessário um token do GitHub para mostrar commits em PRs abertos ou em rascunho. Adicione um nas configurações."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Pesquisar um repositório para adicionar..."
+  },
+  "repoPlaceholder": {
+    "message": "Nenhum repositório selecionado (todos serão incluídos)"
+  },
+  "repoCountNone": {
+    "message": "0 repositórios selecionados"
+  },
+  "repoCount": {
+    "message": "$1 repositórios selecionados"
+  },
+  "clearAllBtn": {
+    "message": "Limpar tudo"
+  },
+  "repoLoading": {
+    "message": "Carregando repositórios..."
+  },
+  "repoLoaded": {
+    "message": "Carregados $1 repositórios."
+  },
+  "repoNotFound": {
+    "message": "Nenhum repositório encontrado"
+  },
+  "repoRefetching": {
+    "message": "Recarregando repositórios..."
+  },
+  "repoLoadFailed": {
+    "message": "Falha ao carregar repositórios."
+  },
+  "repoTokenPrivate": {
+    "message": "Token é inválido ou não tem direitos para repositórios privados."
+  },
+  "repoRefetchFailed": {
+    "message": "Falha ao recarregar repositórios."
+  },
+  "orgSetMessage": {
+    "message": "Organização configurada com sucesso."
+  },
+  "orgClearedMessage": {
+    "message": "Organização removida. Clique em 'Gerar Relatório' para buscar todas as atividades."
+  },
+  "orgNotFoundMessage": {
+    "message": "Organização não encontrada no GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Erro ao validar a organização."
+  },
+  "refreshingButton": {
+    "message": "Atualizando..."
+  },
+  "cacheClearFailed": {
+    "message": "Falha ao limpar o cache."
+  },
+  "madeWithLoveBy": {
+    "message": "Feito com ❤️ por"
+  },
+  "generatingButton": {
+    "message": "Gerando..."
+  },
+  "copiedButton": {
+    "message": "Copiado!"
+  },
+  "orgChangedMessage": {
+    "message": "Organização alterada. Clique no botão Gerar para buscar as atividades do GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Cache limpo com sucesso. Clique em \"Gerar Relatório\" para buscar dados novos."
+  },
+  "cacheExpiredMessage": {
+    "message": "O cache expirou. Clique em \"Gerar\" para buscar dados novos."
+  },
+  "cacheClearedButton": {
+    "message": "Cache Limpo!"
+  },
+  "extensionDisabledMessage": {
+    "message": "A extensão está desativada. Ative-a nas opções para gerar relatórios scrum."
+  },
+  "notePoint1": {
+    "message": "As solicitações de pull são buscadas com base na atividade de revisão mais recente de qualquer contribuidor, não apenas na sua. Revise e ajuste o relatório SCRUM gerado para garantir que ele reflita com precisão o seu trabalho antes de compartilhá-lo."
+  },
+  "noteSeeIssue": {
+    "message": "Veja este problema"
+  },
+  "platformLabel": {
+    "message": "Plataforma"
+  },
+  "usernameLabel": {
+    "message": "Seu nome de usuário"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Incluir apenas PRs revisadas no relatório"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Se marcado, o relatório incluirá apenas PRs revisadas por você."
+  },
+  "onlyMergedPRsLabel": {
+    "message": "Incluir apenas PRs mesclados no relatório"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "Se marcado, o relatório incluirá apenas PRs que foram mesclados. É necessário um token do GitHub."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "É necessário um token do GitHub para filtrar por PRs mesclados. Adicione um nas configurações."
+  },
+  "usernameRequiredError": {
+    "message": "Por favor, digite seu nome de usuário para gerar o relatório."
+  },
+  "unknownPlatformError": {
+    "message": "Plataforma desconhecida selecionada."
+  },
+  "gitlabFetchingError": {
+    "message": "Ocorreu um erro ao buscar os dados do GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Ocorreu um erro ao gerar o relatório."
+  },
+  "githubUserNotFoundError": {
+    "message": "Usuário do GitHub \"$1\" não encontrado (404). Verifique o nome de usuário e tente novamente."
+  },
+  "githubUserValidationError": {
+    "message": "Erro ao validar o usuário do GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Consulta de busca ou intervalo de datas inválido. Verifique o formato e tente novamente."
+  },
+  "githubIssuesFetchError": {
+    "message": "Erro ao buscar issues do GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Erro ao buscar dados de revisão de PR do GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Erro ao buscar dados do usuário do GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Token do GitHub inválido ou expirado. Verifique seu token nas configurações do Scrum Helper e tente novamente."
+  },
+  "displayModeNotice": {
+    "message": "A extensão será aberta no modo $1 no próximo lançamento."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Filtragem de repositórios disponível apenas para o GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Carregamento de repositórios disponível apenas para o GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Busca de repositórios disponível apenas para o GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Carregando repositórios automaticamente..."
+  },
+  "gitlabUserFetchError": {
+    "message": "Erro ao buscar usuário do GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Usuário do GitLab '$1' não encontrado"
+  },
+  "gitlabMembershipError": {
+    "message": "Erro ao buscar projetos de associação do GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Erro ao buscar projetos contribuídos do GitLab: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Nome de usuário obrigatório."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Gerando relatório..."
+  },
+  "copyingReportNotification": {
+    "message": "Copiando relatório..."
+  },
+  "copiedReportNotification": {
+    "message": "Relatório copiado!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Inserindo relatório no e-mail..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Relatório inserido no e-mail!"
+  }
 }

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Relate seu progresso de desenvolvimento buscando automaticamente sua atividade no Git para um período selecionado."
-    },
-    "disableLabel": {
-        "message": "Desativar"
-    },
-    "enableLabel": {
-        "message": "Ativar"
-    },
-    "projectNameLabel": {
-        "message": "Nome do Projeto (usado no assunto do e-mail)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Digite o nome do seu projeto"
-    },
-    "githubUsernameLabel": {
-        "message": "Seu nome de usuário do GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Seu nome de usuário do GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Necessário para buscar suas contribuições"
-    },
-    "contributionsLabel": {
-        "message": "Buscar suas contribuições de:"
-    },
-    "last1DayLabel": {
-        "message": "Dia anterior"
-    },
-    "startDateLabel": {
-        "message": "De:"
-    },
-    "endDateLabel": {
-        "message": "Até:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Mostrar status Aberto/Fechado"
-    },
-    "blockersLabel": {
-        "message": "O que está impedindo seu progresso?"
-    },
-    "blockersPlaceholder": {
-        "message": "Digite o motivo"
-    },
-    "scrumReportLabel": {
-        "message": "Relatório Scrum"
-    },
-    "generateReportButton": {
-        "message": "Gerar"
-    },
-    "copyReportButton": {
-        "message": "Copiar"
-    },
-    "insertInEmailButton": {
-        "message": "Inserir no e-mail"
-    },
-    "insertToEmailFailedError": {
-        "message": "Abra uma aba de e-mail para inserir o relatório"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Nome da Organização"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Digite o nome da organização"
-    },
-    "setButton": {
-        "message": "Definir"
-    },
-    "githubTokenLabel": {
-        "message": "Seu Token do GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Necessário para solicitações autenticadas"
-    },
-    "githubTokenTooltip": {
-        "message": "Por que é recomendado adicionar um token do GitHub? O Scrum Helper funciona sem um token do GitHub, mas é recomendado adicionar um token de acesso pessoal para uma melhor experiência."
-    },
-    "gitlabTokenLabel": {
-        "message": "Seu Token GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Necessário para repos privados"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Por que é recomendado adicionar um token do GitLab? O Scrum Helper funciona sem um token do GitLab para projetos públicos, mas é recomendado adicionar um token de acesso pessoal para uma melhor experiência."
-    },
-    "showCommitsLabel": {
-        "message": "Mostrar commits em PRs abertos/ rascunhos de PRs"
-    },
-    "showCommitsTooltip": {
-        "message": "Token do Github necessário, adicione-o nas configurações."
-    },
-    "onlyIssuesLabel": {
-        "message": "Incluir apenas issues no relatório"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas as issues criadas ou atribuídas ao usuário."
-    },
-    "onlyPRsLabel": {
-        "message": "Incluir apenas PRs no relatório"
-    },
-    "onlyPRsTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas PRs criadas pelo usuário; as PRs revisadas serão excluídas."
-    },
-    "cacheTTLLabel": {
-        "message": "Digite o TTL do cache"
-    },
-    "cacheTTLUnit": {
-        "message": "(em minutos)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Digite o TTL do cache em minutos (Padrão: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Atualizar Dados (ignorar cache)"
-    },
-    "refreshDataInfo": {
-        "message": "Use este botão para buscar dados novos imediatamente."
-    },
-    "noteTitle": {
-        "message": "Nota:"
-    },
-    "viewCodeButton": {
-        "message": "Ver código"
-    },
-    "reportIssueButton": {
-        "message": "Relatar um problema"
-    },
-    "repoFilterLabel": {
-        "message": "Filtrar por repositórios"
-    },
-    "enableFilteringLabel": {
-        "message": "Ativar filtragem"
-    },
-    "tokenRequiredWarning": {
-        "message": "Um token do GitHub é necessário para filtrar repositórios. Adicione um nas configurações."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "É necessário um token do GitHub para mostrar commits em PRs abertos ou em rascunho. Adicione um nas configurações."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Buscar um repositório para adicionar..."
-    },
-    "repoPlaceholder": {
-        "message": "Nenhum repositório selecionado (todos serão incluídos)"
-    },
-    "repoCountNone": {
-        "message": "0 repositórios selecionados"
-    },
-    "repoCount": {
-        "message": "$1 repositórios selecionados"
-    },
-    "clearAllBtn": {
-        "message": "Limpar tudo"
-    },
-    "repoLoading": {
-        "message": "Carregando repositórios..."
-    },
-    "repoLoaded": {
-        "message": "$1 repositórios carregados."
-    },
-    "repoNotFound": {
-        "message": "Nenhum repositório encontrado"
-    },
-    "repoRefetching": {
-        "message": "Recarregando repositórios..."
-    },
-    "repoLoadFailed": {
-        "message": "Falha ao carregar repositórios."
-    },
-    "repoTokenPrivate": {
-        "message": "O token é inválido ou não tem permissão para repositórios privados."
-    },
-    "repoRefetchFailed": {
-        "message": "Falha ao recarregar repositórios."
-    },
-    "orgSetMessage": {
-        "message": "Organização definida com sucesso."
-    },
-    "orgClearedMessage": {
-        "message": "Organização removida. Clique em 'Gerar Relatório' para buscar todas as atividades."
-    },
-    "orgNotFoundMessage": {
-        "message": "Organização não encontrada no GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Erro ao validar a organização."
-    },
-    "refreshingButton": {
-        "message": "Atualizando..."
-    },
-    "cacheClearFailed": {
-        "message": "Falha ao limpar o cache."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Gerando..."
-    },
-    "copiedButton": {
-        "message": "Copiado!"
-    },
-    "orgChangedMessage": {
-        "message": "Organização alterada. Clique em 'Gerar Relatório' para buscar as atividades do GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Cache limpo com sucesso. Clique em 'Gerar Relatório' para buscar dados novos."
-    },
-    "cacheExpiredMessage": {
-        "message": "O cache expirou. Clique em \"Gerar\" para buscar dados novos."
-    },
-    "cacheClearedButton": {
-        "message": "Cache Limpo!"
-    },
-    "extensionDisabledMessage": {
-        "message": "A extensão está desativada. Ative-a nos ajustes para gerar relatórios scrum."
-    },
-    "notePoint1": {
-        "message": "As solicitações de pull são buscadas com base na atividade de revisão mais recente de qualquer contribuidor, não apenas na sua. Revise e ajuste o relatório SCRUM gerado para garantir que ele reflita com precisão o seu trabalho antes de compartilhá-lo."
-    },
-    "noteSeeIssue": {
-        "message": "Veja este issue"
-    },
-    "platformLabel": {
-        "message": "Plataforma"
-    },
-    "usernameLabel": {
-        "message": "Seu nome de usuário"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Incluir apenas PRs revisadas no relatório"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas PRs revisadas por você."
-    },
-    "onlyMergedPRsLabel": {
-        "message": "Incluir apenas PRs mesclados no relatório"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "Se marcado, o relatório incluirá apenas PRs que foram mesclados. É necessário um token do GitHub."
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "É necessário um token do GitHub para filtrar por PRs mesclados. Adicione um nas configurações."
-    },
-    "usernameRequiredError": {
-        "message": "Por favor, digite seu nome de usuário para gerar o relatório."
-    },
-    "unknownPlatformError": {
-        "message": "Plataforma desconhecida selecionada."
-    },
-    "gitlabFetchingError": {
-        "message": "Ocorreu um erro ao buscar os dados do GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Ocorreu um erro ao gerar o relatório."
-    },
-    "githubUserNotFoundError": {
-        "message": "Usuário do GitHub \"$1\" não encontrado (404). Verifique o nome de usuário e tente novamente."
-    },
-    "githubUserValidationError": {
-        "message": "Erro ao validar o usuário do GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Consulta de busca ou intervalo de datas inválido. Verifique o formato e tente novamente."
-    },
-    "githubIssuesFetchError": {
-        "message": "Erro ao buscar issues do GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Erro ao buscar dados de revisão de PR do GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Erro ao buscar dados do usuário do GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Token do GitHub inválido ou expirado. Verifique seu token nas configurações do Scrum Helper e tente novamente."
-    },
-    "displayModeNotice": {
-        "message": "A extensão será aberta no modo $1 no próximo lançamento."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Filtragem de repositórios disponível apenas para o GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Carregamento de repositórios disponível apenas para o GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Busca de repositórios disponível apenas para o GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Carregando repositórios automaticamente..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Erro ao buscar usuário do GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Usuário do GitLab '$1' não encontrado"
-    },
-    "gitlabMembershipError": {
-        "message": "Erro ao buscar projetos de associação do GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Erro ao buscar projetos contribuídos do GitLab: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Nome de usuário obrigatório."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Gerando relatório..."
-    },
-    "copyingReportNotification": {
-        "message": "Copiando relatório..."
-    },
-    "copiedReportNotification": {
-        "message": "Relatório copiado!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Inserindo relatório no e-mail..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Relatório inserido no e-mail!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Relate seu progresso de desenvolvimento buscando automaticamente sua atividade no Git para um período selecionado."
+  },
+  "disableLabel": {
+    "message": "Desativar"
+  },
+  "enableLabel": {
+    "message": "Ativar"
+  },
+  "projectNameLabel": {
+    "message": "Nome do Projeto (usado no assunto do e-mail)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Digite o nome do seu projeto"
+  },
+  "githubUsernameLabel": {
+    "message": "Seu nome de usuário do GitHub"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Seu nome de usuário do GitLab"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Necessário para buscar suas contribuições"
+  },
+  "contributionsLabel": {
+    "message": "Buscar suas contribuições de:"
+  },
+  "last1DayLabel": {
+    "message": "Dia anterior"
+  },
+  "lastWeekLabel": {
+    "message": "Resumo da semana anterior",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "De:"
+  },
+  "endDateLabel": {
+    "message": "Até:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Mostrar status Aberto/Fechado"
+  },
+  "blockersLabel": {
+    "message": "O que está impedindo seu progresso?"
+  },
+  "blockersPlaceholder": {
+    "message": "Digite o motivo"
+  },
+  "scrumReportLabel": {
+    "message": "Relatório Scrum"
+  },
+  "generateReportButton": {
+    "message": "Gerar"
+  },
+  "copyReportButton": {
+    "message": "Copiar"
+  },
+  "insertInEmailButton": {
+    "message": "Inserir no e-mail"
+  },
+  "insertToEmailFailedError": {
+    "message": "Abra uma aba de e-mail para inserir o relatório"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Nome da Organização"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Digite o nome da organização"
+  },
+  "setButton": {
+    "message": "Definir"
+  },
+  "githubTokenLabel": {
+    "message": "Seu Token do GitHub"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Necessário para solicitações autenticadas"
+  },
+  "githubTokenTooltip": {
+    "message": "Por que é recomendado adicionar um token do GitHub? O Scrum Helper funciona sem um token do GitHub, mas é recomendado adicionar um token de acesso pessoal para uma melhor experiência."
+  },
+  "gitlabTokenLabel": {
+    "message": "Seu Token GitLab"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Necessário para repos privados"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Por que é recomendado adicionar um token do GitLab? O Scrum Helper funciona sem um token do GitLab para projetos públicos, mas é recomendado adicionar um token de acesso pessoal para uma melhor experiência."
+  },
+  "showCommitsLabel": {
+    "message": "Mostrar commits em PRs abertos/ rascunhos de PRs"
+  },
+  "showCommitsTooltip": {
+    "message": "Token do Github necessário, adicione-o nas configurações."
+  },
+  "onlyIssuesLabel": {
+    "message": "Incluir apenas issues no relatório"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Se marcado, o relatório incluirá apenas as issues criadas ou atribuídas ao usuário."
+  },
+  "onlyPRsLabel": {
+    "message": "Incluir apenas PRs no relatório"
+  },
+  "onlyPRsTooltip": {
+    "message": "Se marcado, o relatório incluirá apenas PRs criadas pelo usuário; as PRs revisadas serão excluídas."
+  },
+  "cacheTTLLabel": {
+    "message": "Digite o TTL do cache"
+  },
+  "cacheTTLUnit": {
+    "message": "(em minutos)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Digite o TTL do cache em minutos (Padrão: 10)"
+  },
+  "refreshDataButton": {
+    "message": "Atualizar Dados (ignorar cache)"
+  },
+  "refreshDataInfo": {
+    "message": "Use este botão para buscar dados novos imediatamente."
+  },
+  "noteTitle": {
+    "message": "Nota:"
+  },
+  "viewCodeButton": {
+    "message": "Ver código"
+  },
+  "reportIssueButton": {
+    "message": "Relatar um problema"
+  },
+  "repoFilterLabel": {
+    "message": "Filtrar por repositórios"
+  },
+  "enableFilteringLabel": {
+    "message": "Ativar filtragem"
+  },
+  "tokenRequiredWarning": {
+    "message": "Um token do GitHub é necessário para filtrar repositórios. Adicione um nas configurações."
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "É necessário um token do GitHub para mostrar commits em PRs abertos ou em rascunho. Adicione um nas configurações."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Buscar um repositório para adicionar..."
+  },
+  "repoPlaceholder": {
+    "message": "Nenhum repositório selecionado (todos serão incluídos)"
+  },
+  "repoCountNone": {
+    "message": "0 repositórios selecionados"
+  },
+  "repoCount": {
+    "message": "$1 repositórios selecionados"
+  },
+  "clearAllBtn": {
+    "message": "Limpar tudo"
+  },
+  "repoLoading": {
+    "message": "Carregando repositórios..."
+  },
+  "repoLoaded": {
+    "message": "$1 repositórios carregados."
+  },
+  "repoNotFound": {
+    "message": "Nenhum repositório encontrado"
+  },
+  "repoRefetching": {
+    "message": "Recarregando repositórios..."
+  },
+  "repoLoadFailed": {
+    "message": "Falha ao carregar repositórios."
+  },
+  "repoTokenPrivate": {
+    "message": "O token é inválido ou não tem permissão para repositórios privados."
+  },
+  "repoRefetchFailed": {
+    "message": "Falha ao recarregar repositórios."
+  },
+  "orgSetMessage": {
+    "message": "Organização definida com sucesso."
+  },
+  "orgClearedMessage": {
+    "message": "Organização removida. Clique em 'Gerar Relatório' para buscar todas as atividades."
+  },
+  "orgNotFoundMessage": {
+    "message": "Organização não encontrada no GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Erro ao validar a organização."
+  },
+  "refreshingButton": {
+    "message": "Atualizando..."
+  },
+  "cacheClearFailed": {
+    "message": "Falha ao limpar o cache."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Gerando..."
+  },
+  "copiedButton": {
+    "message": "Copiado!"
+  },
+  "orgChangedMessage": {
+    "message": "Organização alterada. Clique em 'Gerar Relatório' para buscar as atividades do GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Cache limpo com sucesso. Clique em 'Gerar Relatório' para buscar dados novos."
+  },
+  "cacheExpiredMessage": {
+    "message": "O cache expirou. Clique em \"Gerar\" para buscar dados novos."
+  },
+  "cacheClearedButton": {
+    "message": "Cache Limpo!"
+  },
+  "extensionDisabledMessage": {
+    "message": "A extensão está desativada. Ative-a nos ajustes para gerar relatórios scrum."
+  },
+  "notePoint1": {
+    "message": "As solicitações de pull são buscadas com base na atividade de revisão mais recente de qualquer contribuidor, não apenas na sua. Revise e ajuste o relatório SCRUM gerado para garantir que ele reflita com precisão o seu trabalho antes de compartilhá-lo."
+  },
+  "noteSeeIssue": {
+    "message": "Veja este issue"
+  },
+  "platformLabel": {
+    "message": "Plataforma"
+  },
+  "usernameLabel": {
+    "message": "Seu nome de usuário"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Incluir apenas PRs revisadas no relatório"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Se marcado, o relatório incluirá apenas PRs revisadas por você."
+  },
+  "onlyMergedPRsLabel": {
+    "message": "Incluir apenas PRs mesclados no relatório"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "Se marcado, o relatório incluirá apenas PRs que foram mesclados. É necessário um token do GitHub."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "É necessário um token do GitHub para filtrar por PRs mesclados. Adicione um nas configurações."
+  },
+  "usernameRequiredError": {
+    "message": "Por favor, digite seu nome de usuário para gerar o relatório."
+  },
+  "unknownPlatformError": {
+    "message": "Plataforma desconhecida selecionada."
+  },
+  "gitlabFetchingError": {
+    "message": "Ocorreu um erro ao buscar os dados do GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Ocorreu um erro ao gerar o relatório."
+  },
+  "githubUserNotFoundError": {
+    "message": "Usuário do GitHub \"$1\" não encontrado (404). Verifique o nome de usuário e tente novamente."
+  },
+  "githubUserValidationError": {
+    "message": "Erro ao validar o usuário do GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Consulta de busca ou intervalo de datas inválido. Verifique o formato e tente novamente."
+  },
+  "githubIssuesFetchError": {
+    "message": "Erro ao buscar issues do GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Erro ao buscar dados de revisão de PR do GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Erro ao buscar dados do usuário do GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Token do GitHub inválido ou expirado. Verifique seu token nas configurações do Scrum Helper e tente novamente."
+  },
+  "displayModeNotice": {
+    "message": "A extensão será aberta no modo $1 no próximo lançamento."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Filtragem de repositórios disponível apenas para o GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Carregamento de repositórios disponível apenas para o GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Busca de repositórios disponível apenas para o GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Carregando repositórios automaticamente..."
+  },
+  "gitlabUserFetchError": {
+    "message": "Erro ao buscar usuário do GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Usuário do GitLab '$1' não encontrado"
+  },
+  "gitlabMembershipError": {
+    "message": "Erro ao buscar projetos de associação do GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Erro ao buscar projetos contribuídos do GitLab: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Nome de usuário obrigatório."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Gerando relatório..."
+  },
+  "copyingReportNotification": {
+    "message": "Copiando relatório..."
+  },
+  "copiedReportNotification": {
+    "message": "Relatório copiado!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Inserindo relatório no e-mail..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Relatório inserido no e-mail!"
+  }
 }

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Сообщайте о своем прогрессе в разработке, автоматически получая данные о вашей активности в Git за выбранный период."
-    },
-    "disableLabel": {
-        "message": "Отключить"
-    },
-    "enableLabel": {
-        "message": "Включить"
-    },
-    "projectNameLabel": {
-        "message": "Название проекта (используется в теме письма)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Введите название вашего проекта"
-    },
-    "githubUsernameLabel": {
-        "message": "Ваше имя пользователя GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Ваше имя пользователя GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Требуется для получения ваших вкладов"
-    },
-    "contributionsLabel": {
-        "message": "Получить ваши вклады за:"
-    },
-    "last1DayLabel": {
-        "message": "Предыдущий день"
-    },
-    "startDateLabel": {
-        "message": "С:"
-    },
-    "endDateLabel": {
-        "message": "До:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Показывать статус Открыто/Закрыто"
-    },
-    "blockersLabel": {
-        "message": "Что мешает вашему прогрессу?"
-    },
-    "blockersPlaceholder": {
-        "message": "Введите причину"
-    },
-    "scrumReportLabel": {
-        "message": "Scrum-отчет"
-    },
-    "generateReportButton": {
-        "message": "Создать"
-    },
-    "copyReportButton": {
-        "message": "Копировать"
-    },
-    "insertInEmailButton": {
-        "message": "Вставить в письмо"
-    },
-    "insertToEmailFailedError": {
-        "message": "Откройте вкладку электронной почты, чтобы вставить отчет"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Название организации"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Введите название организации"
-    },
-    "setButton": {
-        "message": "Установить"
-    },
-    "githubTokenLabel": {
-        "message": "Ваш токен GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Требуется для аутентифицированных запросов"
-    },
-    "githubTokenTooltip": {
-        "message": "Зачем рекомендуется добавлять токен GitHub? Scrum Helper работает без токена GitHub, но для лучшего опыта рекомендуется добавить токен личного доступа."
-    },
-    "gitlabTokenLabel": {
-        "message": "Ваш токен GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Требуется для приватных репо"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Зачем рекомендуется добавлять токен GitLab? Scrum Helper работает без токена GitLab для публичных проектов, но для лучшего опыта рекомендуется добавить токен личного доступа."
-    },
-    "showCommitsLabel": {
-        "message": "Показывать коммиты в открытых PR/ черновиках PR"
-    },
-    "showCommitsTooltip": {
-        "message": "Требуется токен Github, добавьте его в настройках."
-    },
-    "onlyIssuesLabel": {
-        "message": "Включить в отчет только задачи"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Если флажок установлен, в отчет будут включены только задачи, созданные пользователем или назначенные ему."
-    },
-    "onlyPRsLabel": {
-        "message": "Включать в отчёт только PR"
-    },
-    "onlyPRsTooltip": {
-        "message": "Если отмечено, отчёт будет включать только pull request'ы, созданные пользователем; проверенные PR будут исключены."
-    },
-    "cacheTTLLabel": {
-        "message": "Введите TTL кеша"
-    },
-    "cacheTTLUnit": {
-        "message": "(в минутах)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Укажите TTL кэша в минутах (по умолчанию: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Обновить данные (в обход кэша)"
-    },
-    "refreshDataInfo": {
-        "message": "Используйте эту кнопку для немедленного получения свежих данных."
-    },
-    "noteTitle": {
-        "message": "Примечание:"
-    },
-    "viewCodeButton": {
-        "message": "Посмотреть код"
-    },
-    "reportIssueButton": {
-        "message": "Сообщить о проблеме"
-    },
-    "repoFilterLabel": {
-        "message": "Фильтровать по репозиториям"
-    },
-    "enableFilteringLabel": {
-        "message": "Включить фильтрацию"
-    },
-    "tokenRequiredWarning": {
-        "message": "Для фильтрации репозиториев требуется токен GitHub. Пожалуйста, добавьте его в настройках."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "Для показа коммитов в открытых или черновиках PR требуется токен GitHub. Добавьте его в настройках."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Найти репозиторий для добавления..."
-    },
-    "repoPlaceholder": {
-        "message": "Репозитории не выбраны (будут включены все)"
-    },
-    "repoCountNone": {
-        "message": "0 репозиториев выбрано"
-    },
-    "repoCount": {
-        "message": "$1 репозиториев выбрано"
-    },
-    "clearAllBtn": {
-        "message": "Очистить всё"
-    },
-    "repoLoading": {
-        "message": "Загрузка репозиториев..."
-    },
-    "repoLoaded": {
-        "message": "Загружено $1 репозиториев."
-    },
-    "repoNotFound": {
-        "message": "Репозитории не найдены"
-    },
-    "repoRefetching": {
-        "message": "Перезагрузка репозиториев..."
-    },
-    "repoLoadFailed": {
-        "message": "Не удалось загрузить репозитории."
-    },
-    "repoTokenPrivate": {
-        "message": "Токен недействителен или не имеет прав для частных репозиториев."
-    },
-    "repoRefetchFailed": {
-        "message": "Не удалось перезагрузить репозитории."
-    },
-    "orgSetMessage": {
-        "message": "Организация успешно установлена."
-    },
-    "orgClearedMessage": {
-        "message": "Организация удалена. Нажмите 'Создать отчет', чтобы получить все действия."
-    },
-    "orgNotFoundMessage": {
-        "message": "Организация не найдена на GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Ошибка при проверке организации."
-    },
-    "refreshingButton": {
-        "message": "Обновление..."
-    },
-    "cacheClearFailed": {
-        "message": "Не удалось очистить кэш."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Создание..."
-    },
-    "copiedButton": {
-        "message": "Скопировано!"
-    },
-    "orgChangedMessage": {
-        "message": "Организация изменена. Нажмите 'Создать отчет', чтобы получить данные о действиях в GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Кэш успешно очищен. Нажмите 'Создать отчет', чтобы получить свежие данные."
-    },
-    "cacheExpiredMessage": {
-        "message": "Кэш истёк. Нажмите \"Создать\", чтобы получить новые данные."
-    },
-    "cacheClearedButton": {
-        "message": "Кэш очищен!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Расширение отключено. Включите его в настройках, чтобы создавать scrum-отчеты."
-    },
-    "notePoint1": {
-        "message": "Pull-реквесты извлекаются на основе последней активности по проверке любого участника, а не только вашей. Пожалуйста, просмотрите и скорректируйте сгенерированный отчет SCRUM, чтобы убедиться, что он точно отражает вашу работу, прежде чем делиться им."
-    },
-    "noteSeeIssue": {
-        "message": "Смотрите эту проблему"
-    },
-    "platformLabel": {
-        "message": "Платформа"
-    },
-    "usernameLabel": {
-        "message": "Ваше имя пользователя"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Включить в отчет только проверенные PR"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Если отмечено, отчёт будет включать только PR, проверенные вами."
-    },
-    "onlyMergedPRsLabel": {
-        "message": "Включать в отчет только объединенные (merged) PR"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "Если отмечено, отчет будет включать только объединенные PR. Требуется токен GitHub."
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "Для фильтрации по объединенным PR требуется токен GitHub. Добавьте его в настройках."
-    },
-    "usernameRequiredError": {
-        "message": "Пожалуйста, введите имя пользователя для создания отчета."
-    },
-    "unknownPlatformError": {
-        "message": "Выбрана неизвестная платформа."
-    },
-    "gitlabFetchingError": {
-        "message": "Произошла ошибка при получении данных GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Произошла ошибка при создании отчета."
-    },
-    "githubUserNotFoundError": {
-        "message": "Пользователь GitHub \"$1\" не найден (404). Проверьте имя пользователя и попробуйте снова."
-    },
-    "githubUserValidationError": {
-        "message": "Ошибка при проверке пользователя GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Недопустимый поисковый запрос или диапазон дат. Проверьте формат и попробуйте снова."
-    },
-    "githubIssuesFetchError": {
-        "message": "Ошибка при получении задач GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Ошибка при получении данных проверки PR GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Ошибка при получении данных пользователя GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Недействительный или истекший токен GitHub. Проверьте токен в настройках Scrum Helper и попробуйте снова."
-    },
-    "displayModeNotice": {
-        "message": "Расширение откроется в режиме $1 при следующем запуске."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Фильтрация репозиториев доступна только для GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Загрузка репозиториев доступна только для GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Получение репозиториев доступно только для GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Репозитории загружаются автоматически..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Ошибка при получении пользователя GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Пользователь GitLab '$1' не найден"
-    },
-    "gitlabMembershipError": {
-        "message": "Ошибка при получении проектов членства GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Ошибка при получении проектов с вкладом GitLab: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Требуется имя пользователя."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Создание отчёта..."
-    },
-    "copyingReportNotification": {
-        "message": "Копирование отчёта..."
-    },
-    "copiedReportNotification": {
-        "message": "Отчет скопирован!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Вставка отчёта в письмо..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Отчёт вставлен в письмо!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Сообщайте о своем прогрессе в разработке, автоматически получая данные о вашей активности в Git за выбранный период."
+  },
+  "disableLabel": {
+    "message": "Отключить"
+  },
+  "enableLabel": {
+    "message": "Включить"
+  },
+  "projectNameLabel": {
+    "message": "Название проекта (используется в теме письма)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Введите название вашего проекта"
+  },
+  "githubUsernameLabel": {
+    "message": "Ваше имя пользователя GitHub"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Ваше имя пользователя GitLab"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Требуется для получения ваших вкладов"
+  },
+  "contributionsLabel": {
+    "message": "Получить ваши вклады за:"
+  },
+  "last1DayLabel": {
+    "message": "Предыдущий день"
+  },
+  "lastWeekLabel": {
+    "message": "Сводка за прошлую неделю",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "С:"
+  },
+  "endDateLabel": {
+    "message": "До:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Показывать статус Открыто/Закрыто"
+  },
+  "blockersLabel": {
+    "message": "Что мешает вашему прогрессу?"
+  },
+  "blockersPlaceholder": {
+    "message": "Введите причину"
+  },
+  "scrumReportLabel": {
+    "message": "Scrum-отчет"
+  },
+  "generateReportButton": {
+    "message": "Создать"
+  },
+  "copyReportButton": {
+    "message": "Копировать"
+  },
+  "insertInEmailButton": {
+    "message": "Вставить в письмо"
+  },
+  "insertToEmailFailedError": {
+    "message": "Откройте вкладку электронной почты, чтобы вставить отчет"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Название организации"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Введите название организации"
+  },
+  "setButton": {
+    "message": "Установить"
+  },
+  "githubTokenLabel": {
+    "message": "Ваш токен GitHub"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Требуется для аутентифицированных запросов"
+  },
+  "githubTokenTooltip": {
+    "message": "Зачем рекомендуется добавлять токен GitHub? Scrum Helper работает без токена GitHub, но для лучшего опыта рекомендуется добавить токен личного доступа."
+  },
+  "gitlabTokenLabel": {
+    "message": "Ваш токен GitLab"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Требуется для приватных репо"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Зачем рекомендуется добавлять токен GitLab? Scrum Helper работает без токена GitLab для публичных проектов, но для лучшего опыта рекомендуется добавить токен личного доступа."
+  },
+  "showCommitsLabel": {
+    "message": "Показывать коммиты в открытых PR/ черновиках PR"
+  },
+  "showCommitsTooltip": {
+    "message": "Требуется токен Github, добавьте его в настройках."
+  },
+  "onlyIssuesLabel": {
+    "message": "Включить в отчет только задачи"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Если флажок установлен, в отчет будут включены только задачи, созданные пользователем или назначенные ему."
+  },
+  "onlyPRsLabel": {
+    "message": "Включать в отчёт только PR"
+  },
+  "onlyPRsTooltip": {
+    "message": "Если отмечено, отчёт будет включать только pull request'ы, созданные пользователем; проверенные PR будут исключены."
+  },
+  "cacheTTLLabel": {
+    "message": "Введите TTL кеша"
+  },
+  "cacheTTLUnit": {
+    "message": "(в минутах)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Укажите TTL кэша в минутах (по умолчанию: 10)"
+  },
+  "refreshDataButton": {
+    "message": "Обновить данные (в обход кэша)"
+  },
+  "refreshDataInfo": {
+    "message": "Используйте эту кнопку для немедленного получения свежих данных."
+  },
+  "noteTitle": {
+    "message": "Примечание:"
+  },
+  "viewCodeButton": {
+    "message": "Посмотреть код"
+  },
+  "reportIssueButton": {
+    "message": "Сообщить о проблеме"
+  },
+  "repoFilterLabel": {
+    "message": "Фильтровать по репозиториям"
+  },
+  "enableFilteringLabel": {
+    "message": "Включить фильтрацию"
+  },
+  "tokenRequiredWarning": {
+    "message": "Для фильтрации репозиториев требуется токен GitHub. Пожалуйста, добавьте его в настройках."
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "Для показа коммитов в открытых или черновиках PR требуется токен GitHub. Добавьте его в настройках."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Найти репозиторий для добавления..."
+  },
+  "repoPlaceholder": {
+    "message": "Репозитории не выбраны (будут включены все)"
+  },
+  "repoCountNone": {
+    "message": "0 репозиториев выбрано"
+  },
+  "repoCount": {
+    "message": "$1 репозиториев выбрано"
+  },
+  "clearAllBtn": {
+    "message": "Очистить всё"
+  },
+  "repoLoading": {
+    "message": "Загрузка репозиториев..."
+  },
+  "repoLoaded": {
+    "message": "Загружено $1 репозиториев."
+  },
+  "repoNotFound": {
+    "message": "Репозитории не найдены"
+  },
+  "repoRefetching": {
+    "message": "Перезагрузка репозиториев..."
+  },
+  "repoLoadFailed": {
+    "message": "Не удалось загрузить репозитории."
+  },
+  "repoTokenPrivate": {
+    "message": "Токен недействителен или не имеет прав для частных репозиториев."
+  },
+  "repoRefetchFailed": {
+    "message": "Не удалось перезагрузить репозитории."
+  },
+  "orgSetMessage": {
+    "message": "Организация успешно установлена."
+  },
+  "orgClearedMessage": {
+    "message": "Организация удалена. Нажмите 'Создать отчет', чтобы получить все действия."
+  },
+  "orgNotFoundMessage": {
+    "message": "Организация не найдена на GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Ошибка при проверке организации."
+  },
+  "refreshingButton": {
+    "message": "Обновление..."
+  },
+  "cacheClearFailed": {
+    "message": "Не удалось очистить кэш."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Создание..."
+  },
+  "copiedButton": {
+    "message": "Скопировано!"
+  },
+  "orgChangedMessage": {
+    "message": "Организация изменена. Нажмите 'Создать отчет', чтобы получить данные о действиях в GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Кэш успешно очищен. Нажмите 'Создать отчет', чтобы получить свежие данные."
+  },
+  "cacheExpiredMessage": {
+    "message": "Кэш истёк. Нажмите \"Создать\", чтобы получить новые данные."
+  },
+  "cacheClearedButton": {
+    "message": "Кэш очищен!"
+  },
+  "extensionDisabledMessage": {
+    "message": "Расширение отключено. Включите его в настройках, чтобы создавать scrum-отчеты."
+  },
+  "notePoint1": {
+    "message": "Pull-реквесты извлекаются на основе последней активности по проверке любого участника, а не только вашей. Пожалуйста, просмотрите и скорректируйте сгенерированный отчет SCRUM, чтобы убедиться, что он точно отражает вашу работу, прежде чем делиться им."
+  },
+  "noteSeeIssue": {
+    "message": "Смотрите эту проблему"
+  },
+  "platformLabel": {
+    "message": "Платформа"
+  },
+  "usernameLabel": {
+    "message": "Ваше имя пользователя"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Включить в отчет только проверенные PR"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Если отмечено, отчёт будет включать только PR, проверенные вами."
+  },
+  "onlyMergedPRsLabel": {
+    "message": "Включать в отчет только объединенные (merged) PR"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "Если отмечено, отчет будет включать только объединенные PR. Требуется токен GitHub."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "Для фильтрации по объединенным PR требуется токен GitHub. Добавьте его в настройках."
+  },
+  "usernameRequiredError": {
+    "message": "Пожалуйста, введите имя пользователя для создания отчета."
+  },
+  "unknownPlatformError": {
+    "message": "Выбрана неизвестная платформа."
+  },
+  "gitlabFetchingError": {
+    "message": "Произошла ошибка при получении данных GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Произошла ошибка при создании отчета."
+  },
+  "githubUserNotFoundError": {
+    "message": "Пользователь GitHub \"$1\" не найден (404). Проверьте имя пользователя и попробуйте снова."
+  },
+  "githubUserValidationError": {
+    "message": "Ошибка при проверке пользователя GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Недопустимый поисковый запрос или диапазон дат. Проверьте формат и попробуйте снова."
+  },
+  "githubIssuesFetchError": {
+    "message": "Ошибка при получении задач GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Ошибка при получении данных проверки PR GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Ошибка при получении данных пользователя GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Недействительный или истекший токен GitHub. Проверьте токен в настройках Scrum Helper и попробуйте снова."
+  },
+  "displayModeNotice": {
+    "message": "Расширение откроется в режиме $1 при следующем запуске."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Фильтрация репозиториев доступна только для GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Загрузка репозиториев доступна только для GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Получение репозиториев доступно только для GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Репозитории загружаются автоматически..."
+  },
+  "gitlabUserFetchError": {
+    "message": "Ошибка при получении пользователя GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Пользователь GitLab '$1' не найден"
+  },
+  "gitlabMembershipError": {
+    "message": "Ошибка при получении проектов членства GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Ошибка при получении проектов с вкладом GitLab: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Требуется имя пользователя."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Создание отчёта..."
+  },
+  "copyingReportNotification": {
+    "message": "Копирование отчёта..."
+  },
+  "copiedReportNotification": {
+    "message": "Отчет скопирован!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Вставка отчёта в письмо..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Отчёт вставлен в письмо!"
+  }
 }

--- a/src/_locales/ta/messages.json
+++ b/src/_locales/ta/messages.json
@@ -1,335 +1,339 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "தேர்ந்தெடுக்கப்பட்ட காலப்பகுதிக்கான உங்கள் Git செயல்பாட்டைத் தானாகவே பெற்று, உங்கள் மேம்பாட்டு முன்னேற்றத்தைப் புகாரளியுங்கள்."
-    },
-    "disableLabel": {
-        "message": "முடக்கு"
-    },
-    "enableLabel": {
-        "message": "இயக்கு"
-    },
-    "projectNameLabel": {
-        "message": "திட்டப் பெயர் (மின்னஞ்சல் தலைப்பில் பயன்படுத்தப்படும்)"
-    },
-    "projectNamePlaceholder": {
-        "message": "உங்கள் திட்டப் பெயரை உள்ளிடவும்"
-    },
-    "githubUsernameLabel": {
-        "message": "உங்கள் GitHub பயனர்பெயர்"
-    },
-    "gitlabUsernameLabel": {
-        "message": "உங்கள் GitLab பயனர்பெயர்"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "உங்கள் பங்களிப்புகளை பெற தேவையானது"
-    },
-    "contributionsLabel": {
-        "message": "பங்களிப்புகளை பெற காலகட்டம்:"
-    },
-    "last1DayLabel": {
-        "message": "முந்தைய நாள்"
-    },
-    "startDateLabel": {
-        "message": "தொடக்கம்:"
-    },
-    "endDateLabel": {
-        "message": "முடிவு:"
-    },
-    "showOpenClosedLabel": {
-        "message": "PR லேபல்களைக் காட்டு"
-    },
-    "blockersLabel": {
-        "message": "உங்கள் முன்னேற்றத்தை தடுப்பது என்ன?"
-    },
-    "blockersPlaceholder": {
-        "message": "உங்கள் காரணத்தை உள்ளிடவும்"
-    },
-    "scrumReportLabel": {
-        "message": "Scrum அறிக்கை"
-    },
-    "generateReportButton": {
-        "message": "உருவாக்கு"
-    },
-    "copyReportButton": {
-        "message": "நகலெடு"
-    },
-    "insertInEmailButton": {
-        "message": "மின்னஞ்சலில் செருகு"
-    },
-    "insertToEmailFailedError": {
-        "message": "அறிக்கையைச் செருக மின்னஞ்சல் தாவலைத் திறக்கவும்"
-    },
-    "settingsOrgNameLabel": {
-        "message": "நிறுவன பெயர்"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "நிறுவன பெயரை உள்ளிடவும்"
-    },
-    "setButton": {
-        "message": "அமை"
-    },
-    "githubTokenLabel": {
-        "message": "உங்கள் GitHub டோக்கன்"
-    },
-    "githubTokenPlaceholder": {
-        "message": "அங்கீகரிக்கப்பட்ட கோரிக்கைகளுக்கு தேவையானது"
-    },
-    "githubTokenTooltip": {
-        "message": "GitHub டோக்கன் சேர்க்க ஏன் பரிந்துரைக்கப்படுகிறது? Scrum Helper GitHub டோக்கன் இல்லாமலும் செயல்படும், ஆனால் சிறந்த அனுபவத்திற்காக தனிப்பட்ட அணுகல் டோக்கன் சேர்க்க பரிந்துரைக்கப்படுகிறது."
-    },
-    "gitlabTokenLabel": {
-        "message": "உங்கள் GitLab டோக்கன்"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "தனிப்பட்ட திட்டங்களை அணுக தேவையானது"
-    },
-    "gitlabTokenTooltip": {
-        "message": "GitLab டோக்கன் சேர்க்க ஏன் பரிந்துரைக்கப்படுகிறது? Scrum Helper பொது திட்டங்களுக்கு GitLab டோக்கன் இல்லாமலும் செயல்படும், ஆனால் சிறந்த அனுபவத்திற்காக தனிப்பட்ட அணுகல் டோக்கன் சேர்க்க பரிந்துரைக்கப்படுகிறது."
-    },
-    "showCommitsLabel": {
-        "message": "திறந்த PR / வரைவு PR களில் commits காட்டு"
-    },
-    "showCommitsTooltip": {
-        "message": "GitHub டோக்கன் தேவை, அமைப்புகளில் சேர்க்கவும்."
-    },
-    "onlyIssuesLabel": {
-        "message": "அறிக்கையில் சிக்கல்களை மட்டும் சேர்"
-    },
-    "onlyIssuesTooltip": {
-        "message": "தேர்ந்தெடுக்கப்பட்டால், அறிக்கையில் பயனரால் உருவாக்கப்பட்ட அல்லது ஒதுக்கப்பட்ட சிக்கல்கள் மட்டுமே இருக்கும்."
-    },
-    "onlyPRsLabel": {
-        "message": "அறிக்கையில் PR களை மட்டும் சேர்"
-    },
-    "onlyPRsTooltip": {
-        "message": "தேர்ந்தெடுக்கப்பட்டால், அறிக்கையில் பயனரால் உருவாக்கப்பட்ட PR கள் மட்டுமே இருக்கும். மதிப்பாய்வு செய்யப்பட்ட PR கள் விலக்கப்படும்."
-    },
-    "cacheTTLLabel": {
-        "message": "தற்காலிக சேமிப்பு TTL ஐ உள்ளிடவும்"
-    },
-    "cacheTTLUnit": {
-        "message": "(நிமிடங்களில்)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "தற்காலிக சேமிப்பு TTL ஐ நிமிடங்களில் உள்ளிடவும் (இயல்புநிலை: 10 நிமிடங்கள்)"
-    },
-    "refreshDataButton": {
-        "message": "தரவை புதுப்பி (தற்காலிக சேமிப்பை புறக்கணி)"
-    },
-    "refreshDataInfo": {
-        "message": "புதிய தரவை உடனடியாக பெற இந்த பொத்தானை பயன்படுத்தவும்."
-    },
-    "noteTitle": {
-        "message": "குறிப்பு:"
-    },
-    "viewCodeButton": {
-        "message": "குறியீட்டைக் காண்"
-    },
-    "reportIssueButton": {
-        "message": "சிக்கலை அறிவி"
-    },
-    "repoFilterLabel": {
-        "message": "களஞ்சியங்களால் வடிகட்டு"
-    },
-    "enableFilteringLabel": {
-        "message": "வடிகட்டலை இயக்கு"
-    },
-    "tokenRequiredWarning": {
-        "message": "களஞ்சியங்களை வடிகட்ட GitHub டோக்கன் தேவை. அமைப்புகளில் ஒன்றை சேர்க்கவும்."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "திறந்த அல்லது வரைவு PR களில் commits காட்ட GitHub டோக்கன் தேவை. அமைப்புகளில் ஒன்றை சேர்க்கவும்."
-    },
-    "repoSearchPlaceholder": {
-        "message": "சேர்க்க களஞ்சியத்தை தேடவும்..."
-    },
-    "repoPlaceholder": {
-        "message": "களஞ்சியங்கள் தேர்ந்தெடுக்கப்படவில்லை (அனைத்தும் சேர்க்கப்படும்)"
-    },
-    "repoCountNone": {
-        "message": "0 களஞ்சியங்கள் தேர்ந்தெடுக்கப்பட்டன"
-    },
-    "repoCount": {
-        "message": "$1 களஞ்சியங்கள் தேர்ந்தெடுக்கப்பட்டன"
-    },
-    "repoLoading": {
-        "message": "களஞ்சியங்கள் ஏற்றப்படுகின்றன..."
-    },
-    "repoLoaded": {
-        "message": "$1 களஞ்சியங்கள் ஏற்றப்பட்டன."
-    },
-    "repoNotFound": {
-        "message": "களஞ்சியங்கள் எதுவும் கிடைக்கவில்லை"
-    },
-    "repoRefetching": {
-        "message": "களஞ்சியங்கள் மீண்டும் பெறப்படுகின்றன..."
-    },
-    "repoLoadFailed": {
-        "message": "களஞ்சியங்களை ஏற்றுவதில் தோல்வி."
-    },
-    "repoTokenPrivate": {
-        "message": "டோக்கன் தவறானது அல்லது தனிப்பட்ட களஞ்சியங்களுக்கான உரிமைகள் இல்லை."
-    },
-    "repoRefetchFailed": {
-        "message": "களஞ்சியங்களை மீண்டும் பெறுவதில் தோல்வி."
-    },
-    "orgSetMessage": {
-        "message": "நிறுவனம் வெற்றிகரமாக அமைக்கப்பட்டது."
-    },
-    "orgClearedMessage": {
-        "message": "நிறுவனம் அழிக்கப்பட்டது. அனைத்து செயல்பாடுகளையும் பெற 'உருவாக்கு' என்பதை கிளிக் செய்யவும்."
-    },
-    "orgNotFoundMessage": {
-        "message": "GitHub இல் நிறுவனம் கிடைக்கவில்லை."
-    },
-    "orgValidationErrorMessage": {
-        "message": "நிறுவனத்தை சரிபார்க்கும்போது பிழை."
-    },
-    "refreshingButton": {
-        "message": "புதுப்பிக்கிறது..."
-    },
-    "cacheClearFailed": {
-        "message": "தற்காலிக சேமிப்பை அழிப்பதில் தோல்வி."
-    },
-    "madeWithLoveBy": {
-        "message": "❤️ உடன் உருவாக்கியவர்"
-    },
-    "generatingButton": {
-        "message": "உருவாக்குகிறது..."
-    },
-    "copiedButton": {
-        "message": "நகலெடுக்கப்பட்டது!"
-    },
-    "orgChangedMessage": {
-        "message": "நிறுவனம் மாற்றப்பட்டது. GitHub செயல்பாடுகளை பெற 'உருவாக்கு' பொத்தானை கிளிக் செய்யவும்."
-    },
-    "cacheClearedMessage": {
-        "message": "தற்காலிக சேமிப்பு வெற்றிகரமாக அழிக்கப்பட்டது. புதிய தரவை பெற «உருவாக்கு» என்பதை கிளிக் செய்யவும்."
-    },
-    "cacheExpiredMessage": {
-        "message": "தற்காலிக சேமிப்பு காலாவதியானது. புதிய தரவை பெற «உருவாக்கு» என்பதை கிளிக் செய்யவும்."
-    },
-    "cacheClearedButton": {
-        "message": "தற்காலிக சேமிப்பு அழிக்கப்பட்டது!"
-    },
-    "extensionDisabledMessage": {
-        "message": "நீட்டிப்பு முடக்கப்பட்டுள்ளது. Scrum அறிக்கைகளை உருவாக்க விருப்பங்களில் இருந்து இயக்கவும்."
-    },
-    "notePoint1": {
-        "message": "Pull requests உங்களது மட்டுமல்ல, எந்தவொரு பங்களிப்பாளரின் சமீபத்திய மதிப்பாய்வு செயல்பாட்டின் அடிப்படையில் பெறப்படுகின்றன. பகிர்வதற்கு முன்பு உங்கள் பணியை துல்லியமாக பிரதிபலிக்கிறதா என்பதை உறுதிப்படுத்த உருவாக்கப்பட்ட SCRUM அறிக்கையை மதிப்பாய்வு செய்து சரிசெய்யவும்."
-    },
-    "noteSeeIssue": {
-        "message": "இந்த சிக்கலைப் பாருங்கள்"
-    },
-    "platformLabel": {
-        "message": "தளம்"
-    },
-    "usernameLabel": {
-        "message": "உங்கள் பயனர்பெயர்"
-    },
-    "onlyRevPRsLabel": {
-        "message": "அறிக்கையில் மதிப்பாய்வு செய்யப்பட்ட PR களை மட்டும் சேர்"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "தேர்ந்தெடுக்கப்பட்டால், அறிக்கையில் நீங்கள் மதிப்பாய்வு செய்த PR கள் மட்டுமே இருக்கும்."
-    },
-    "onlyMergedPRsLabel": {
-        "message": "இணைக்கப்பட்ட பிஆர்களை மட்டும் அறிக்கையில் சேர்க்கவும்"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "தேர்ந்தெடுக்கப்பட்டால், அறிக்கை இணைக்கப்பட்ட பிஆர்களை மட்டுமே உள்ளடக்கும். ஒரு GitHub டோக்கன் தேவை."
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "இணைக்கப்பட்ட பிஆர்கள் மூலம் வடிகட்ட ஒரு GitHub டோக்கன் தேவை. அமைப்புகளில் ஒன்றைச் சேர்க்கவும்."
-    },
-    "usernameRequiredError": {
-        "message": "அறிக்கையை உருவாக்க உங்கள் பயனர்பெயரை உள்ளிடவும்."
-    },
-    "unknownPlatformError": {
-        "message": "அறியப்படாத தளம் தேர்ந்தெடுக்கப்பட்டது."
-    },
-    "gitlabFetchingError": {
-        "message": "GitLab தரவை எடுக்கும்போது பிழை ஏற்பட்டது."
-    },
-    "reportGenerationError": {
-        "message": "அறிக்கையை உருவாக்கும்போது பிழை ஏற்பட்டது."
-    },
-    "githubUserNotFoundError": {
-        "message": "GitHub பயனர் \"$1\" கண்டறியப்படவில்லை."
-    },
-    "githubUserValidationError": {
-        "message": "GitHub பயனரைச் சரிபார்ப்பதில் பிழை: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "தவறான தேடல் அல்லது தேதி வரம்பு. வடிவத்தை சரிபார்த்து மீண்டும் முயற்சிக்கவும்."
-    },
-    "githubIssuesFetchError": {
-        "message": "GitHub சிக்கல்களை எடுப்பதில் பிழை: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "GitHub PR மதிப்பாய்வு தரவை எடுப்பதில் பிழை: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "GitHub பயனர் தரவை எடுப்பதில் பிழை: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "தவறான அல்லது காலாவதியான GitHub டோக்கன். Scrum Helper அமைப்புகளில் உங்கள் டோக்கனைச் சரிபார்த்து மீண்டும் முயற்சிக்கவும்."
-    },
-    "displayModeNotice": {
-        "message": "அடுத்த துவக்கத்தில் நீட்டிப்பு $1 பயன்முறையில் திறக்கும்."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "தொகுப்பு வடிகட்டுதல் GitHubக்கு மட்டுமே கிடைக்கும்."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "தொகுப்பு ஏற்றுதல் GitHubக்கு மட்டுமே கிடைக்கும்."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "தொகுப்பு மீட்டெடுப்பு GitHubக்கு மட்டுமே கிடைக்கும்."
-    },
-    "loadingReposAutomatically": {
-        "message": "தொகுப்புகள் தானாகவே ஏற்றப்படுகின்றன..."
-    },
-    "gitlabUserFetchError": {
-        "message": "GitLab பயனரை எடுப்பதில் பிழை: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "GitLab பயனர் '$1' கண்டறியப்படவில்லை."
-    },
-    "gitlabMembershipError": {
-        "message": "GitLab உறுப்பினர் திட்டங்களை எடுப்பதில் பிழை: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "GitLab பங்களிப்பு திட்டங்களை எடுப்பதில் பிழை: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "பயனர்பெயர் தேவை."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "அறிக்கை உருவாக்கப்படுகிறது..."
-    },
-    "copyingReportNotification": {
-        "message": "அறிக்கை நகலெடுக்கப்படுகிறது..."
-    },
-    "copiedReportNotification": {
-        "message": "அறிக்கை நகலெடுக்கப்பட்டது!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "அறிக்கையை மின்னஞ்சலில் செருகுகிறது..."
-    },
-    "insertedInEmailNotification": {
-        "message": "அறிக்கை மின்னஞ்சலில் செருகப்பட்டது!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "தேர்ந்தெடுக்கப்பட்ட காலப்பகுதிக்கான உங்கள் Git செயல்பாட்டைத் தானாகவே பெற்று, உங்கள் மேம்பாட்டு முன்னேற்றத்தைப் புகாரளியுங்கள்."
+  },
+  "disableLabel": {
+    "message": "முடக்கு"
+  },
+  "enableLabel": {
+    "message": "இயக்கு"
+  },
+  "projectNameLabel": {
+    "message": "திட்டப் பெயர் (மின்னஞ்சல் தலைப்பில் பயன்படுத்தப்படும்)"
+  },
+  "projectNamePlaceholder": {
+    "message": "உங்கள் திட்டப் பெயரை உள்ளிடவும்"
+  },
+  "githubUsernameLabel": {
+    "message": "உங்கள் GitHub பயனர்பெயர்"
+  },
+  "gitlabUsernameLabel": {
+    "message": "உங்கள் GitLab பயனர்பெயர்"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "உங்கள் பங்களிப்புகளை பெற தேவையானது"
+  },
+  "contributionsLabel": {
+    "message": "பங்களிப்புகளை பெற காலகட்டம்:"
+  },
+  "last1DayLabel": {
+    "message": "முந்தைய நாள்"
+  },
+  "lastWeekLabel": {
+    "message": "கடந்த வார சுруக்கம்",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "தொடக்கம்:"
+  },
+  "endDateLabel": {
+    "message": "முடிவு:"
+  },
+  "showOpenClosedLabel": {
+    "message": "PR லேபல்களைக் காட்டு"
+  },
+  "blockersLabel": {
+    "message": "உங்கள் முன்னேற்றத்தை தடுப்பது என்ன?"
+  },
+  "blockersPlaceholder": {
+    "message": "உங்கள் காரணத்தை உள்ளிடவும்"
+  },
+  "scrumReportLabel": {
+    "message": "Scrum அறிக்கை"
+  },
+  "generateReportButton": {
+    "message": "உருவாக்கு"
+  },
+  "copyReportButton": {
+    "message": "நகலெடு"
+  },
+  "insertInEmailButton": {
+    "message": "மின்னஞ்சலில் செருகு"
+  },
+  "insertToEmailFailedError": {
+    "message": "அறிக்கையைச் செருக மின்னஞ்சல் தாவலைத் திறக்கவும்"
+  },
+  "settingsOrgNameLabel": {
+    "message": "நிறுவன பெயர்"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "நிறுவன பெயரை உள்ளிடவும்"
+  },
+  "setButton": {
+    "message": "அமை"
+  },
+  "githubTokenLabel": {
+    "message": "உங்கள் GitHub டோக்கன்"
+  },
+  "githubTokenPlaceholder": {
+    "message": "அங்கீகரிக்கப்பட்ட கோரிக்கைகளுக்கு தேவையானது"
+  },
+  "githubTokenTooltip": {
+    "message": "GitHub டோக்கன் சேர்க்க ஏன் பரிந்துரைக்கப்படுகிறது? Scrum Helper GitHub டோக்கன் இல்லாமலும் செயல்படும், ஆனால் சிறந்த அனுபவத்திற்காக தனிப்பட்ட அணுகல் டோக்கன் சேர்க்க பரிந்துரைக்கப்படுகிறது."
+  },
+  "gitlabTokenLabel": {
+    "message": "உங்கள் GitLab டோக்கன்"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "தனிப்பட்ட திட்டங்களை அணுக தேவையானது"
+  },
+  "gitlabTokenTooltip": {
+    "message": "GitLab டோக்கன் சேர்க்க ஏன் பரிந்துரைக்கப்படுகிறது? Scrum Helper பொது திட்டங்களுக்கு GitLab டோக்கன் இல்லாமலும் செயல்படும், ஆனால் சிறந்த அனுபவத்திற்காக தனிப்பட்ட அணுகல் டோக்கன் சேர்க்க பரிந்துரைக்கப்படுகிறது."
+  },
+  "showCommitsLabel": {
+    "message": "திறந்த PR / வரைவு PR களில் commits காட்டு"
+  },
+  "showCommitsTooltip": {
+    "message": "GitHub டோக்கன் தேவை, அமைப்புகளில் சேர்க்கவும்."
+  },
+  "onlyIssuesLabel": {
+    "message": "அறிக்கையில் சிக்கல்களை மட்டும் சேர்"
+  },
+  "onlyIssuesTooltip": {
+    "message": "தேர்ந்தெடுக்கப்பட்டால், அறிக்கையில் பயனரால் உருவாக்கப்பட்ட அல்லது ஒதுக்கப்பட்ட சிக்கல்கள் மட்டுமே இருக்கும்."
+  },
+  "onlyPRsLabel": {
+    "message": "அறிக்கையில் PR களை மட்டும் சேர்"
+  },
+  "onlyPRsTooltip": {
+    "message": "தேர்ந்தெடுக்கப்பட்டால், அறிக்கையில் பயனரால் உருவாக்கப்பட்ட PR கள் மட்டுமே இருக்கும். மதிப்பாய்வு செய்யப்பட்ட PR கள் விலக்கப்படும்."
+  },
+  "cacheTTLLabel": {
+    "message": "தற்காலிக சேமிப்பு TTL ஐ உள்ளிடவும்"
+  },
+  "cacheTTLUnit": {
+    "message": "(நிமிடங்களில்)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "தற்காலிக சேமிப்பு TTL ஐ நிமிடங்களில் உள்ளிடவும் (இயல்புநிலை: 10 நிமிடங்கள்)"
+  },
+  "refreshDataButton": {
+    "message": "தரவை புதுப்பி (தற்காலிக சேமிப்பை புறக்கணி)"
+  },
+  "refreshDataInfo": {
+    "message": "புதிய தரவை உடனடியாக பெற இந்த பொத்தானை பயன்படுத்தவும்."
+  },
+  "noteTitle": {
+    "message": "குறிப்பு:"
+  },
+  "viewCodeButton": {
+    "message": "குறியீட்டைக் காண்"
+  },
+  "reportIssueButton": {
+    "message": "சிக்கலை அறிவி"
+  },
+  "repoFilterLabel": {
+    "message": "களஞ்சியங்களால் வடிகட்டு"
+  },
+  "enableFilteringLabel": {
+    "message": "வடிகட்டலை இயக்கு"
+  },
+  "tokenRequiredWarning": {
+    "message": "களஞ்சியங்களை வடிகட்ட GitHub டோக்கன் தேவை. அமைப்புகளில் ஒன்றை சேர்க்கவும்."
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "திறந்த அல்லது வரைவு PR களில் commits காட்ட GitHub டோக்கன் தேவை. அமைப்புகளில் ஒன்றை சேர்க்கவும்."
+  },
+  "repoSearchPlaceholder": {
+    "message": "சேர்க்க களஞ்சியத்தை தேடவும்..."
+  },
+  "repoPlaceholder": {
+    "message": "களஞ்சியங்கள் தேர்ந்தெடுக்கப்படவில்லை (அனைத்தும் சேர்க்கப்படும்)"
+  },
+  "repoCountNone": {
+    "message": "0 களஞ்சியங்கள் தேர்ந்தெடுக்கப்பட்டன"
+  },
+  "repoCount": {
+    "message": "$1 களஞ்சியங்கள் தேர்ந்தெடுக்கப்பட்டன"
+  },
+  "repoLoading": {
+    "message": "களஞ்சியங்கள் ஏற்றப்படுகின்றன..."
+  },
+  "repoLoaded": {
+    "message": "$1 களஞ்சியங்கள் ஏற்றப்பட்டன."
+  },
+  "repoNotFound": {
+    "message": "களஞ்சியங்கள் எதுவும் கிடைக்கவில்லை"
+  },
+  "repoRefetching": {
+    "message": "களஞ்சியங்கள் மீண்டும் பெறப்படுகின்றன..."
+  },
+  "repoLoadFailed": {
+    "message": "களஞ்சியங்களை ஏற்றுவதில் தோல்வி."
+  },
+  "repoTokenPrivate": {
+    "message": "டோக்கன் தவறானது அல்லது தனிப்பட்ட களஞ்சியங்களுக்கான உரிமைகள் இல்லை."
+  },
+  "repoRefetchFailed": {
+    "message": "களஞ்சியங்களை மீண்டும் பெறுவதில் தோல்வி."
+  },
+  "orgSetMessage": {
+    "message": "நிறுவனம் வெற்றிகரமாக அமைக்கப்பட்டது."
+  },
+  "orgClearedMessage": {
+    "message": "நிறுவனம் அழிக்கப்பட்டது. அனைத்து செயல்பாடுகளையும் பெற 'உருவாக்கு' என்பதை கிளிக் செய்யவும்."
+  },
+  "orgNotFoundMessage": {
+    "message": "GitHub இல் நிறுவனம் கிடைக்கவில்லை."
+  },
+  "orgValidationErrorMessage": {
+    "message": "நிறுவனத்தை சரிபார்க்கும்போது பிழை."
+  },
+  "refreshingButton": {
+    "message": "புதுப்பிக்கிறது..."
+  },
+  "cacheClearFailed": {
+    "message": "தற்காலிக சேமிப்பை அழிப்பதில் தோல்வி."
+  },
+  "madeWithLoveBy": {
+    "message": "❤️ உடன் உருவாக்கியவர்"
+  },
+  "generatingButton": {
+    "message": "உருவாக்குகிறது..."
+  },
+  "copiedButton": {
+    "message": "நகலெடுக்கப்பட்டது!"
+  },
+  "orgChangedMessage": {
+    "message": "நிறுவனம் மாற்றப்பட்டது. GitHub செயல்பாடுகளை பெற 'உருவாக்கு' பொத்தானை கிளிக் செய்யவும்."
+  },
+  "cacheClearedMessage": {
+    "message": "தற்காலிக சேமிப்பு வெற்றிகரமாக அழிக்கப்பட்டது. புதிய தரவை பெற «உருவாக்கு» என்பதை கிளிக் செய்யவும்."
+  },
+  "cacheExpiredMessage": {
+    "message": "தற்காலிக சேமிப்பு காலாவதியானது. புதிய தரவை பெற «உருவாக்கு» என்பதை கிளிக் செய்யவும்."
+  },
+  "cacheClearedButton": {
+    "message": "தற்காலிக சேமிப்பு அழிக்கப்பட்டது!"
+  },
+  "extensionDisabledMessage": {
+    "message": "நீட்டிப்பு முடக்கப்பட்டுள்ளது. Scrum அறிக்கைகளை உருவாக்க விருப்பங்களில் இருந்து இயக்கவும்."
+  },
+  "notePoint1": {
+    "message": "Pull requests உங்களது மட்டுமல்ல, எந்தவொரு பங்களிப்பாளரின் சமீபத்திய மதிப்பாய்வு செயல்பாட்டின் அடிப்படையில் பெறப்படுகின்றன. பகிர்வதற்கு முன்பு உங்கள் பணியை துல்லியமாக பிரதிபலிக்கிறதா என்பதை உறுதிப்படுத்த உருவாக்கப்பட்ட SCRUM அறிக்கையை மதிப்பாய்வு செய்து சரிசெய்யவும்."
+  },
+  "noteSeeIssue": {
+    "message": "இந்த சிக்கலைப் பாருங்கள்"
+  },
+  "platformLabel": {
+    "message": "தளம்"
+  },
+  "usernameLabel": {
+    "message": "உங்கள் பயனர்பெயர்"
+  },
+  "onlyRevPRsLabel": {
+    "message": "அறிக்கையில் மதிப்பாய்வு செய்யப்பட்ட PR களை மட்டும் சேர்"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "தேர்ந்தெடுக்கப்பட்டால், அறிக்கையில் நீங்கள் மதிப்பாய்வு செய்த PR கள் மட்டுமே இருக்கும்."
+  },
+  "onlyMergedPRsLabel": {
+    "message": "இணைக்கப்பட்ட பிஆர்களை மட்டும் அறிக்கையில் சேர்க்கவும்"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "தேர்ந்தெடுக்கப்பட்டால், அறிக்கை இணைக்கப்பட்ட பிஆர்களை மட்டுமே உள்ளடக்கும். ஒரு GitHub டோக்கன் தேவை."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "இணைக்கப்பட்ட பிஆர்கள் மூலம் வடிகட்ட ஒரு GitHub டோக்கன் தேவை. அமைப்புகளில் ஒன்றைச் சேர்க்கவும்."
+  },
+  "usernameRequiredError": {
+    "message": "அறிக்கையை உருவாக்க உங்கள் பயனர்பெயரை உள்ளிடவும்."
+  },
+  "unknownPlatformError": {
+    "message": "அறியப்படாத தளம் தேர்ந்தெடுக்கப்பட்டது."
+  },
+  "gitlabFetchingError": {
+    "message": "GitLab தரவை எடுக்கும்போது பிழை ஏற்பட்டது."
+  },
+  "reportGenerationError": {
+    "message": "அறிக்கையை உருவாக்கும்போது பிழை ஏற்பட்டது."
+  },
+  "githubUserNotFoundError": {
+    "message": "GitHub பயனர் \"$1\" கண்டறியப்படவில்லை."
+  },
+  "githubUserValidationError": {
+    "message": "GitHub பயனரைச் சரிபார்ப்பதில் பிழை: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "தவறான தேடல் அல்லது தேதி வரம்பு. வடிவத்தை சரிபார்த்து மீண்டும் முயற்சிக்கவும்."
+  },
+  "githubIssuesFetchError": {
+    "message": "GitHub சிக்கல்களை எடுப்பதில் பிழை: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "GitHub PR மதிப்பாய்வு தரவை எடுப்பதில் பிழை: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "GitHub பயனர் தரவை எடுப்பதில் பிழை: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "தவறான அல்லது காலாவதியான GitHub டோக்கன். Scrum Helper அமைப்புகளில் உங்கள் டோக்கனைச் சரிபார்த்து மீண்டும் முயற்சிக்கவும்."
+  },
+  "displayModeNotice": {
+    "message": "அடுத்த துவக்கத்தில் நீட்டிப்பு $1 பயன்முறையில் திறக்கும்."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "தொகுப்பு வடிகட்டுதல் GitHubக்கு மட்டுமே கிடைக்கும்."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "தொகுப்பு ஏற்றுதல் GitHubக்கு மட்டுமே கிடைக்கும்."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "தொகுப்பு மீட்டெடுப்பு GitHubக்கு மட்டுமே கிடைக்கும்."
+  },
+  "loadingReposAutomatically": {
+    "message": "தொகுப்புகள் தானாகவே ஏற்றப்படுகின்றன..."
+  },
+  "gitlabUserFetchError": {
+    "message": "GitLab பயனரை எடுப்பதில் பிழை: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "GitLab பயனர் '$1' கண்டறியப்படவில்லை."
+  },
+  "gitlabMembershipError": {
+    "message": "GitLab உறுப்பினர் திட்டங்களை எடுப்பதில் பிழை: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "GitLab பங்களிப்பு திட்டங்களை எடுப்பதில் பிழை: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "பயனர்பெயர் தேவை."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "அறிக்கை உருவாக்கப்படுகிறது..."
+  },
+  "copyingReportNotification": {
+    "message": "அறிக்கை நகலெடுக்கப்படுகிறது..."
+  },
+  "copiedReportNotification": {
+    "message": "அறிக்கை நகலெடுக்கப்பட்டது!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "அறிக்கையை மின்னஞ்சலில் செருகுகிறது..."
+  },
+  "insertedInEmailNotification": {
+    "message": "அறிக்கை மின்னஞ்சலில் செருகப்பட்டது!"
+  }
 }

--- a/src/_locales/te/messages.json
+++ b/src/_locales/te/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "ఎంచుకున్న కాలవ్యవధికి మీ Git కార్యకలాపాలను స్వయంచాలకంగా తెచ్చి, మీ అభివృద్ధి పురోగతిని నివేదించండి"
-    },
-    "disableLabel": {
-        "message": "అచేతనం"
-    },
-    "enableLabel": {
-        "message": "సక్రియం"
-    },
-    "projectNameLabel": {
-        "message": "ప్రాజెక్ట్ పేరు (ఇమెయిల్ విషయంలో వాడబడుతుంది)"
-    },
-    "projectNamePlaceholder": {
-        "message": "మీ ప్రాజెక్ట్ పేరును నమోదు చేయండి"
-    },
-    "githubUsernameLabel": {
-        "message": "మీ GitHub వాడుకరి పేరు"
-    },
-    "gitlabUsernameLabel": {
-        "message": "మీ GitLab వాడుకరి పేరు"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "మీ సహకారాలను తెచ్చుకోవడానికి అవసరం"
-    },
-    "contributionsLabel": {
-        "message": "మీ సహకారాలను ఇక్కడ నుండి తెచ్చుకోండి:"
-    },
-    "last1DayLabel": {
-        "message": "గత రోజు"
-    },
-    "startDateLabel": {
-        "message": "నుండి:"
-    },
-    "endDateLabel": {
-        "message": "వరకు:"
-    },
-    "showOpenClosedLabel": {
-        "message": "PR లేబుళ్లు చూపించు"
-    },
-    "blockersLabel": {
-        "message": "మీరు ఏమి కారణంగా ముందుకు సాగలేకపోతున్నారు?"
-    },
-    "blockersPlaceholder": {
-        "message": "మీ కారణం ఇక్కడ రాయండి"
-    },
-    "scrumReportLabel": {
-        "message": "స్క్రమ్ నివేదిక"
-    },
-    "generateReportButton": {
-        "message": "సృష్టించు"
-    },
-    "copyReportButton": {
-        "message": "కాపీ"
-    },
-    "insertInEmailButton": {
-        "message": "ఇమెయిల్‌లో చేర్చు"
-    },
-    "insertToEmailFailedError": {
-        "message": "నివేదికను చొప్పించడానికి ఒక ఇమెయిల్ ట్యాబ్‌ను తెరవండి"
-    },
-    "settingsOrgNameLabel": {
-        "message": "సంస్థ పేరు"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "సంస్థ పేరును నమోదు చేయండి"
-    },
-    "setButton": {
-        "message": "సెట్ చేయి"
-    },
-    "githubTokenLabel": {
-        "message": "మీ GitHub టోకెన్"
-    },
-    "githubTokenPlaceholder": {
-        "message": "ఆథెంటికేటెడ్ అభ్యర్థనలకు అవసరం"
-    },
-    "githubTokenTooltip": {
-        "message": "GitHub టోకెన్‌ను జోడించడం ఎందుకు సిఫారసు చేయబడుతుంది? Scrum Helper GitHub టోకెన్ లేకుండా పనిచేస్తుంది, కాని మెరుగైన అనుభవం కోసం ఒక ఖాతా ఆక్సెస్ టోకెన్‌ను జోడించడం సిఫారసు చేయబడుతుంది."
-    },
-    "gitlabTokenLabel": {
-        "message": "మీ GitLab టోకెన్"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "ప్రైవేట్ రెపోస్ కోసం అవసరం"
-    },
-    "gitlabTokenTooltip": {
-        "message": "GitLab టోకెన్‌ను జోడించడం ఎందుకు సిఫారసు చేయబడుతుంది? Scrum Helper పబ్లిక్ ప్రాజెక్ట్‌ల కోసం GitLab టోకెన్ లేకుండా పనిచేస్తుంది, కానీ మెరుగైన అనుభవం కోసం ఒక ఖాతా ఆక్సెస్ టోకెన్‌ను జోడించడం సిఫారసు చేయబడుతుంది."
-    },
-    "showCommitsLabel": {
-        "message": "ఓపెన్ PRలు / డ్రాఫ్ట్ PRలపై కమిట్లు చూపించు"
-    },
-    "showCommitsTooltip": {
-        "message": "GitHub టోకెన్ అవసరం — దయచేసి సెట్టింగ్స్‌లో జోడించండి."
-    },
-    "onlyIssuesLabel": {
-        "message": "నివేదికలో ఇష్యూలను మాత్రమే చేర్చు"
-    },
-    "onlyIssuesTooltip": {
-        "message": "ఎంచుకుంటే, నివేదికలో వాడుకరికి కేటాయించబడిన లేదా సృష్టించబడిన ఇష్యూలు మాత్రమే చూపబడతాయి."
-    },
-    "onlyPRsLabel": {
-        "message": "నివేదికలో PRలను మాత్రమే చేర్చు"
-    },
-    "onlyPRsTooltip": {
-        "message": "ఎంచుకుంటే, నివేదికలో మీరు సృష్టించిన PRలు మాత్రమే ఉంటాయి. సమీక్షించిన PRలు తప్పించబడతాయి."
-    },
-    "cacheTTLLabel": {
-        "message": "క్యాష్ TTL ను నమోదు చేయండి"
-    },
-    "cacheTTLUnit": {
-        "message": "(నిమిషాలలో)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "క్యాష్ TTL ని నిమిషాలలో రాయండి (డిఫాల్ట్ 10 నిమిషాలు)"
-    },
-    "refreshDataButton": {
-        "message": "డేటా రీఫ్రెష్ చేయండి (క్యాష్‌ను దాటవేయండి)"
-    },
-    "refreshDataInfo": {
-        "message": "తాజా డేటాను వెంటనే తెచ్చుకోవడానికి ఈ బటన్‌ను ఉపయోగించండి."
-    },
-    "noteTitle": {
-        "message": "గమనిక:"
-    },
-    "viewCodeButton": {
-        "message": "కోడ్ చూడండి"
-    },
-    "reportIssueButton": {
-        "message": "సమస్యను నివేదించండి"
-    },
-    "repoFilterLabel": {
-        "message": "రిపోజిటరీల ద్వారా ఫిల్టర్ చేయండి"
-    },
-    "enableFilteringLabel": {
-        "message": "ఫిల్టరింగ్‌ని ప్రారంభించండి"
-    },
-    "tokenRequiredWarning": {
-        "message": "రిపోజిటరీ ఫిల్టరింగ్ కోసం GitHub టోకెన్ అవసరం. దయచేసి సెట్టింగ్‌లలో ఒకదాన్ని జోడించండి."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "ఓపెన్ లేదా డ్రాఫ్ట్ పిఆర్‌లలో కమిట్‌లను చూపించడానికి గిట్‌హబ్ టోకెన్ అవసరం. దయచేసి సెట్టింగ్‌లలో ఒకదాన్ని జోడించండి."
-    },
-    "repoSearchPlaceholder": {
-        "message": "రిపోజిటరీల కోసం శోధించండి..."
-    },
-    "repoPlaceholder": {
-        "message": "ఎంచుకున్న రిపోజిటరీలు లేవు (అన్నీ చేర్చబడతాయి)"
-    },
-    "repoCountNone": {
-        "message": "0 రిపోజిటరీలు ఎంచుకోబడ్డాయి"
-    },
-    "repoCount": {
-        "message": "$1 రిపోజిటరీలు ఎంపిక చేయబడ్డాయి"
-    },
-    "clearAllBtn": {
-        "message": "అన్నీ తొలగించు"
-    },
-    "repoLoading": {
-        "message": "రిపోజిటరీలు లోడ్ అవుతున్నాయి..."
-    },
-    "repoLoaded": {
-        "message": "$1 రిపోజిటరీలు లోడ్ అయ్యాయి."
-    },
-    "repoNotFound": {
-        "message": "రిపోజిటరీలు కనబడలేదు"
-    },
-    "repoRefetching": {
-        "message": "రిపోజిటరీలను మళ్లీ తెచ్చుకుంటున్నారు..."
-    },
-    "repoLoadFailed": {
-        "message": "రిపోజిటరీలను లోడ్ చేయలేకపోయాం."
-    },
-    "repoTokenPrivate": {
-        "message": "టోకెన్ చెల్లదు లేదా ప్రైవేట్ రిపోజిటరీలకు అనుమతి లేదు."
-    },
-    "repoRefetchFailed": {
-        "message": "రిపోజిటరీలను మళ్లీ తెచ్చుకోవడం విఫలమైంది."
-    },
-    "orgSetMessage": {
-        "message": "సంస్థ విజయవంతంగా సెట్ చేయబడింది."
-    },
-    "orgClearedMessage": {
-        "message": "సంస్థ తొలగించబడింది. అన్ని కార్యకలాపాలు తెచ్చుకోవడానికి 'నివేదికను రూపొందించు' పై క్లిక్ చేయండి."
-    },
-    "orgNotFoundMessage": {
-        "message": "GitHub లో సంస్థ కనుగొనబడలేదు."
-    },
-    "orgValidationErrorMessage": {
-        "message": "సంస్థను ధృవీకరించడంలో లోపం."
-    },
-    "refreshingButton": {
-        "message": "రిఫ్రెష్ అవుతోంది..."
-    },
-    "cacheClearFailed": {
-        "message": "క్యాష్ క్లియర్ చేయడం విఫలమైంది."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "జనరేట్ అవుతోంది..."
-    },
-    "copiedButton": {
-        "message": "కాపీ అయింది!"
-    },
-    "orgChangedMessage": {
-        "message": "సంస్థ మార్చబడింది. GitHub కార్యకలాపాలను తెచ్చుకోవడానికి 'నివేదికను రూపొందించు' పై క్లిక్ చేయండి."
-    },
-    "cacheClearedMessage": {
-        "message": "క్యాష్ విజయవంతంగా క్లియర్ చేయబడింది. తాజా డేటా కోసం \"నివేదికను రూపొందించు\" పై క్లిక్ చేయండి."
-    },
-    "cacheExpiredMessage": {
-        "message": "క్యాష్ గడువు ముగిసింది. తాజా డేటా పొందడానికి \"నివేదికను రూపొందించు\" పై క్లిక్ చేయండి."
-    },
-    "cacheClearedButton": {
-        "message": "కాష్ తొలగించబడింది!"
-    },
-    "extensionDisabledMessage": {
-        "message": "ఎక్స్‌టెన్షన్ నిలిపివేయబడింది. స్క్రమ్ నివేదికలు రూపొందించేందుకు సెట్టింగ్స్‌లో ఎనేబుల్ చేయండి."
-    },
-    "notePoint1": {
-        "message": "పుల్ రిక్వెస్ట్‌లు మీ స్వంత సమీక్షా కార్యాచరణ ఆధారంగా మాత్రమే కాకుండా, ఏ సహకారుని ద్వారా కూడా తీసుకోబడతాయి. పంచుకునే ముందు మీ పనిని ఖచ్చితంగా ప్రతిబింబిస్తుందని నిర్ధారించుకోవడానికి ఉత్పన్నమైన SCRUM నివేదికను సమీక్షించండి మరియు సర్దుబాటు చేయండి."
-    },
-    "noteSeeIssue": {
-        "message": "ఈ ఇష్యూ చూడండి"
-    },
-    "platformLabel": {
-        "message": "ప్లాట్‌ఫారమ్"
-    },
-    "usernameLabel": {
-        "message": "మీ యూజర్‌నేమ్"
-    },
-    "onlyRevPRsLabel": {
-        "message": "నివేదికలో మీరు సమీక్షించిన PRలను మాత్రమే చేర్చు"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "ఎంచుకుంటే, నివేదికలో మీరు సమీక్షించిన PRలు మాత్రమే చూపబడతాయి."
-    },
-    "onlyMergedPRsLabel": {
-        "message": "విలీనం చేయబడిన పిఆర్‌లను మాత్రమే నివేదికలో చేర్చండి"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "ఎంపిక చేస్తే, నివేదిక విలీనం చేయబడిన పిఆర్‌లను మాత్రమే కలిగి ఉంటుంది. గిట్‌హబ్ టోకెన్ అవసరం."
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "విలీనం చేయబడిన పిఆర్‌ల ద్వారా వడపోయడానికి గిట్‌హబ్ టోకెన్ అవసరం. సెట్టింగ్‌లలో ఒకదాన్ని జోడించండి."
-    },
-    "usernameRequiredError": {
-        "message": "నివేదికను రూపొందించడానికి దయచేసి మీ వినియోగదారు పేరును నమోదు చేయండి."
-    },
-    "unknownPlatformError": {
-        "message": "తెలియని ప్లాట్‌ఫారమ్ ఎంపిక చేయబడింది."
-    },
-    "gitlabFetchingError": {
-        "message": "GitLab డేటాను పొందేటప్పుడు ఒక లోపం సంభవించింది."
-    },
-    "reportGenerationError": {
-        "message": "నివేదికను రూపొందించేటప్పుడు ఒక లోపం సంభవించింది."
-    },
-    "githubUserNotFoundError": {
-        "message": "గిట్‌హబ్ వినియోగదారు \"$1\" కనుగొనబడలేదు."
-    },
-    "githubUserValidationError": {
-        "message": "గిట్‌హబ్ వినియోగదారుని ధృవీకరించడంలో లోపం: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "చెల్లని శోధన ప్రశ్న లేదా తేదీ పరిధి. దయచేసి ఆకృతిని ధృవీకరించి, మళ్లీ ప్రయత్నించండి."
-    },
-    "githubIssuesFetchError": {
-        "message": "గిట్‌హబ్ ఇష్యూలను పొందడంలో లోపం: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "గిట్‌హబ్ పిఆర్ సమీక్ష డేటాను పొందడంలో లోపం: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "గిట్‌హబ్ వినియోగదారు డేటాను పొందడంలో లోపం: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "చెల్లని లేదా గడువు ముగిసిన గిట్‌హబ్ టోకెన్. దయచేసి స్క్రమ్ హెల్పర్ సెట్టింగ్‌లలో మీ టోకెన్‌ను తనిఖీ చేసి, మళ్లీ ప్రయత్నించండి."
-    },
-    "displayModeNotice": {
-        "message": "తదుపరిసారి ప్రారంభించినప్పుడు పొడిగింపు $1 మోడ్‌లో తెరవబడుతుంది."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "రిపోజిటరీ వడపోత గిట్‌హబ్‌కు మాత్రమే అందుబాటులో ఉంది."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "రిపోజిటరీ లోడింగ్ గిట్‌హబ్‌కు మాత్రమే అందుబాటులో ఉంది."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "రిపోజిటరీ పొందడం గిట్‌హబ్‌కు మాత్రమే అందుబాటులో ఉంది."
-    },
-    "loadingReposAutomatically": {
-        "message": "రిపోజిటరీలను స్వయంచాలకంగా లోడ్ చేస్తోంది..."
-    },
-    "gitlabUserFetchError": {
-        "message": "GitLab వినియోగదారుని పొందడంలో లోపం: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "GitLab వినియోగదారు '$1' కనుగొనబడలేదు."
-    },
-    "gitlabMembershipError": {
-        "message": "GitLab సభ్యత్వ ప్రాజెక్ట్‌లను పొందడంలో లోపం: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "GitLab సహకార ప్రాజెక్ట్‌లను పొందడంలో లోపం: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "యూజర్‌నేమ్ అవసరం."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "నివేదిక తయారవుతోంది..."
-    },
-    "copyingReportNotification": {
-        "message": "నివేదిక కాపీ అవుతోంది..."
-    },
-    "copiedReportNotification": {
-        "message": "నివేదిక కాపీ చేయబడింది!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "నివేదిక ఇమెయిల్‌లో చేర్చబడుతోంది..."
-    },
-    "insertedInEmailNotification": {
-        "message": "నివేదిక ఇమెయిల్‌లో చేర్చబడింది!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "ఎంచుకున్న కాలవ్యవధికి మీ Git కార్యకలాపాలను స్వయంచాలకంగా తెచ్చి, మీ అభివృద్ధి పురోగతిని నివేదించండి"
+  },
+  "disableLabel": {
+    "message": "అచేతనం"
+  },
+  "enableLabel": {
+    "message": "సక్రియం"
+  },
+  "projectNameLabel": {
+    "message": "ప్రాజెక్ట్ పేరు (ఇమెయిల్ విషయంలో వాడబడుతుంది)"
+  },
+  "projectNamePlaceholder": {
+    "message": "మీ ప్రాజెక్ట్ పేరును నమోదు చేయండి"
+  },
+  "githubUsernameLabel": {
+    "message": "మీ GitHub వాడుకరి పేరు"
+  },
+  "gitlabUsernameLabel": {
+    "message": "మీ GitLab వాడుకరి పేరు"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "మీ సహకారాలను తెచ్చుకోవడానికి అవసరం"
+  },
+  "contributionsLabel": {
+    "message": "మీ సహకారాలను ఇక్కడ నుండి తెచ్చుకోండి:"
+  },
+  "last1DayLabel": {
+    "message": "గత రోజు"
+  },
+  "lastWeekLabel": {
+    "message": "గత వారం సారాంశం",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "నుండి:"
+  },
+  "endDateLabel": {
+    "message": "వరకు:"
+  },
+  "showOpenClosedLabel": {
+    "message": "PR లేబుళ్లు చూపించు"
+  },
+  "blockersLabel": {
+    "message": "మీరు ఏమి కారణంగా ముందుకు సాగలేకపోతున్నారు?"
+  },
+  "blockersPlaceholder": {
+    "message": "మీ కారణం ఇక్కడ రాయండి"
+  },
+  "scrumReportLabel": {
+    "message": "స్క్రమ్ నివేదిక"
+  },
+  "generateReportButton": {
+    "message": "సృష్టించు"
+  },
+  "copyReportButton": {
+    "message": "కాపీ"
+  },
+  "insertInEmailButton": {
+    "message": "ఇమెయిల్‌లో చేర్చు"
+  },
+  "insertToEmailFailedError": {
+    "message": "నివేదికను చొప్పించడానికి ఒక ఇమెయిల్ ట్యాబ్‌ను తెరవండి"
+  },
+  "settingsOrgNameLabel": {
+    "message": "సంస్థ పేరు"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "సంస్థ పేరును నమోదు చేయండి"
+  },
+  "setButton": {
+    "message": "సెట్ చేయి"
+  },
+  "githubTokenLabel": {
+    "message": "మీ GitHub టోకెన్"
+  },
+  "githubTokenPlaceholder": {
+    "message": "ఆథెంటికేటెడ్ అభ్యర్థనలకు అవసరం"
+  },
+  "githubTokenTooltip": {
+    "message": "GitHub టోకెన్‌ను జోడించడం ఎందుకు సిఫారసు చేయబడుతుంది? Scrum Helper GitHub టోకెన్ లేకుండా పనిచేస్తుంది, కాని మెరుగైన అనుభవం కోసం ఒక ఖాతా ఆక్సెస్ టోకెన్‌ను జోడించడం సిఫారసు చేయబడుతుంది."
+  },
+  "gitlabTokenLabel": {
+    "message": "మీ GitLab టోకెన్"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "ప్రైవేట్ రెపోస్ కోసం అవసరం"
+  },
+  "gitlabTokenTooltip": {
+    "message": "GitLab టోకెన్‌ను జోడించడం ఎందుకు సిఫారసు చేయబడుతుంది? Scrum Helper పబ్లిక్ ప్రాజెక్ట్‌ల కోసం GitLab టోకెన్ లేకుండా పనిచేస్తుంది, కానీ మెరుగైన అనుభవం కోసం ఒక ఖాతా ఆక్సెస్ టోకెన్‌ను జోడించడం సిఫారసు చేయబడుతుంది."
+  },
+  "showCommitsLabel": {
+    "message": "ఓపెన్ PRలు / డ్రాఫ్ట్ PRలపై కమిట్లు చూపించు"
+  },
+  "showCommitsTooltip": {
+    "message": "GitHub టోకెన్ అవసరం — దయచేసి సెట్టింగ్స్‌లో జోడించండి."
+  },
+  "onlyIssuesLabel": {
+    "message": "నివేదికలో ఇష్యూలను మాత్రమే చేర్చు"
+  },
+  "onlyIssuesTooltip": {
+    "message": "ఎంచుకుంటే, నివేదికలో వాడుకరికి కేటాయించబడిన లేదా సృష్టించబడిన ఇష్యూలు మాత్రమే చూపబడతాయి."
+  },
+  "onlyPRsLabel": {
+    "message": "నివేదికలో PRలను మాత్రమే చేర్చు"
+  },
+  "onlyPRsTooltip": {
+    "message": "ఎంచుకుంటే, నివేదికలో మీరు సృష్టించిన PRలు మాత్రమే ఉంటాయి. సమీక్షించిన PRలు తప్పించబడతాయి."
+  },
+  "cacheTTLLabel": {
+    "message": "క్యాష్ TTL ను నమోదు చేయండి"
+  },
+  "cacheTTLUnit": {
+    "message": "(నిమిషాలలో)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "క్యాష్ TTL ని నిమిషాలలో రాయండి (డిఫాల్ట్ 10 నిమిషాలు)"
+  },
+  "refreshDataButton": {
+    "message": "డేటా రీఫ్రెష్ చేయండి (క్యాష్‌ను దాటవేయండి)"
+  },
+  "refreshDataInfo": {
+    "message": "తాజా డేటాను వెంటనే తెచ్చుకోవడానికి ఈ బటన్‌ను ఉపయోగించండి."
+  },
+  "noteTitle": {
+    "message": "గమనిక:"
+  },
+  "viewCodeButton": {
+    "message": "కోడ్ చూడండి"
+  },
+  "reportIssueButton": {
+    "message": "సమస్యను నివేదించండి"
+  },
+  "repoFilterLabel": {
+    "message": "రిపోజిటరీల ద్వారా ఫిల్టర్ చేయండి"
+  },
+  "enableFilteringLabel": {
+    "message": "ఫిల్టరింగ్‌ని ప్రారంభించండి"
+  },
+  "tokenRequiredWarning": {
+    "message": "రిపోజిటరీ ఫిల్టరింగ్ కోసం GitHub టోకెన్ అవసరం. దయచేసి సెట్టింగ్‌లలో ఒకదాన్ని జోడించండి."
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "ఓపెన్ లేదా డ్రాఫ్ట్ పిఆర్‌లలో కమిట్‌లను చూపించడానికి గిట్‌హబ్ టోకెన్ అవసరం. దయచేసి సెట్టింగ్‌లలో ఒకదాన్ని జోడించండి."
+  },
+  "repoSearchPlaceholder": {
+    "message": "రిపోజిటరీల కోసం శోధించండి..."
+  },
+  "repoPlaceholder": {
+    "message": "ఎంచుకున్న రిపోజిటరీలు లేవు (అన్నీ చేర్చబడతాయి)"
+  },
+  "repoCountNone": {
+    "message": "0 రిపోజిటరీలు ఎంచుకోబడ్డాయి"
+  },
+  "repoCount": {
+    "message": "$1 రిపోజిటరీలు ఎంపిక చేయబడ్డాయి"
+  },
+  "clearAllBtn": {
+    "message": "అన్నీ తొలగించు"
+  },
+  "repoLoading": {
+    "message": "రిపోజిటరీలు లోడ్ అవుతున్నాయి..."
+  },
+  "repoLoaded": {
+    "message": "$1 రిపోజిటరీలు లోడ్ అయ్యాయి."
+  },
+  "repoNotFound": {
+    "message": "రిపోజిటరీలు కనబడలేదు"
+  },
+  "repoRefetching": {
+    "message": "రిపోజిటరీలను మళ్లీ తెచ్చుకుంటున్నారు..."
+  },
+  "repoLoadFailed": {
+    "message": "రిపోజిటరీలను లోడ్ చేయలేకపోయాం."
+  },
+  "repoTokenPrivate": {
+    "message": "టోకెన్ చెల్లదు లేదా ప్రైవేట్ రిపోజిటరీలకు అనుమతి లేదు."
+  },
+  "repoRefetchFailed": {
+    "message": "రిపోజిటరీలను మళ్లీ తెచ్చుకోవడం విఫలమైంది."
+  },
+  "orgSetMessage": {
+    "message": "సంస్థ విజయవంతంగా సెట్ చేయబడింది."
+  },
+  "orgClearedMessage": {
+    "message": "సంస్థ తొలగించబడింది. అన్ని కార్యకలాపాలు తెచ్చుకోవడానికి 'నివేదికను రూపొందించు' పై క్లిక్ చేయండి."
+  },
+  "orgNotFoundMessage": {
+    "message": "GitHub లో సంస్థ కనుగొనబడలేదు."
+  },
+  "orgValidationErrorMessage": {
+    "message": "సంస్థను ధృవీకరించడంలో లోపం."
+  },
+  "refreshingButton": {
+    "message": "రిఫ్రెష్ అవుతోంది..."
+  },
+  "cacheClearFailed": {
+    "message": "క్యాష్ క్లియర్ చేయడం విఫలమైంది."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "జనరేట్ అవుతోంది..."
+  },
+  "copiedButton": {
+    "message": "కాపీ అయింది!"
+  },
+  "orgChangedMessage": {
+    "message": "సంస్థ మార్చబడింది. GitHub కార్యకలాపాలను తెచ్చుకోవడానికి 'నివేదికను రూపొందించు' పై క్లిక్ చేయండి."
+  },
+  "cacheClearedMessage": {
+    "message": "క్యాష్ విజయవంతంగా క్లియర్ చేయబడింది. తాజా డేటా కోసం \"నివేదికను రూపొందించు\" పై క్లిక్ చేయండి."
+  },
+  "cacheExpiredMessage": {
+    "message": "క్యాష్ గడువు ముగిసింది. తాజా డేటా పొందడానికి \"నివేదికను రూపొందించు\" పై క్లిక్ చేయండి."
+  },
+  "cacheClearedButton": {
+    "message": "కాష్ తొలగించబడింది!"
+  },
+  "extensionDisabledMessage": {
+    "message": "ఎక్స్‌టెన్షన్ నిలిపివేయబడింది. స్క్రమ్ నివేదికలు రూపొందించేందుకు సెట్టింగ్స్‌లో ఎనేబుల్ చేయండి."
+  },
+  "notePoint1": {
+    "message": "పుల్ రిక్వెస్ట్‌లు మీ స్వంత సమీక్షా కార్యాచరణ ఆధారంగా మాత్రమే కాకుండా, ఏ సహకారుని ద్వారా కూడా తీసుకోబడతాయి. పంచుకునే ముందు మీ పనిని ఖచ్చితంగా ప్రతిబింబిస్తుందని నిర్ధారించుకోవడానికి ఉత్పన్నమైన SCRUM నివేదికను సమీక్షించండి మరియు సర్దుబాటు చేయండి."
+  },
+  "noteSeeIssue": {
+    "message": "ఈ ఇష్యూ చూడండి"
+  },
+  "platformLabel": {
+    "message": "ప్లాట్‌ఫారమ్"
+  },
+  "usernameLabel": {
+    "message": "మీ యూజర్‌నేమ్"
+  },
+  "onlyRevPRsLabel": {
+    "message": "నివేదికలో మీరు సమీక్షించిన PRలను మాత్రమే చేర్చు"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "ఎంచుకుంటే, నివేదికలో మీరు సమీక్షించిన PRలు మాత్రమే చూపబడతాయి."
+  },
+  "onlyMergedPRsLabel": {
+    "message": "విలీనం చేయబడిన పిఆర్‌లను మాత్రమే నివేదికలో చేర్చండి"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "ఎంపిక చేస్తే, నివేదిక విలీనం చేయబడిన పిఆర్‌లను మాత్రమే కలిగి ఉంటుంది. గిట్‌హబ్ టోకెన్ అవసరం."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "విలీనం చేయబడిన పిఆర్‌ల ద్వారా వడపోయడానికి గిట్‌హబ్ టోకెన్ అవసరం. సెట్టింగ్‌లలో ఒకదాన్ని జోడించండి."
+  },
+  "usernameRequiredError": {
+    "message": "నివేదికను రూపొందించడానికి దయచేసి మీ వినియోగదారు పేరును నమోదు చేయండి."
+  },
+  "unknownPlatformError": {
+    "message": "తెలియని ప్లాట్‌ఫారమ్ ఎంపిక చేయబడింది."
+  },
+  "gitlabFetchingError": {
+    "message": "GitLab డేటాను పొందేటప్పుడు ఒక లోపం సంభవించింది."
+  },
+  "reportGenerationError": {
+    "message": "నివేదికను రూపొందించేటప్పుడు ఒక లోపం సంభవించింది."
+  },
+  "githubUserNotFoundError": {
+    "message": "గిట్‌హబ్ వినియోగదారు \"$1\" కనుగొనబడలేదు."
+  },
+  "githubUserValidationError": {
+    "message": "గిట్‌హబ్ వినియోగదారుని ధృవీకరించడంలో లోపం: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "చెల్లని శోధన ప్రశ్న లేదా తేదీ పరిధి. దయచేసి ఆకృతిని ధృవీకరించి, మళ్లీ ప్రయత్నించండి."
+  },
+  "githubIssuesFetchError": {
+    "message": "గిట్‌హబ్ ఇష్యూలను పొందడంలో లోపం: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "గిట్‌హబ్ పిఆర్ సమీక్ష డేటాను పొందడంలో లోపం: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "గిట్‌హబ్ వినియోగదారు డేటాను పొందడంలో లోపం: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "చెల్లని లేదా గడువు ముగిసిన గిట్‌హబ్ టోకెన్. దయచేసి స్క్రమ్ హెల్పర్ సెట్టింగ్‌లలో మీ టోకెన్‌ను తనిఖీ చేసి, మళ్లీ ప్రయత్నించండి."
+  },
+  "displayModeNotice": {
+    "message": "తదుపరిసారి ప్రారంభించినప్పుడు పొడిగింపు $1 మోడ్‌లో తెరవబడుతుంది."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "రిపోజిటరీ వడపోత గిట్‌హబ్‌కు మాత్రమే అందుబాటులో ఉంది."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "రిపోజిటరీ లోడింగ్ గిట్‌హబ్‌కు మాత్రమే అందుబాటులో ఉంది."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "రిపోజిటరీ పొందడం గిట్‌హబ్‌కు మాత్రమే అందుబాటులో ఉంది."
+  },
+  "loadingReposAutomatically": {
+    "message": "రిపోజిటరీలను స్వయంచాలకంగా లోడ్ చేస్తోంది..."
+  },
+  "gitlabUserFetchError": {
+    "message": "GitLab వినియోగదారుని పొందడంలో లోపం: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "GitLab వినియోగదారు '$1' కనుగొనబడలేదు."
+  },
+  "gitlabMembershipError": {
+    "message": "GitLab సభ్యత్వ ప్రాజెక్ట్‌లను పొందడంలో లోపం: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "GitLab సహకార ప్రాజెక్ట్‌లను పొందడంలో లోపం: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "యూజర్‌నేమ్ అవసరం."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "నివేదిక తయారవుతోంది..."
+  },
+  "copyingReportNotification": {
+    "message": "నివేదిక కాపీ అవుతోంది..."
+  },
+  "copiedReportNotification": {
+    "message": "నివేదిక కాపీ చేయబడింది!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "నివేదిక ఇమెయిల్‌లో చేర్చబడుతోంది..."
+  },
+  "insertedInEmailNotification": {
+    "message": "నివేదిక ఇమెయిల్‌లో చేర్చబడింది!"
+  }
 }

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Звітуйте про свій прогрес у розробці, автоматично отримуючи вашу активність у Git за вибраний період."
-    },
-    "disableLabel": {
-        "message": "Вимкнути"
-    },
-    "enableLabel": {
-        "message": "Увімкнути"
-    },
-    "projectNameLabel": {
-        "message": "Назва проекту (використовується в темі електронного листа)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Введіть назву вашого проекту"
-    },
-    "githubUsernameLabel": {
-        "message": "Ваше ім'я користувача GitHub"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Ваше ім'я користувача GitLab"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Потрібно для отримання ваших внесків"
-    },
-    "contributionsLabel": {
-        "message": "Отримати ваші внески за:"
-    },
-    "last1DayLabel": {
-        "message": "Попередній день"
-    },
-    "startDateLabel": {
-        "message": "З:"
-    },
-    "endDateLabel": {
-        "message": "По:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Показувати статус Відкрито/Закрито"
-    },
-    "blockersLabel": {
-        "message": "Що заважає вашому прогресу?"
-    },
-    "blockersPlaceholder": {
-        "message": "Введіть вашу причину"
-    },
-    "scrumReportLabel": {
-        "message": "Звіт Scrum"
-    },
-    "generateReportButton": {
-        "message": "Створити звіт"
-    },
-    "copyReportButton": {
-        "message": "Копіювати звіт"
-    },
-    "insertInEmailButton": {
-        "message": "Вставити в електронний лист"
-    },
-    "insertToEmailFailedError": {
-        "message": "Відкрийте вкладку електронної пошти, щоб вставити звіт"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Назва організації"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Введіть назву організації"
-    },
-    "setButton": {
-        "message": "Встановити"
-    },
-    "githubTokenLabel": {
-        "message": "Ваш токен GitHub"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Потрібно для автентифікованих запитів"
-    },
-    "githubTokenTooltip": {
-        "message": "Чому рекомендується додати токен GitHub? Scrum Helper працює без токена GitHub, але додавання особистого токена доступу рекомендується для кращого досвіду."
-    },
-    "gitlabTokenLabel": {
-        "message": "Ваш токен GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Потрібно для доступу до приватних проектів"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Чому рекомендується додати токен GitLab? Scrum Helper працює без токена GitLab для публічних проектів, але додавання особистого токена доступу рекомендується для кращого досвіду."
-    },
-    "showCommitsLabel": {
-        "message": "Показувати коміти у відкритих PR/ чернетках PR"
-    },
-    "showCommitsTooltip": {
-        "message": "Потрібен токен GitHub, додайте його в налаштуваннях."
-    },
-    "onlyIssuesLabel": {
-        "message": "Включати до звіту лише проблеми"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Якщо позначено, звіт включатиме лише проблеми, створені користувачем або призначені йому."
-    },
-    "onlyPRsLabel": {
-        "message": "Включати до звіту лише PR"
-    },
-    "onlyPRsTooltip": {
-        "message": "Якщо позначено, звіт включатиме лише pull requests, створені користувачем; переглянуті PR будуть виключені."
-    },
-    "cacheTTLLabel": {
-        "message": "Введіть TTL кешу"
-    },
-    "cacheTTLUnit": {
-        "message": "(у хвилинах)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Введіть TTL кешу в хвилинах (За замовчуванням: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Оновити дані (обійти кеш)"
-    },
-    "refreshDataInfo": {
-        "message": "Використовуйте цю кнопку, щоб негайно отримати свіжі дані."
-    },
-    "noteTitle": {
-        "message": "Примітка:"
-    },
-    "viewCodeButton": {
-        "message": "Переглянути код"
-    },
-    "reportIssueButton": {
-        "message": "Повідомити про проблему"
-    },
-    "repoFilterLabel": {
-        "message": "Фільтрувати за репозиторіями"
-    },
-    "enableFilteringLabel": {
-        "message": "Увімкнути фільтрацію"
-    },
-    "tokenRequiredWarning": {
-        "message": "Для фільтрації репозиторіїв потрібен токен GitHub. Будь ласка, додайте його в налаштуваннях."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "Для відображення комітів у відкритих або чернеткових PR потрібен токен GitHub. Додайте його в налаштуваннях."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Шукати репозиторій для додавання..."
-    },
-    "repoPlaceholder": {
-        "message": "Репозиторії не вибрано (будуть включені всі)"
-    },
-    "repoCountNone": {
-        "message": "Вибрано 0 репозиторіїв"
-    },
-    "repoCount": {
-        "message": "Вибрано $1 репозиторіїв"
-    },
-    "clearAllBtn": {
-        "message": "Очистити все"
-    },
-    "repoLoading": {
-        "message": "Завантаження репозиторіїв..."
-    },
-    "repoLoaded": {
-        "message": "Завантажено $1 репозиторіїв."
-    },
-    "repoNotFound": {
-        "message": "Репозиторіїв не знайдено"
-    },
-    "repoRefetching": {
-        "message": "Повторне завантаження репозиторіїв..."
-    },
-    "repoLoadFailed": {
-        "message": "Не вдалося завантажити репозиторії."
-    },
-    "repoTokenPrivate": {
-        "message": "Токен недійсний або не має прав для приватних репозиторіїв."
-    },
-    "repoRefetchFailed": {
-        "message": "Не вдалося повторно завантажити репозиторії."
-    },
-    "orgSetMessage": {
-        "message": "Організацію встановлено успішно."
-    },
-    "orgClearedMessage": {
-        "message": "Організацію очищено. Натисніть 'Створити звіт', щоб отримати всі активності."
-    },
-    "orgNotFoundMessage": {
-        "message": "Організацію не знайдено на GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Помилка під час перевірки організації."
-    },
-    "refreshingButton": {
-        "message": "Оновлення..."
-    },
-    "cacheClearFailed": {
-        "message": "Не вдалося очистити кеш."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Створення..."
-    },
-    "copiedButton": {
-        "message": "Скопійовано!"
-    },
-    "orgChangedMessage": {
-        "message": "Організацію змінено. Натисніть 'Створити звіт', щоб отримати активності GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Кеш успішно очищено. Натисніть 'Створити звіт', щоб отримати свіжі дані."
-    },
-    "cacheExpiredMessage": {
-        "message": "Кеш закінчився. Натисніть \"Створити\", щоб отримати нові дані."
-    },
-    "cacheClearedButton": {
-        "message": "Кеш очищено!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Розширення вимкнено. Увімкніть його в налаштуваннях, щоб створювати звіти scrum."
-    },
-    "notePoint1": {
-        "message": "Pull-запити отримуються на основі останньої активності рецензування будь-якого учасника, а не лише вашої. Будь ласка, перегляньте та відкоригуйте згенерований звіт SCRUM, щоб переконатися, що він точно відображає вашу роботу, перш ніж ділитися ним."
-    },
-    "noteSeeIssue": {
-        "message": "Дивіться цю проблему"
-    },
-    "platformLabel": {
-        "message": "Платформа"
-    },
-    "usernameLabel": {
-        "message": "Ваше ім'я користувача"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Включати до звіту лише переглянуті PR"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Якщо позначено, звіт включатиме лише PR, переглянуті вами."
-    },
-    "onlyMergedPRsLabel": {
-        "message": "Включати у звіт тільки об'єднані (merged) PR"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "Якщо позначено, звіт буде включати тільки об'єднані PR. Потрібен токен GitHub."
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "Для фільтрації за об'єднаними PR потрібен токен GitHub. Додайте його в налаштуваннях."
-    },
-    "usernameRequiredError": {
-        "message": "Будь ласка, введіть ім'я користувача для створення звіту."
-    },
-    "unknownPlatformError": {
-        "message": "Вибрано невідому платформу."
-    },
-    "gitlabFetchingError": {
-        "message": "Сталася помилка під час отримання даних GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Сталася помилка під час створення звіту."
-    },
-    "githubUserNotFoundError": {
-        "message": "Користувача GitHub \"$1\" не знайдено (404). Перевірте ім'я користувача і спробуйте ще раз."
-    },
-    "githubUserValidationError": {
-        "message": "Помилка під час перевірки користувача GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Недійсний пошуковий запит або діапазон дат. Перевірте формат і спробуйте ще раз."
-    },
-    "githubIssuesFetchError": {
-        "message": "Помилка під час отримання задач GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Помилка під час отримання даних перевірки PR GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Помилка під час отримання даних користувача GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Недійсний або прострочений токен GitHub. Перевірте токен у налаштуваннях Scrum Helper і спробуйте ще раз."
-    },
-    "displayModeNotice": {
-        "message": "Розширення відкриється в режимі $1 при наступному запуску."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Фільтрація репозиторіїв доступна лише для GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Завантаження репозиторіїв доступне лише для GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Отримання репозиторіїв доступне лише для GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Репозиторії завантажуються автоматично..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Помилка під час отримання користувача GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Користувача GitLab '$1' не знайдено"
-    },
-    "gitlabMembershipError": {
-        "message": "Помилка під час отримання проектів членства GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Помилка під час отримання проектів з внеском GitLab: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Потрібне ім'я користувача."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Генерація звіту..."
-    },
-    "copyingReportNotification": {
-        "message": "Копіювання звіту..."
-    },
-    "copiedReportNotification": {
-        "message": "Звіт скопійовано!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Вставка звіту в лист..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Звіт вставлено в лист!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Звітуйте про свій прогрес у розробці, автоматично отримуючи вашу активність у Git за вибраний період."
+  },
+  "disableLabel": {
+    "message": "Вимкнути"
+  },
+  "enableLabel": {
+    "message": "Увімкнути"
+  },
+  "projectNameLabel": {
+    "message": "Назва проекту (використовується в темі електронного листа)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Введіть назву вашого проекту"
+  },
+  "githubUsernameLabel": {
+    "message": "Ваше ім'я користувача GitHub"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Ваше ім'я користувача GitLab"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Потрібно для отримання ваших внесків"
+  },
+  "contributionsLabel": {
+    "message": "Отримати ваші внески за:"
+  },
+  "last1DayLabel": {
+    "message": "Попередній день"
+  },
+  "lastWeekLabel": {
+    "message": "Підсумок за минулий тиждень",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "З:"
+  },
+  "endDateLabel": {
+    "message": "По:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Показувати статус Відкрито/Закрито"
+  },
+  "blockersLabel": {
+    "message": "Що заважає вашому прогресу?"
+  },
+  "blockersPlaceholder": {
+    "message": "Введіть вашу причину"
+  },
+  "scrumReportLabel": {
+    "message": "Звіт Scrum"
+  },
+  "generateReportButton": {
+    "message": "Створити звіт"
+  },
+  "copyReportButton": {
+    "message": "Копіювати звіт"
+  },
+  "insertInEmailButton": {
+    "message": "Вставити в електронний лист"
+  },
+  "insertToEmailFailedError": {
+    "message": "Відкрийте вкладку електронної пошти, щоб вставити звіт"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Назва організації"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Введіть назву організації"
+  },
+  "setButton": {
+    "message": "Встановити"
+  },
+  "githubTokenLabel": {
+    "message": "Ваш токен GitHub"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Потрібно для автентифікованих запитів"
+  },
+  "githubTokenTooltip": {
+    "message": "Чому рекомендується додати токен GitHub? Scrum Helper працює без токена GitHub, але додавання особистого токена доступу рекомендується для кращого досвіду."
+  },
+  "gitlabTokenLabel": {
+    "message": "Ваш токен GitLab"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Потрібно для доступу до приватних проектів"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Чому рекомендується додати токен GitLab? Scrum Helper працює без токена GitLab для публічних проектів, але додавання особистого токена доступу рекомендується для кращого досвіду."
+  },
+  "showCommitsLabel": {
+    "message": "Показувати коміти у відкритих PR/ чернетках PR"
+  },
+  "showCommitsTooltip": {
+    "message": "Потрібен токен GitHub, додайте його в налаштуваннях."
+  },
+  "onlyIssuesLabel": {
+    "message": "Включати до звіту лише проблеми"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Якщо позначено, звіт включатиме лише проблеми, створені користувачем або призначені йому."
+  },
+  "onlyPRsLabel": {
+    "message": "Включати до звіту лише PR"
+  },
+  "onlyPRsTooltip": {
+    "message": "Якщо позначено, звіт включатиме лише pull requests, створені користувачем; переглянуті PR будуть виключені."
+  },
+  "cacheTTLLabel": {
+    "message": "Введіть TTL кешу"
+  },
+  "cacheTTLUnit": {
+    "message": "(у хвилинах)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Введіть TTL кешу в хвилинах (За замовчуванням: 10)"
+  },
+  "refreshDataButton": {
+    "message": "Оновити дані (обійти кеш)"
+  },
+  "refreshDataInfo": {
+    "message": "Використовуйте цю кнопку, щоб негайно отримати свіжі дані."
+  },
+  "noteTitle": {
+    "message": "Примітка:"
+  },
+  "viewCodeButton": {
+    "message": "Переглянути код"
+  },
+  "reportIssueButton": {
+    "message": "Повідомити про проблему"
+  },
+  "repoFilterLabel": {
+    "message": "Фільтрувати за репозиторіями"
+  },
+  "enableFilteringLabel": {
+    "message": "Увімкнути фільтрацію"
+  },
+  "tokenRequiredWarning": {
+    "message": "Для фільтрації репозиторіїв потрібен токен GitHub. Будь ласка, додайте його в налаштуваннях."
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "Для відображення комітів у відкритих або чернеткових PR потрібен токен GitHub. Додайте його в налаштуваннях."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Шукати репозиторій для додавання..."
+  },
+  "repoPlaceholder": {
+    "message": "Репозиторії не вибрано (будуть включені всі)"
+  },
+  "repoCountNone": {
+    "message": "Вибрано 0 репозиторіїв"
+  },
+  "repoCount": {
+    "message": "Вибрано $1 репозиторіїв"
+  },
+  "clearAllBtn": {
+    "message": "Очистити все"
+  },
+  "repoLoading": {
+    "message": "Завантаження репозиторіїв..."
+  },
+  "repoLoaded": {
+    "message": "Завантажено $1 репозиторіїв."
+  },
+  "repoNotFound": {
+    "message": "Репозиторіїв не знайдено"
+  },
+  "repoRefetching": {
+    "message": "Повторне завантаження репозиторіїв..."
+  },
+  "repoLoadFailed": {
+    "message": "Не вдалося завантажити репозиторії."
+  },
+  "repoTokenPrivate": {
+    "message": "Токен недійсний або не має прав для приватних репозиторіїв."
+  },
+  "repoRefetchFailed": {
+    "message": "Не вдалося повторно завантажити репозиторії."
+  },
+  "orgSetMessage": {
+    "message": "Організацію встановлено успішно."
+  },
+  "orgClearedMessage": {
+    "message": "Організацію очищено. Натисніть 'Створити звіт', щоб отримати всі активності."
+  },
+  "orgNotFoundMessage": {
+    "message": "Організацію не знайдено на GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Помилка під час перевірки організації."
+  },
+  "refreshingButton": {
+    "message": "Оновлення..."
+  },
+  "cacheClearFailed": {
+    "message": "Не вдалося очистити кеш."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Створення..."
+  },
+  "copiedButton": {
+    "message": "Скопійовано!"
+  },
+  "orgChangedMessage": {
+    "message": "Організацію змінено. Натисніть 'Створити звіт', щоб отримати активності GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Кеш успішно очищено. Натисніть 'Створити звіт', щоб отримати свіжі дані."
+  },
+  "cacheExpiredMessage": {
+    "message": "Кеш закінчився. Натисніть \"Створити\", щоб отримати нові дані."
+  },
+  "cacheClearedButton": {
+    "message": "Кеш очищено!"
+  },
+  "extensionDisabledMessage": {
+    "message": "Розширення вимкнено. Увімкніть його в налаштуваннях, щоб створювати звіти scrum."
+  },
+  "notePoint1": {
+    "message": "Pull-запити отримуються на основі останньої активності рецензування будь-якого учасника, а не лише вашої. Будь ласка, перегляньте та відкоригуйте згенерований звіт SCRUM, щоб переконатися, що він точно відображає вашу роботу, перш ніж ділитися ним."
+  },
+  "noteSeeIssue": {
+    "message": "Дивіться цю проблему"
+  },
+  "platformLabel": {
+    "message": "Платформа"
+  },
+  "usernameLabel": {
+    "message": "Ваше ім'я користувача"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Включати до звіту лише переглянуті PR"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Якщо позначено, звіт включатиме лише PR, переглянуті вами."
+  },
+  "onlyMergedPRsLabel": {
+    "message": "Включати у звіт тільки об'єднані (merged) PR"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "Якщо позначено, звіт буде включати тільки об'єднані PR. Потрібен токен GitHub."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "Для фільтрації за об'єднаними PR потрібен токен GitHub. Додайте його в налаштуваннях."
+  },
+  "usernameRequiredError": {
+    "message": "Будь ласка, введіть ім'я користувача для створення звіту."
+  },
+  "unknownPlatformError": {
+    "message": "Вибрано невідому платформу."
+  },
+  "gitlabFetchingError": {
+    "message": "Сталася помилка під час отримання даних GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Сталася помилка під час створення звіту."
+  },
+  "githubUserNotFoundError": {
+    "message": "Користувача GitHub \"$1\" не знайдено (404). Перевірте ім'я користувача і спробуйте ще раз."
+  },
+  "githubUserValidationError": {
+    "message": "Помилка під час перевірки користувача GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Недійсний пошуковий запит або діапазон дат. Перевірте формат і спробуйте ще раз."
+  },
+  "githubIssuesFetchError": {
+    "message": "Помилка під час отримання задач GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Помилка під час отримання даних перевірки PR GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Помилка під час отримання даних користувача GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Недійсний або прострочений токен GitHub. Перевірте токен у налаштуваннях Scrum Helper і спробуйте ще раз."
+  },
+  "displayModeNotice": {
+    "message": "Розширення відкриється в режимі $1 при наступному запуску."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Фільтрація репозиторіїв доступна лише для GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Завантаження репозиторіїв доступне лише для GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Отримання репозиторіїв доступне лише для GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Репозиторії завантажуються автоматично..."
+  },
+  "gitlabUserFetchError": {
+    "message": "Помилка під час отримання користувача GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Користувача GitLab '$1' не знайдено"
+  },
+  "gitlabMembershipError": {
+    "message": "Помилка під час отримання проектів членства GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Помилка під час отримання проектів з внеском GitLab: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Потрібне ім'я користувача."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Генерація звіту..."
+  },
+  "copyingReportNotification": {
+    "message": "Копіювання звіту..."
+  },
+  "copiedReportNotification": {
+    "message": "Звіт скопійовано!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Вставка звіту в лист..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Звіт вставлено в лист!"
+  }
 }

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "Báo cáo tiến độ phát triển của bạn bằng cách tự động lấy hoạt động Git trong một khoảng thời gian đã chọn."
-    },
-    "disableLabel": {
-        "message": "Tắt"
-    },
-    "enableLabel": {
-        "message": "Bật"
-    },
-    "projectNameLabel": {
-        "message": "Tên dự án (sử dụng trong chủ đề email)"
-    },
-    "projectNamePlaceholder": {
-        "message": "Nhập tên dự án của bạn"
-    },
-    "githubUsernameLabel": {
-        "message": "Tên người dùng GitHub của bạn"
-    },
-    "gitlabUsernameLabel": {
-        "message": "Tên người dùng GitLab của bạn"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "Bắt buộc để lấy các đóng góp của bạn"
-    },
-    "contributionsLabel": {
-        "message": "Lấy đóng góp của bạn trong:"
-    },
-    "last1DayLabel": {
-        "message": "Ngày trước"
-    },
-    "startDateLabel": {
-        "message": "Từ:"
-    },
-    "endDateLabel": {
-        "message": "Đến:"
-    },
-    "showOpenClosedLabel": {
-        "message": "Hiển thị trạng thái Mở/Đóng"
-    },
-    "blockersLabel": {
-        "message": "Điều gì đang cản trở bạn?"
-    },
-    "blockersPlaceholder": {
-        "message": "Nhập lý do của bạn"
-    },
-    "scrumReportLabel": {
-        "message": "Báo cáo Scrum"
-    },
-    "generateReportButton": {
-        "message": "Tạo"
-    },
-    "copyReportButton": {
-        "message": "Sao chép"
-    },
-    "insertInEmailButton": {
-        "message": "Chèn vào email"
-    },
-    "insertToEmailFailedError": {
-        "message": "Mở một tab email để chèn báo cáo"
-    },
-    "settingsOrgNameLabel": {
-        "message": "Tên tổ chức"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "Nhập tên tổ chức"
-    },
-    "setButton": {
-        "message": "Đặt"
-    },
-    "githubTokenLabel": {
-        "message": "Mã token GitHub của bạn"
-    },
-    "githubTokenPlaceholder": {
-        "message": "Bắt buộc cho các yêu cầu đã xác thực"
-    },
-    "githubTokenTooltip": {
-        "message": "Tại sao nên thêm mã token GitHub? Scrum Helper hoạt động mà không cần mã token GitHub, nhưng việc thêm mã thông báo truy cập cá nhân được khuyến nghị để có trải nghiệm tốt hơn."
-    },
-    "gitlabTokenLabel": {
-        "message": "Mã token GitLab"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "Bắt buộc cho repo riêng tư"
-    },
-    "gitlabTokenTooltip": {
-        "message": "Tại sao nên thêm mã token GitLab? Scrum Helper hoạt động mà không cần mã token GitLab cho các dự án công khai, nhưng việc thêm mã thông báo truy cập cá nhân được khuyến nghị để có trải nghiệm tốt hơn."
-    },
-    "showCommitsLabel": {
-        "message": "Hiển thị các commit trên PR đang mở/ PR nháp"
-    },
-    "showCommitsTooltip": {
-        "message": "Yêu cầu mã thông báo Github, hãy thêm nó trong cài đặt."
-    },
-    "onlyIssuesLabel": {
-        "message": "Chỉ bao gồm các vấn đề trong báo cáo"
-    },
-    "onlyIssuesTooltip": {
-        "message": "Nếu được chọn, báo cáo sẽ chỉ bao gồm các vấn đề do người dùng tạo hoặc được giao."
-    },
-    "onlyPRsLabel": {
-        "message": "Chỉ bao gồm PR trong báo cáo"
-    },
-    "onlyPRsTooltip": {
-        "message": "Nếu được chọn, báo cáo chỉ bao gồm các pull request do người dùng tạo; các PR đã được xem xét sẽ bị loại trừ."
-    },
-    "cacheTTLLabel": {
-        "message": "Nhập TTL bộ nhớ cache"
-    },
-    "cacheTTLUnit": {
-        "message": "(tính bằng phút)"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "Nhập TTL bộ nhớ đệm bằng phút (Mặc định: 10)"
-    },
-    "refreshDataButton": {
-        "message": "Làm mới dữ liệu (bỏ qua bộ nhớ đệm)"
-    },
-    "refreshDataInfo": {
-        "message": "Sử dụng nút này để lấy dữ liệu mới ngay lập tức."
-    },
-    "noteTitle": {
-        "message": "Lưu ý:"
-    },
-    "viewCodeButton": {
-        "message": "Xem mã"
-    },
-    "reportIssueButton": {
-        "message": "Báo cáo sự cố"
-    },
-    "repoFilterLabel": {
-        "message": "Lọc theo kho lưu trữ"
-    },
-    "enableFilteringLabel": {
-        "message": "Bật bộ lọc"
-    },
-    "tokenRequiredWarning": {
-        "message": "Cần có mã token GitHub để lọc kho lưu trữ. Vui lòng thêm một mã trong cài đặt."
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "Cần có mã thông báo GitHub để hiển thị các commit trên các PR đang mở hoặc bản nháp. Vui lòng thêm một mã trong cài đặt."
-    },
-    "repoSearchPlaceholder": {
-        "message": "Tìm kiếm kho lưu trữ để thêm..."
-    },
-    "repoPlaceholder": {
-        "message": "Chưa chọn kho lưu trữ nào (tất cả sẽ được bao gồm)"
-    },
-    "repoCountNone": {
-        "message": "0 kho lưu trữ đã chọn"
-    },
-    "repoCount": {
-        "message": "$1 kho lưu trữ đã chọn"
-    },
-    "clearAllBtn": {
-        "message": "Xóa tất cả"
-    },
-    "repoLoading": {
-        "message": "Đang tải kho lưu trữ..."
-    },
-    "repoLoaded": {
-        "message": "Đã tải $1 kho lưu trữ."
-    },
-    "repoNotFound": {
-        "message": "Không tìm thấy kho lưu trữ nào"
-    },
-    "repoRefetching": {
-        "message": "Đang tải lại kho lưu trữ..."
-    },
-    "repoLoadFailed": {
-        "message": "Không thể tải kho lưu trữ."
-    },
-    "repoTokenPrivate": {
-        "message": "Mã token không hợp lệ hoặc không có quyền đối với kho lưu trữ riêng tư."
-    },
-    "repoRefetchFailed": {
-        "message": "Không thể tải lại kho lưu trữ."
-    },
-    "orgSetMessage": {
-        "message": "Tổ chức đã được đặt thành công."
-    },
-    "orgClearedMessage": {
-        "message": "Đã xóa tổ chức. Nhấp vào 'Tạo báo cáo' để lấy tất cả hoạt động."
-    },
-    "orgNotFoundMessage": {
-        "message": "Không tìm thấy tổ chức trên GitHub."
-    },
-    "orgValidationErrorMessage": {
-        "message": "Lỗi khi xác thực tổ chức."
-    },
-    "refreshingButton": {
-        "message": "Đang làm mới..."
-    },
-    "cacheClearFailed": {
-        "message": "Xóa bộ nhớ đệm thất bại."
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "Đang tạo..."
-    },
-    "copiedButton": {
-        "message": "Đã sao chép!"
-    },
-    "orgChangedMessage": {
-        "message": "Tổ chức đã thay đổi. Nhấp vào 'Tạo báo cáo' để lấy các hoạt động trên GitHub."
-    },
-    "cacheClearedMessage": {
-        "message": "Bộ nhớ đệm đã được xóa thành công. Nhấp vào 'Tạo báo cáo' để lấy dữ liệu mới."
-    },
-    "cacheExpiredMessage": {
-        "message": "Bộ nhớ đệm đã hết hạn. Nhấp vào \"Tạo\" để lấy dữ liệu mới."
-    },
-    "cacheClearedButton": {
-        "message": "Đã xóa bộ nhớ đệm!"
-    },
-    "extensionDisabledMessage": {
-        "message": "Tiện ích mở rộng đã bị tắt. Bật nó từ cài đặt để tạo báo cáo scrum."
-    },
-    "notePoint1": {
-        "message": "Pull request được lấy dựa trên hoạt động đánh giá gần đây nhất của bất kỳ người đóng góp nào, không chỉ của riêng bạn. Vui lòng xem xét và điều chỉnh báo cáo SCRUM được tạo để đảm bảo nó phản ánh chính xác công việc của bạn trước khi chia sẻ."
-    },
-    "noteSeeIssue": {
-        "message": "Xem vấn đề này"
-    },
-    "platformLabel": {
-        "message": "Nền tảng"
-    },
-    "usernameLabel": {
-        "message": "Tên người dùng của bạn"
-    },
-    "onlyRevPRsLabel": {
-        "message": "Chỉ bao gồm các PR bạn đã xem xét trong báo cáo"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "Nếu được chọn, báo cáo sẽ chỉ bao gồm các PR bạn đã xem xét."
-    },
-    "onlyMergedPRsLabel": {
-        "message": "Chỉ bao gồm các PR đã hợp nhất (merged) trong báo cáo"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "Nếu được chọn, báo cáo sẽ chỉ bao gồm các PR đã được hợp nhất. Cần có mã thông báo GitHub."
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "Cần có mã thông báo GitHub để lọc theo các PR đã hợp nhất. Vui lòng thêm một mã trong cài đặt."
-    },
-    "usernameRequiredError": {
-        "message": "Vui lòng nhập tên người dùng để tạo báo cáo."
-    },
-    "unknownPlatformError": {
-        "message": "Đã chọn nền tảng không xác định."
-    },
-    "gitlabFetchingError": {
-        "message": "Đã xảy ra lỗi khi lấy dữ liệu GitLab."
-    },
-    "reportGenerationError": {
-        "message": "Đã xảy ra lỗi khi tạo báo cáo."
-    },
-    "githubUserNotFoundError": {
-        "message": "Không tìm thấy người dùng GitHub \"$1\" (404). Vui lòng kiểm tra tên người dùng và thử lại."
-    },
-    "githubUserValidationError": {
-        "message": "Lỗi khi xác thực người dùng GitHub: $1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "Truy vấn tìm kiếm hoặc khoảng ngày không hợp lệ. Vui lòng kiểm tra định dạng và thử lại."
-    },
-    "githubIssuesFetchError": {
-        "message": "Lỗi khi lấy các vấn đề từ GitHub: $1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "Lỗi khi lấy dữ liệu đánh giá PR từ GitHub: $1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "Lỗi khi lấy dữ liệu người dùng GitHub: $1 $2"
-    },
-    "invalidTokenError": {
-        "message": "Mã token GitHub không hợp lệ hoặc đã hết hạn. Vui lòng kiểm tra mã token trong cài đặt Scrum Helper và thử lại."
-    },
-    "displayModeNotice": {
-        "message": "Tiện ích sẽ mở ở chế độ $1 trong lần khởi động tiếp theo."
-    },
-    "repoFilteringGithubOnly": {
-        "message": "Chỉ có thể lọc kho lưu trữ trên GitHub."
-    },
-    "repoLoadingGithubOnly": {
-        "message": "Chỉ có thể tải kho lưu trữ trên GitHub."
-    },
-    "repoFetchingGithubOnly": {
-        "message": "Chỉ có thể lấy kho lưu trữ trên GitHub."
-    },
-    "loadingReposAutomatically": {
-        "message": "Đang tự động tải kho lưu trữ..."
-    },
-    "gitlabUserFetchError": {
-        "message": "Lỗi khi lấy người dùng GitLab: $1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "Không tìm thấy người dùng GitLab '$1'"
-    },
-    "gitlabMembershipError": {
-        "message": "Lỗi khi lấy dự án thành viên GitLab: $1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "Lỗi khi lấy dự án đóng góp GitLab: $1 $2"
-    },
-    "usernameMissingError": {
-        "message": "Yêu cầu tên người dùng."
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "Đang tạo báo cáo..."
-    },
-    "copyingReportNotification": {
-        "message": "Đang sao chép báo cáo..."
-    },
-    "copiedReportNotification": {
-        "message": "Đã sao chép báo cáo!"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "Đang chèn báo cáo vào email..."
-    },
-    "insertedInEmailNotification": {
-        "message": "Đã chèn báo cáo vào email!"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "Báo cáo tiến độ phát triển của bạn bằng cách tự động lấy hoạt động Git trong một khoảng thời gian đã chọn."
+  },
+  "disableLabel": {
+    "message": "Tắt"
+  },
+  "enableLabel": {
+    "message": "Bật"
+  },
+  "projectNameLabel": {
+    "message": "Tên dự án (sử dụng trong chủ đề email)"
+  },
+  "projectNamePlaceholder": {
+    "message": "Nhập tên dự án của bạn"
+  },
+  "githubUsernameLabel": {
+    "message": "Tên người dùng GitHub của bạn"
+  },
+  "gitlabUsernameLabel": {
+    "message": "Tên người dùng GitLab của bạn"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "Bắt buộc để lấy các đóng góp của bạn"
+  },
+  "contributionsLabel": {
+    "message": "Lấy đóng góp của bạn trong:"
+  },
+  "last1DayLabel": {
+    "message": "Ngày trước"
+  },
+  "lastWeekLabel": {
+    "message": "Tóm tắt tuần trước",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "Từ:"
+  },
+  "endDateLabel": {
+    "message": "Đến:"
+  },
+  "showOpenClosedLabel": {
+    "message": "Hiển thị trạng thái Mở/Đóng"
+  },
+  "blockersLabel": {
+    "message": "Điều gì đang cản trở bạn?"
+  },
+  "blockersPlaceholder": {
+    "message": "Nhập lý do của bạn"
+  },
+  "scrumReportLabel": {
+    "message": "Báo cáo Scrum"
+  },
+  "generateReportButton": {
+    "message": "Tạo"
+  },
+  "copyReportButton": {
+    "message": "Sao chép"
+  },
+  "insertInEmailButton": {
+    "message": "Chèn vào email"
+  },
+  "insertToEmailFailedError": {
+    "message": "Mở một tab email để chèn báo cáo"
+  },
+  "settingsOrgNameLabel": {
+    "message": "Tên tổ chức"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "Nhập tên tổ chức"
+  },
+  "setButton": {
+    "message": "Đặt"
+  },
+  "githubTokenLabel": {
+    "message": "Mã token GitHub của bạn"
+  },
+  "githubTokenPlaceholder": {
+    "message": "Bắt buộc cho các yêu cầu đã xác thực"
+  },
+  "githubTokenTooltip": {
+    "message": "Tại sao nên thêm mã token GitHub? Scrum Helper hoạt động mà không cần mã token GitHub, nhưng việc thêm mã thông báo truy cập cá nhân được khuyến nghị để có trải nghiệm tốt hơn."
+  },
+  "gitlabTokenLabel": {
+    "message": "Mã token GitLab"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "Bắt buộc cho repo riêng tư"
+  },
+  "gitlabTokenTooltip": {
+    "message": "Tại sao nên thêm mã token GitLab? Scrum Helper hoạt động mà không cần mã token GitLab cho các dự án công khai, nhưng việc thêm mã thông báo truy cập cá nhân được khuyến nghị để có trải nghiệm tốt hơn."
+  },
+  "showCommitsLabel": {
+    "message": "Hiển thị các commit trên PR đang mở/ PR nháp"
+  },
+  "showCommitsTooltip": {
+    "message": "Yêu cầu mã thông báo Github, hãy thêm nó trong cài đặt."
+  },
+  "onlyIssuesLabel": {
+    "message": "Chỉ bao gồm các vấn đề trong báo cáo"
+  },
+  "onlyIssuesTooltip": {
+    "message": "Nếu được chọn, báo cáo sẽ chỉ bao gồm các vấn đề do người dùng tạo hoặc được giao."
+  },
+  "onlyPRsLabel": {
+    "message": "Chỉ bao gồm PR trong báo cáo"
+  },
+  "onlyPRsTooltip": {
+    "message": "Nếu được chọn, báo cáo chỉ bao gồm các pull request do người dùng tạo; các PR đã được xem xét sẽ bị loại trừ."
+  },
+  "cacheTTLLabel": {
+    "message": "Nhập TTL bộ nhớ cache"
+  },
+  "cacheTTLUnit": {
+    "message": "(tính bằng phút)"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "Nhập TTL bộ nhớ đệm bằng phút (Mặc định: 10)"
+  },
+  "refreshDataButton": {
+    "message": "Làm mới dữ liệu (bỏ qua bộ nhớ đệm)"
+  },
+  "refreshDataInfo": {
+    "message": "Sử dụng nút này để lấy dữ liệu mới ngay lập tức."
+  },
+  "noteTitle": {
+    "message": "Lưu ý:"
+  },
+  "viewCodeButton": {
+    "message": "Xem mã"
+  },
+  "reportIssueButton": {
+    "message": "Báo cáo sự cố"
+  },
+  "repoFilterLabel": {
+    "message": "Lọc theo kho lưu trữ"
+  },
+  "enableFilteringLabel": {
+    "message": "Bật bộ lọc"
+  },
+  "tokenRequiredWarning": {
+    "message": "Cần có mã token GitHub để lọc kho lưu trữ. Vui lòng thêm một mã trong cài đặt."
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "Cần có mã thông báo GitHub để hiển thị các commit trên các PR đang mở hoặc bản nháp. Vui lòng thêm một mã trong cài đặt."
+  },
+  "repoSearchPlaceholder": {
+    "message": "Tìm kiếm kho lưu trữ để thêm..."
+  },
+  "repoPlaceholder": {
+    "message": "Chưa chọn kho lưu trữ nào (tất cả sẽ được bao gồm)"
+  },
+  "repoCountNone": {
+    "message": "0 kho lưu trữ đã chọn"
+  },
+  "repoCount": {
+    "message": "$1 kho lưu trữ đã chọn"
+  },
+  "clearAllBtn": {
+    "message": "Xóa tất cả"
+  },
+  "repoLoading": {
+    "message": "Đang tải kho lưu trữ..."
+  },
+  "repoLoaded": {
+    "message": "Đã tải $1 kho lưu trữ."
+  },
+  "repoNotFound": {
+    "message": "Không tìm thấy kho lưu trữ nào"
+  },
+  "repoRefetching": {
+    "message": "Đang tải lại kho lưu trữ..."
+  },
+  "repoLoadFailed": {
+    "message": "Không thể tải kho lưu trữ."
+  },
+  "repoTokenPrivate": {
+    "message": "Mã token không hợp lệ hoặc không có quyền đối với kho lưu trữ riêng tư."
+  },
+  "repoRefetchFailed": {
+    "message": "Không thể tải lại kho lưu trữ."
+  },
+  "orgSetMessage": {
+    "message": "Tổ chức đã được đặt thành công."
+  },
+  "orgClearedMessage": {
+    "message": "Đã xóa tổ chức. Nhấp vào 'Tạo báo cáo' để lấy tất cả hoạt động."
+  },
+  "orgNotFoundMessage": {
+    "message": "Không tìm thấy tổ chức trên GitHub."
+  },
+  "orgValidationErrorMessage": {
+    "message": "Lỗi khi xác thực tổ chức."
+  },
+  "refreshingButton": {
+    "message": "Đang làm mới..."
+  },
+  "cacheClearFailed": {
+    "message": "Xóa bộ nhớ đệm thất bại."
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "Đang tạo..."
+  },
+  "copiedButton": {
+    "message": "Đã sao chép!"
+  },
+  "orgChangedMessage": {
+    "message": "Tổ chức đã thay đổi. Nhấp vào 'Tạo báo cáo' để lấy các hoạt động trên GitHub."
+  },
+  "cacheClearedMessage": {
+    "message": "Bộ nhớ đệm đã được xóa thành công. Nhấp vào 'Tạo báo cáo' để lấy dữ liệu mới."
+  },
+  "cacheExpiredMessage": {
+    "message": "Bộ nhớ đệm đã hết hạn. Nhấp vào \"Tạo\" để lấy dữ liệu mới."
+  },
+  "cacheClearedButton": {
+    "message": "Đã xóa bộ nhớ đệm!"
+  },
+  "extensionDisabledMessage": {
+    "message": "Tiện ích mở rộng đã bị tắt. Bật nó từ cài đặt để tạo báo cáo scrum."
+  },
+  "notePoint1": {
+    "message": "Pull request được lấy dựa trên hoạt động đánh giá gần đây nhất của bất kỳ người đóng góp nào, không chỉ của riêng bạn. Vui lòng xem xét và điều chỉnh báo cáo SCRUM được tạo để đảm bảo nó phản ánh chính xác công việc của bạn trước khi chia sẻ."
+  },
+  "noteSeeIssue": {
+    "message": "Xem vấn đề này"
+  },
+  "platformLabel": {
+    "message": "Nền tảng"
+  },
+  "usernameLabel": {
+    "message": "Tên người dùng của bạn"
+  },
+  "onlyRevPRsLabel": {
+    "message": "Chỉ bao gồm các PR bạn đã xem xét trong báo cáo"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "Nếu được chọn, báo cáo sẽ chỉ bao gồm các PR bạn đã xem xét."
+  },
+  "onlyMergedPRsLabel": {
+    "message": "Chỉ bao gồm các PR đã hợp nhất (merged) trong báo cáo"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "Nếu được chọn, báo cáo sẽ chỉ bao gồm các PR đã được hợp nhất. Cần có mã thông báo GitHub."
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "Cần có mã thông báo GitHub để lọc theo các PR đã hợp nhất. Vui lòng thêm một mã trong cài đặt."
+  },
+  "usernameRequiredError": {
+    "message": "Vui lòng nhập tên người dùng để tạo báo cáo."
+  },
+  "unknownPlatformError": {
+    "message": "Đã chọn nền tảng không xác định."
+  },
+  "gitlabFetchingError": {
+    "message": "Đã xảy ra lỗi khi lấy dữ liệu GitLab."
+  },
+  "reportGenerationError": {
+    "message": "Đã xảy ra lỗi khi tạo báo cáo."
+  },
+  "githubUserNotFoundError": {
+    "message": "Không tìm thấy người dùng GitHub \"$1\" (404). Vui lòng kiểm tra tên người dùng và thử lại."
+  },
+  "githubUserValidationError": {
+    "message": "Lỗi khi xác thực người dùng GitHub: $1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "Truy vấn tìm kiếm hoặc khoảng ngày không hợp lệ. Vui lòng kiểm tra định dạng và thử lại."
+  },
+  "githubIssuesFetchError": {
+    "message": "Lỗi khi lấy các vấn đề từ GitHub: $1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "Lỗi khi lấy dữ liệu đánh giá PR từ GitHub: $1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "Lỗi khi lấy dữ liệu người dùng GitHub: $1 $2"
+  },
+  "invalidTokenError": {
+    "message": "Mã token GitHub không hợp lệ hoặc đã hết hạn. Vui lòng kiểm tra mã token trong cài đặt Scrum Helper và thử lại."
+  },
+  "displayModeNotice": {
+    "message": "Tiện ích sẽ mở ở chế độ $1 trong lần khởi động tiếp theo."
+  },
+  "repoFilteringGithubOnly": {
+    "message": "Chỉ có thể lọc kho lưu trữ trên GitHub."
+  },
+  "repoLoadingGithubOnly": {
+    "message": "Chỉ có thể tải kho lưu trữ trên GitHub."
+  },
+  "repoFetchingGithubOnly": {
+    "message": "Chỉ có thể lấy kho lưu trữ trên GitHub."
+  },
+  "loadingReposAutomatically": {
+    "message": "Đang tự động tải kho lưu trữ..."
+  },
+  "gitlabUserFetchError": {
+    "message": "Lỗi khi lấy người dùng GitLab: $1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "Không tìm thấy người dùng GitLab '$1'"
+  },
+  "gitlabMembershipError": {
+    "message": "Lỗi khi lấy dự án thành viên GitLab: $1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "Lỗi khi lấy dự án đóng góp GitLab: $1 $2"
+  },
+  "usernameMissingError": {
+    "message": "Yêu cầu tên người dùng."
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "Đang tạo báo cáo..."
+  },
+  "copyingReportNotification": {
+    "message": "Đang sao chép báo cáo..."
+  },
+  "copiedReportNotification": {
+    "message": "Đã sao chép báo cáo!"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "Đang chèn báo cáo vào email..."
+  },
+  "insertedInEmailNotification": {
+    "message": "Đã chèn báo cáo vào email!"
+  }
 }

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -1,338 +1,342 @@
 {
-    "appName": {
-        "message": "Scrum Helper"
-    },
-    "appDescription": {
-        "message": "通过自动获取选定时间段内的 Git 活动来报告您的开发进度。"
-    },
-    "disableLabel": {
-        "message": "禁用"
-    },
-    "enableLabel": {
-        "message": "启用"
-    },
-    "projectNameLabel": {
-        "message": "项目名称（用于电子邮件主题）"
-    },
-    "projectNamePlaceholder": {
-        "message": "输入您的项目名称"
-    },
-    "githubUsernameLabel": {
-        "message": "您的 GitHub 用户名"
-    },
-    "gitlabUsernameLabel": {
-        "message": "您的 GitLab 用户名"
-    },
-    "githubUsernamePlaceholder": {
-        "message": "获取您的贡献所必需"
-    },
-    "contributionsLabel": {
-        "message": "获取您在此期间的贡献："
-    },
-    "last1DayLabel": {
-        "message": "前一天"
-    },
-    "startDateLabel": {
-        "message": "从:"
-    },
-    "endDateLabel": {
-        "message": "到:"
-    },
-    "showOpenClosedLabel": {
-        "message": "显示“打开/关闭”状态"
-    },
-    "blockersLabel": {
-        "message": "什么阻碍了您的进展？"
-    },
-    "blockersPlaceholder": {
-        "message": "输入您的原因"
-    },
-    "scrumReportLabel": {
-        "message": "Scrum 报告"
-    },
-    "generateReportButton": {
-        "message": "生成"
-    },
-    "copyReportButton": {
-        "message": "复制"
-    },
-    "insertInEmailButton": {
-        "message": "插入到邮件"
-    },
-    "insertToEmailFailedError": {
-        "message": "打开电子邮件标签页以插入报告"
-    },
-    "settingsOrgNameLabel": {
-        "message": "组织名称"
-    },
-    "settingsOrgNamePlaceholder": {
-        "message": "输入组织名称"
-    },
-    "setButton": {
-        "message": "设置"
-    },
-    "githubTokenLabel": {
-        "message": "您的 GitHub 令牌"
-    },
-    "githubTokenPlaceholder": {
-        "message": "进行身份验证请求所必需"
-    },
-    "githubTokenTooltip": {
-        "message": "为什么建议添加 GitHub 令牌？Scrum Helper 无需 GitHub 令牌也能工作，但添加个人访问令牌可以提供更好的体验。"
-    },
-    "gitlabTokenLabel": {
-        "message": "您的 GitLab 令牌"
-    },
-    "gitlabTokenPlaceholder": {
-        "message": "私有仓库需要"
-    },
-    "gitlabTokenTooltip": {
-        "message": "为什么建议添加 GitLab 令牌？Scrum Helper 对于公开项目无需 GitLab 令牌也能工作，但添加个人访问令牌可以提供更好的体验。"
-    },
-    "showCommitsLabel": {
-        "message": "在打开的 PR/草稿 PR 上显示提交"
-    },
-    "showCommitsTooltip": {
-        "message": "需要 Github 令牌，请在设置中添加。"
-    },
-    "onlyIssuesLabel": {
-        "message": "报告中仅包含问题"
-    },
-    "onlyIssuesTooltip": {
-        "message": "如果选中，报告将仅包含由用户创建或分配给用户的问题。"
-    },
-    "onlyPRsLabel": {
-        "message": "报告中仅包含PR"
-    },
-    "onlyPRsTooltip": {
-        "message": "勾选后，报告将只包含用户创建的拉取请求；已审核的PR将被排除。"
-    },
-    "cacheTTLLabel": {
-        "message": "输入缓存 TTL"
-    },
-    "cacheTTLUnit": {
-        "message": "（分钟）"
-    },
-    "cacheTTLPlaceholder": {
-        "message": "以分钟为单位输入缓存 TTL（默认为 10）"
-    },
-    "refreshDataButton": {
-        "message": "刷新数据（绕过缓存）"
-    },
-    "refreshDataInfo": {
-        "message": "使用此按钮立即获取新数据。"
-    },
-    "noteTitle": {
-        "message": "注意："
-    },
-    "viewCodeButton": {
-        "message": "查看代码"
-    },
-    "reportIssueButton": {
-        "message": "报告问题"
-    },
-    "repoFilterLabel": {
-        "message": "按仓库筛选"
-    },
-    "enableFilteringLabel": {
-        "message": "启用筛选"
-    },
-    "tokenRequiredWarning": {
-        "message": "仓库筛选需要GitHub令牌。请在设置中添加一个。"
-    },
-    "tokenRequiredShowCommitsWarning": {
-        "message": "在打开或草稿 PR 中显示提交需要 GitHub 令牌。请在设置中添加一个。"
-    },
-    "repoSearchPlaceholder": {
-        "message": "搜索要添加的仓库..."
-    },
-    "repoPlaceholder": {
-        "message": "未选择任何仓库（将包含所有仓库）"
-    },
-    "repoCountNone": {
-        "message": "已选择 0 个仓库"
-    },
-    "repoCount": {
-        "message": "已选择 $1 个仓库"
-    },
-    "clearAllBtn": {
-        "message": "全部清除"
-    },
-    "repoLoading": {
-        "message": "正在加载仓库..."
-    },
-    "repoLoaded": {
-        "message": "已加载 $1 个仓库。"
-    },
-    "repoNotFound": {
-        "message": "未找到仓库"
-    },
-    "repoRefetching": {
-        "message": "正在重新加载仓库..."
-    },
-    "repoLoadFailed": {
-        "message": "加载仓库失败。"
-    },
-    "repoTokenPrivate": {
-        "message": "令牌无效或没有私有仓库的权限。"
-    },
-    "repoRefetchFailed": {
-        "message": "重新加载仓库失败。"
-    },
-    "orgSetMessage": {
-        "message": "组织设置成功。"
-    },
-    "orgClearedMessage": {
-        "message": "组织已清除。点击“生成报告”以获取所有活动。"
-    },
-    "orgNotFoundMessage": {
-        "message": "在GitHub上找不到组织。"
-    },
-    "orgValidationErrorMessage": {
-        "message": "验证组织时出错。"
-    },
-    "refreshingButton": {
-        "message": "正在刷新..."
-    },
-    "cacheClearFailed": {
-        "message": "清除缓存失败。"
-    },
-    "madeWithLoveBy": {
-        "message": "Made with ❤️ by"
-    },
-    "generatingButton": {
-        "message": "正在生成..."
-    },
-    "copiedButton": {
-        "message": "已复制！"
-    },
-    "orgChangedMessage": {
-        "message": "组织已更改。单击“生成报告”按钮以获取 GitHub 活动。"
-    },
-    "cacheClearedMessage": {
-        "message": "缓存已成功清除。单击“生成报告”以获取新数据。"
-    },
-    "cacheExpiredMessage": {
-        "message": "缓存已过期。点击\"生成\"以获取最新数据。"
-    },
-    "cacheClearedButton": {
-        "message": "缓存已清除！"
-    },
-    "extensionDisabledMessage": {
-        "message": "扩展已禁用。请在设置中启用它以生成 Scrum 报告。"
-    },
-    "notePoint1": {
-        "message": "拉取请求是根据任何贡献者最近的审查活动来获取的，而不仅仅是您自己的。在分享之前，请审查并调整生成的SCRUM报告，以确保它准确地反映您的工作。"
-    },
-    "noteSeeIssue": {
-        "message": "查看此 issue"
-    },
-    "platformLabel": {
-        "message": "平台"
-    },
-    "usernameLabel": {
-        "message": "您的用户名"
-    },
-    "onlyRevPRsLabel": {
-        "message": "报告中仅包含已审核的 PR"
-    },
-    "onlyRevPRsTooltip": {
-        "message": "如果选中，报告将仅包含由您审核的 PR。"
-    },
-    "onlyMergedPRsLabel": {
-        "message": "报告中仅包含已合并的 PR"
-    },
-    "onlyMergedPRsTooltip": {
-        "message": "如果选中，报告将仅包含已合并的 PR。需要 GitHub 令牌。"
-    },
-    "tokenRequiredMergedPRsWarning": {
-        "message": "按已合并 PR 过滤需要 GitHub 令牌。请在设置中添加一个。"
-    },
-    "usernameRequiredError": {
-        "message": "请填写用户名以生成报告。"
-    },
-    "unknownPlatformError": {
-        "message": "选择了未知的平台。"
-    },
-    "gitlabFetchingError": {
-        "message": "获取 GitLab 数据时发生错误。"
-    },
-    "reportGenerationError": {
-        "message": "生成报告时发生错误。"
-    },
-    "githubUserNotFoundError": {
-        "message": "未找到 GitHub 用户 \"$1\"（404）。请检查用户名后重试。"
-    },
-    "githubUserValidationError": {
-        "message": "验证 GitHub 用户时出错：$1 $2"
-    },
-    "invalidSearchQueryError": {
-        "message": "无效的搜索查询或日期范围。请检查格式后重试。"
-    },
-    "githubIssuesFetchError": {
-        "message": "获取 GitHub 问题时出错：$1 $2"
-    },
-    "githubPRReviewFetchError": {
-        "message": "获取 GitHub PR 审查数据时出错：$1 $2"
-    },
-    "githubUserFetchError": {
-        "message": "获取 GitHub 用户数据时出错：$1 $2"
-    },
-    "invalidTokenError": {
-        "message": "GitHub 令牌无效或已过期。请在 Scrum Helper 设置中检查您的令牌并重试。"
-    },
-    "displayModeNotice": {
-        "message": "扩展将在下次启动时以 $1 模式打开。"
-    },
-    "repoFilteringGithubOnly": {
-        "message": "仓库筛选仅适用于 GitHub。"
-    },
-    "repoLoadingGithubOnly": {
-        "message": "仓库加载仅适用于 GitHub。"
-    },
-    "repoFetchingGithubOnly": {
-        "message": "仓库获取仅适用于 GitHub。"
-    },
-    "loadingReposAutomatically": {
-        "message": "正在自动加载仓库..."
-    },
-    "gitlabUserFetchError": {
-        "message": "获取 GitLab 用户时出错：$1 $2"
-    },
-    "gitlabUserNotFoundError": {
-        "message": "未找到 GitLab 用户 '$1'"
-    },
-    "gitlabMembershipError": {
-        "message": "获取 GitLab 成员项目时出错：$1 $2"
-    },
-    "gitlabContributedError": {
-        "message": "获取 GitLab 贡献项目时出错：$1 $2"
-    },
-    "usernameMissingError": {
-        "message": "需要用户名。"
-    },
-    "generateReportTooltip": {
-        "message": "Ctrl+G"
-    },
-    "copyReportTooltip": {
-        "message": "Ctrl+Shift+Y"
-    },
-    "generatingReportNotification": {
-        "message": "正在生成报告..."
-    },
-    "copyingReportNotification": {
-        "message": "正在复制报告..."
-    },
-    "copiedReportNotification": {
-        "message": "报告已复制！"
-    },
-    "insertInEmailTooltip": {
-        "message": "Ctrl+Shift+M"
-    },
-    "insertingInEmailNotification": {
-        "message": "正在将报告插入邮件..."
-    },
-    "insertedInEmailNotification": {
-        "message": "报告已插入邮件！"
-    }
+  "appName": {
+    "message": "Scrum Helper"
+  },
+  "appDescription": {
+    "message": "通过自动获取选定时间段内的 Git 活动来报告您的开发进度。"
+  },
+  "disableLabel": {
+    "message": "禁用"
+  },
+  "enableLabel": {
+    "message": "启用"
+  },
+  "projectNameLabel": {
+    "message": "项目名称（用于电子邮件主题）"
+  },
+  "projectNamePlaceholder": {
+    "message": "输入您的项目名称"
+  },
+  "githubUsernameLabel": {
+    "message": "您的 GitHub 用户名"
+  },
+  "gitlabUsernameLabel": {
+    "message": "您的 GitLab 用户名"
+  },
+  "githubUsernamePlaceholder": {
+    "message": "获取您的贡献所必需"
+  },
+  "contributionsLabel": {
+    "message": "获取您在此期间的贡献："
+  },
+  "last1DayLabel": {
+    "message": "前一天"
+  },
+  "lastWeekLabel": {
+    "message": "上周总结",
+    "description": "Radio button option for the last 7 days."
+  },
+  "startDateLabel": {
+    "message": "从:"
+  },
+  "endDateLabel": {
+    "message": "到:"
+  },
+  "showOpenClosedLabel": {
+    "message": "显示“打开/关闭”状态"
+  },
+  "blockersLabel": {
+    "message": "什么阻碍了您的进展？"
+  },
+  "blockersPlaceholder": {
+    "message": "输入您的原因"
+  },
+  "scrumReportLabel": {
+    "message": "Scrum 报告"
+  },
+  "generateReportButton": {
+    "message": "生成"
+  },
+  "copyReportButton": {
+    "message": "复制"
+  },
+  "insertInEmailButton": {
+    "message": "插入到邮件"
+  },
+  "insertToEmailFailedError": {
+    "message": "打开电子邮件标签页以插入报告"
+  },
+  "settingsOrgNameLabel": {
+    "message": "组织名称"
+  },
+  "settingsOrgNamePlaceholder": {
+    "message": "输入组织名称"
+  },
+  "setButton": {
+    "message": "设置"
+  },
+  "githubTokenLabel": {
+    "message": "您的 GitHub 令牌"
+  },
+  "githubTokenPlaceholder": {
+    "message": "进行身份验证请求所必需"
+  },
+  "githubTokenTooltip": {
+    "message": "为什么建议添加 GitHub 令牌？Scrum Helper 无需 GitHub 令牌也能工作，但添加个人访问令牌可以提供更好的体验。"
+  },
+  "gitlabTokenLabel": {
+    "message": "您的 GitLab 令牌"
+  },
+  "gitlabTokenPlaceholder": {
+    "message": "私有仓库需要"
+  },
+  "gitlabTokenTooltip": {
+    "message": "为什么建议添加 GitLab 令牌？Scrum Helper 对于公开项目无需 GitLab 令牌也能工作，但添加个人访问令牌可以提供更好的体验。"
+  },
+  "showCommitsLabel": {
+    "message": "在打开的 PR/草稿 PR 上显示提交"
+  },
+  "showCommitsTooltip": {
+    "message": "需要 Github 令牌，请在设置中添加。"
+  },
+  "onlyIssuesLabel": {
+    "message": "报告中仅包含问题"
+  },
+  "onlyIssuesTooltip": {
+    "message": "如果选中，报告将仅包含由用户创建或分配给用户的问题。"
+  },
+  "onlyPRsLabel": {
+    "message": "报告中仅包含PR"
+  },
+  "onlyPRsTooltip": {
+    "message": "勾选后，报告将只包含用户创建的拉取请求；已审核的PR将被排除。"
+  },
+  "cacheTTLLabel": {
+    "message": "输入缓存 TTL"
+  },
+  "cacheTTLUnit": {
+    "message": "（分钟）"
+  },
+  "cacheTTLPlaceholder": {
+    "message": "以分钟为单位输入缓存 TTL（默认为 10）"
+  },
+  "refreshDataButton": {
+    "message": "刷新数据（绕过缓存）"
+  },
+  "refreshDataInfo": {
+    "message": "使用此按钮立即获取新数据。"
+  },
+  "noteTitle": {
+    "message": "注意："
+  },
+  "viewCodeButton": {
+    "message": "查看代码"
+  },
+  "reportIssueButton": {
+    "message": "报告问题"
+  },
+  "repoFilterLabel": {
+    "message": "按仓库筛选"
+  },
+  "enableFilteringLabel": {
+    "message": "启用筛选"
+  },
+  "tokenRequiredWarning": {
+    "message": "仓库筛选需要GitHub令牌。请在设置中添加一个。"
+  },
+  "tokenRequiredShowCommitsWarning": {
+    "message": "在打开或草稿 PR 中显示提交需要 GitHub 令牌。请在设置中添加一个。"
+  },
+  "repoSearchPlaceholder": {
+    "message": "搜索要添加的仓库..."
+  },
+  "repoPlaceholder": {
+    "message": "未选择任何仓库（将包含所有仓库）"
+  },
+  "repoCountNone": {
+    "message": "已选择 0 个仓库"
+  },
+  "repoCount": {
+    "message": "已选择 $1 个仓库"
+  },
+  "clearAllBtn": {
+    "message": "全部清除"
+  },
+  "repoLoading": {
+    "message": "正在加载仓库..."
+  },
+  "repoLoaded": {
+    "message": "已加载 $1 个仓库。"
+  },
+  "repoNotFound": {
+    "message": "未找到仓库"
+  },
+  "repoRefetching": {
+    "message": "正在重新加载仓库..."
+  },
+  "repoLoadFailed": {
+    "message": "加载仓库失败。"
+  },
+  "repoTokenPrivate": {
+    "message": "令牌无效或没有私有仓库的权限。"
+  },
+  "repoRefetchFailed": {
+    "message": "重新加载仓库失败。"
+  },
+  "orgSetMessage": {
+    "message": "组织设置成功。"
+  },
+  "orgClearedMessage": {
+    "message": "组织已清除。点击“生成报告”以获取所有活动。"
+  },
+  "orgNotFoundMessage": {
+    "message": "在GitHub上找不到组织。"
+  },
+  "orgValidationErrorMessage": {
+    "message": "验证组织时出错。"
+  },
+  "refreshingButton": {
+    "message": "正在刷新..."
+  },
+  "cacheClearFailed": {
+    "message": "清除缓存失败。"
+  },
+  "madeWithLoveBy": {
+    "message": "Made with ❤️ by"
+  },
+  "generatingButton": {
+    "message": "正在生成..."
+  },
+  "copiedButton": {
+    "message": "已复制！"
+  },
+  "orgChangedMessage": {
+    "message": "组织已更改。单击“生成报告”按钮以获取 GitHub 活动。"
+  },
+  "cacheClearedMessage": {
+    "message": "缓存已成功清除。单击“生成报告”以获取新数据。"
+  },
+  "cacheExpiredMessage": {
+    "message": "缓存已过期。点击\"生成\"以获取最新数据。"
+  },
+  "cacheClearedButton": {
+    "message": "缓存已清除！"
+  },
+  "extensionDisabledMessage": {
+    "message": "扩展已禁用。请在设置中启用它以生成 Scrum 报告。"
+  },
+  "notePoint1": {
+    "message": "拉取请求是根据任何贡献者最近的审查活动来获取的，而不仅仅是您自己的。在分享之前，请审查并调整生成的SCRUM报告，以确保它准确地反映您的工作。"
+  },
+  "noteSeeIssue": {
+    "message": "查看此 issue"
+  },
+  "platformLabel": {
+    "message": "平台"
+  },
+  "usernameLabel": {
+    "message": "您的用户名"
+  },
+  "onlyRevPRsLabel": {
+    "message": "报告中仅包含已审核的 PR"
+  },
+  "onlyRevPRsTooltip": {
+    "message": "如果选中，报告将仅包含由您审核的 PR。"
+  },
+  "onlyMergedPRsLabel": {
+    "message": "报告中仅包含已合并的 PR"
+  },
+  "onlyMergedPRsTooltip": {
+    "message": "如果选中，报告将仅包含已合并的 PR。需要 GitHub 令牌。"
+  },
+  "tokenRequiredMergedPRsWarning": {
+    "message": "按已合并 PR 过滤需要 GitHub 令牌。请在设置中添加一个。"
+  },
+  "usernameRequiredError": {
+    "message": "请填写用户名以生成报告。"
+  },
+  "unknownPlatformError": {
+    "message": "选择了未知的平台。"
+  },
+  "gitlabFetchingError": {
+    "message": "获取 GitLab 数据时发生错误。"
+  },
+  "reportGenerationError": {
+    "message": "生成报告时发生错误。"
+  },
+  "githubUserNotFoundError": {
+    "message": "未找到 GitHub 用户 \"$1\"（404）。请检查用户名后重试。"
+  },
+  "githubUserValidationError": {
+    "message": "验证 GitHub 用户时出错：$1 $2"
+  },
+  "invalidSearchQueryError": {
+    "message": "无效的搜索查询或日期范围。请检查格式后重试。"
+  },
+  "githubIssuesFetchError": {
+    "message": "获取 GitHub 问题时出错：$1 $2"
+  },
+  "githubPRReviewFetchError": {
+    "message": "获取 GitHub PR 审查数据时出错：$1 $2"
+  },
+  "githubUserFetchError": {
+    "message": "获取 GitHub 用户数据时出错：$1 $2"
+  },
+  "invalidTokenError": {
+    "message": "GitHub 令牌无效或已过期。请在 Scrum Helper 设置中检查您的令牌并重试。"
+  },
+  "displayModeNotice": {
+    "message": "扩展将在下次启动时以 $1 模式打开。"
+  },
+  "repoFilteringGithubOnly": {
+    "message": "仓库筛选仅适用于 GitHub。"
+  },
+  "repoLoadingGithubOnly": {
+    "message": "仓库加载仅适用于 GitHub。"
+  },
+  "repoFetchingGithubOnly": {
+    "message": "仓库获取仅适用于 GitHub。"
+  },
+  "loadingReposAutomatically": {
+    "message": "正在自动加载仓库..."
+  },
+  "gitlabUserFetchError": {
+    "message": "获取 GitLab 用户时出错：$1 $2"
+  },
+  "gitlabUserNotFoundError": {
+    "message": "未找到 GitLab 用户 '$1'"
+  },
+  "gitlabMembershipError": {
+    "message": "获取 GitLab 成员项目时出错：$1 $2"
+  },
+  "gitlabContributedError": {
+    "message": "获取 GitLab 贡献项目时出错：$1 $2"
+  },
+  "usernameMissingError": {
+    "message": "需要用户名。"
+  },
+  "generateReportTooltip": {
+    "message": "Ctrl+G"
+  },
+  "copyReportTooltip": {
+    "message": "Ctrl+Shift+Y"
+  },
+  "generatingReportNotification": {
+    "message": "正在生成报告..."
+  },
+  "copyingReportNotification": {
+    "message": "正在复制报告..."
+  },
+  "copiedReportNotification": {
+    "message": "报告已复制！"
+  },
+  "insertInEmailTooltip": {
+    "message": "Ctrl+Shift+M"
+  },
+  "insertingInEmailNotification": {
+    "message": "正在将报告插入邮件..."
+  },
+  "insertedInEmailNotification": {
+    "message": "报告已插入邮件！"
+  }
 }

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -157,6 +157,8 @@ function allIncluded(outputTarget = 'email') {
 	let reviewedPrsArray = [];
 	let weeklyPrsList = [];
 	let weeklyIssuesList = [];
+	let seenPrNumbers = new Set();
+	let seenIssueNumbers = new Set();
 	let githubIssuesData = null;
 	let yesterdayContribution = false;
 	let weeklyContribution = false;
@@ -1073,6 +1075,8 @@ function allIncluded(outputTarget = 'email') {
 		reviewedPrsArray = [];
 		weeklyPrsList = [];
 		weeklyIssuesList = [];
+		seenPrNumbers.clear();
+		seenIssueNumbers.clear();
 		githubPrsReviewDataProcessed = {};
 		issuesDataProcessed = false;
 		prsReviewDataProcessed = false;
@@ -1103,14 +1107,7 @@ function allIncluded(outputTarget = 'email') {
 				weekOrDay2 = 'this week';
 			}
 
-			let content;
-			if (weeklyContribution) {
-				content = buildWeeklySummaryHtml();
-			} else if (yesterdayContribution) {
-				content = `<b>1. What did I do ${weekOrDay}?</b><br>${lastWeekUl}<br><b>2. What do I plan to do ${weekOrDay2}?</b><br>${nextWeekUl}<br><b>3. What is blocking me from making progress?</b><br>${blockerText}`;
-			} else {
-				content = `<b>1. What did I do from ${formatDate(startingDate)} to ${formatDate(endingDate)}?</b><br>${lastWeekUl}<br><b>2. What do I plan to do ${weekOrDay2}?</b><br>${nextWeekUl}<br><b>3. What is blocking me from making progress?</b><br>${blockerText}`;
-			}
+			const content = getScrumContent(lastWeekUl, nextWeekUl, blockerText);
 			// Wait for both subject and body to be available, then inject both
 			let injected = false;
 			const interval = setInterval(() => {
@@ -1236,10 +1233,10 @@ function allIncluded(outputTarget = 'email') {
 		return html;
 	}
 
-	function writeScrumBody() {
-		const lastWeekUl = buildActivityListHtml();
-		const nextWeekUl = buildNextWeekListHtml();
-		const blockerText = buildBlockerTextHtml();
+	function getScrumContent(lastWeekUl, nextWeekUl, blockerText) {
+		if (weeklyContribution) {
+			return buildWeeklySummaryHtml();
+		}
 
 		let weekOrDay = 'the period';
 		let weekOrDay2 = 'today';
@@ -1251,24 +1248,18 @@ function allIncluded(outputTarget = 'email') {
 			weekOrDay2 = 'this week';
 		}
 
-		let content;
-		if (weeklyContribution) {
-			content = buildWeeklySummaryHtml();
-		} else if (yesterdayContribution) {
-			content = `<b>1. What did I do ${weekOrDay}?</b><br>
-${lastWeekUl}<br>
-<b>2. What do I plan to do ${weekOrDay2}?</b><br>
-${nextWeekUl}<br>
-<b>3. What is blocking me from making progress?</b><br>
-${blockerText}`;
-		} else {
-			content = `<b>1. What did I do from ${formatDate(startingDate)} to ${formatDate(endingDate)}?</b><br>
-${lastWeekUl}<br>
-<b>2. What do I plan to do ${weekOrDay2}?</b><br>
-${nextWeekUl}<br>
-<b>3. What is blocking me from making progress?</b><br>
-${blockerText}`;
+		if (yesterdayContribution) {
+			return `<b>1. What did I do ${weekOrDay}?</b><br>${lastWeekUl}<br><b>2. What do I plan to do ${weekOrDay2}?</b><br>${nextWeekUl}<br><b>3. What is blocking me from making progress?</b><br>${blockerText}`;
 		}
+
+		return `<b>1. What did I do from ${formatDate(startingDate)} to ${formatDate(endingDate)}?</b><br>${lastWeekUl}<br><b>2. What do I plan to do ${weekOrDay2}?</b><br>${nextWeekUl}<br><b>3. What is blocking me from making progress?</b><br>${blockerText}`;
+	}
+
+	function writeScrumBody() {
+		const lastWeekUl = buildActivityListHtml();
+		const nextWeekUl = buildNextWeekListHtml();
+		const blockerText = buildBlockerTextHtml();
+		const content = getScrumContent(lastWeekUl, nextWeekUl, blockerText);
 
 		if (outputTarget === 'popup') {
 			const scrumReport = document.getElementById('scrumReport');
@@ -1924,7 +1915,8 @@ ${blockerText}`;
 				log('[SCRUM-DEBUG] Added PR/MR to lastWeekArray:', li, item);
 				lastWeekArray.push(li);
 				if (weeklyContribution) {
-					if (!weeklyPrsList.some((pr) => pr.number === number)) {
+					if (!seenPrNumbers.has(number)) {
+						seenPrNumbers.add(number);
 						weeklyPrsList.push({ number, title, html_url });
 					}
 				}
@@ -2001,7 +1993,8 @@ ${blockerText}`;
 				log('[SCRUM-DEBUG] Added issue to lastWeekArray:', li, item);
 				lastWeekArray.push(li);
 				if (weeklyContribution && isNewIssue) {
-					if (!weeklyIssuesList.some((issue) => issue.number === number)) {
+					if (!seenIssueNumbers.has(number)) {
+						seenIssueNumbers.add(number);
 						weeklyIssuesList.push({ number, title, html_url });
 					}
 				}

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -155,6 +155,8 @@ function allIncluded(outputTarget = 'email') {
 	let lastWeekArray = [];
 	let nextWeekArray = [];
 	let reviewedPrsArray = [];
+	let weeklyPrsList = [];
+	let weeklyIssuesList = [];
 	let githubIssuesData = null;
 	let yesterdayContribution = false;
 	let weeklyContribution = false;
@@ -1069,6 +1071,8 @@ function allIncluded(outputTarget = 'email') {
 		lastWeekArray = [];
 		nextWeekArray = [];
 		reviewedPrsArray = [];
+		weeklyPrsList = [];
+		weeklyIssuesList = [];
 		githubPrsReviewDataProcessed = {};
 		issuesDataProcessed = false;
 		prsReviewDataProcessed = false;
@@ -1100,7 +1104,9 @@ function allIncluded(outputTarget = 'email') {
 			}
 
 			let content;
-			if (yesterdayContribution || weeklyContribution) {
+			if (weeklyContribution) {
+				content = buildWeeklySummaryHtml();
+			} else if (yesterdayContribution) {
 				content = `<b>1. What did I do ${weekOrDay}?</b><br>${lastWeekUl}<br><b>2. What do I plan to do ${weekOrDay2}?</b><br>${nextWeekUl}<br><b>3. What is blocking me from making progress?</b><br>${blockerText}`;
 			} else {
 				content = `<b>1. What did I do from ${formatDate(startingDate)} to ${formatDate(endingDate)}?</b><br>${lastWeekUl}<br><b>2. What do I plan to do ${weekOrDay2}?</b><br>${nextWeekUl}<br><b>3. What is blocking me from making progress?</b><br>${blockerText}`;
@@ -1177,6 +1183,59 @@ function allIncluded(outputTarget = 'email') {
 		return wrapCompactText(userReason);
 	}
 
+	function buildWeeklySummaryHtml() {
+		let html = '<b>Previous Week Summary</b><br><ul>';
+
+		// 1. Made or updated existing PR
+		html += '<li><b>Made or updated existing PR :</b>';
+		if (weeklyPrsList.length > 0) {
+			html += '<ul>';
+			for (const pr of weeklyPrsList) {
+				html += `<li><a href="${pr.html_url}" target="_blank" rel="noopener noreferrer">(#${pr.number})</a> - <a href="${pr.html_url}" target="_blank" rel="noopener noreferrer">${escapeHtml(pr.title)}</a></li>`;
+			}
+			html += '</ul>';
+		} else {
+			html += '<ul><li>None</li></ul>';
+		}
+		html += '</li>';
+
+		// 2. Opened issues
+		html += '<li><b>Opened issues :</b>';
+		if (weeklyIssuesList.length > 0) {
+			html += '<ul>';
+			for (const issue of weeklyIssuesList) {
+				html += `<li><a href="${issue.html_url}" target="_blank" rel="noopener noreferrer">${escapeHtml(issue.title)}</a></li>`;
+			}
+			html += '</ul>';
+		} else {
+			html += '<ul><li>None</li></ul>';
+		}
+		html += '</li>';
+
+		// 3. Reviewed PR
+		html += '<li><b>Reviewed PR :</b>';
+		const repos = Object.keys(githubPrsReviewDataProcessed);
+		if (repos.length > 0) {
+			html += '<ul>';
+			for (const repo of repos) {
+				html += `<li>${escapeHtml(repo)}<ul><li>`;
+				const prs = githubPrsReviewDataProcessed[repo];
+				const prLinks = prs.map(
+					(pr) => `<a href="${pr.html_url}" target="_blank" rel="noopener noreferrer">#${pr.number}</a>`,
+				);
+				html += prLinks.join(', ');
+				html += '</li></ul></li>';
+			}
+			html += '</ul>';
+		} else {
+			html += '<ul><li>None</li></ul>';
+		}
+		html += '</li>';
+
+		html += '</ul>';
+		return html;
+	}
+
 	function writeScrumBody() {
 		const lastWeekUl = buildActivityListHtml();
 		const nextWeekUl = buildNextWeekListHtml();
@@ -1193,7 +1252,9 @@ function allIncluded(outputTarget = 'email') {
 		}
 
 		let content;
-		if (yesterdayContribution || weeklyContribution) {
+		if (weeklyContribution) {
+			content = buildWeeklySummaryHtml();
+		} else if (yesterdayContribution) {
 			content = `<b>1. What did I do ${weekOrDay}?</b><br>
 ${lastWeekUl}<br>
 <b>2. What do I plan to do ${weekOrDay2}?</b><br>
@@ -1862,6 +1923,11 @@ ${blockerText}`;
 				}
 				log('[SCRUM-DEBUG] Added PR/MR to lastWeekArray:', li, item);
 				lastWeekArray.push(li);
+				if (weeklyContribution) {
+					if (!weeklyPrsList.some((pr) => pr.number === number)) {
+						weeklyPrsList.push({ number, title, html_url });
+					}
+				}
 				continue; // Prevent issue logic from overwriting PR li
 			} else {
 				// Only process as issue if not a PR
@@ -1934,6 +2000,11 @@ ${blockerText}`;
 
 				log('[SCRUM-DEBUG] Added issue to lastWeekArray:', li, item);
 				lastWeekArray.push(li);
+				if (weeklyContribution && isNewIssue) {
+					if (!weeklyIssuesList.some((issue) => issue.number === number)) {
+						weeklyIssuesList.push({ number, title, html_url });
+					}
+				}
 			}
 		}
 		log('[SCRUM-DEBUG] Final lastWeekArray:', lastWeekArray);


### PR DESCRIPTION
Fixes #746

**Description**
Currently, selecting the "Previous Week" option generates a long daily-style scrum report. As proposed in the issue, this pull request replaces it with a concise, ready-to-share "Previous Week Summary" grouping the week's accomplishments.

**Proposed Changes & Implementation Details
Activity Tracking**: We added two local arrays (weeklyPrsList and weeklyIssuesList) inside the allIncluded() scope in scrumHelper.js to gather weekly PR actions and opened issues.
      **Layout Structure**: We implemented buildWeeklySummaryHtml() to format the weekly data into a nested bulleted list:
Made or updated existing PR: Lists all authored or updated PRs with direct links.
      **Opened issues**: Lists newly opened issues with direct links.
      **Reviewed PR**: Groups reviewed PRs by repository name under a comma-separated list of links.
**UI Label Update**: Renamed the timeframe button label (lastWeekLabel) from "Previous week" to "Previous week summary" in the popup UI and updated all 21 locale messages.json files for consistent translation fallback.
Side-Effect & Merge Safety
**Zero External Dependencies**: No external libraries or NPM packages were added. The logic relies purely on vanilla JavaScript and existing extension utilities.
**Zero Storage Migrations**: It reuses legacy keys (weeklyContribution, lastScrumReportHtml), posing no storage migration issues for existing users.
**Branch Isolation**: The weekly summary format is strictly gated by the weeklyContribution condition in scrumHelper.js:
**javascript-**
if (weeklyContribution) {
    content = buildWeeklySummaryHtml();
} else {
    // Legacy daily-style scrum layout continues to render
}

**Verification & Proof
Strict Isolation**: Omitted plans and blockers for the weekly summary report type, while ensuring the "Previous day" and custom range scrum reports remain completely untouched.
**Daily Report Safe**: Selecting the "Previous day" option or setting custom date ranges still generates the traditional 3-part daily scrum report (verified in Chrome unpacked Developer Mode).
**Biome Validation**: We successfully formatted and check-linted the codebase using Biome (npm run format and npm run check) with zero errors.

<img width="632" height="431" alt="Screenshot 2026-07-14 095506" src="https://github.com/user-attachments/assets/55e0d6e4-c1e5-4405-9654-72a786b9d277" />
<img width="634" height="451" alt="Screenshot 2026-07-14 095436" src="https://github.com/user-attachments/assets/a450a299-477b-4fee-a9a5-c67ebd800f73" />

## Summary by Sourcery

Replace the previous week detailed scrum report with a concise previous week summary focused on PRs, issues, and reviews.

New Features:
- Introduce a Previous Week Summary view that aggregates authored/updated PRs, opened issues, and reviewed PRs into a single HTML report.

Enhancements:
- Track weekly PRs and issues separately from daily activity to power the new weekly summary layout.
- Update the weekly report content selection logic to use the new summary format while keeping daily and custom reports unchanged.
- Refresh UI and localization strings to label the option as 'Previous week summary' across all supported locales.