### PR TITLE
Refactor: Replace innerHTML with textContent for safely clearing DOM elements

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -311,7 +311,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	function renderTokenPreview() {
 		if (!tokenPreview || !githubTokenInput) return;
-		tokenPreview.innerHTML = '';
+		tokenPreview.textContent = '';
 		const value = githubTokenInput.value;
 		const isDark = document.body.classList.contains('dark-mode');
 		for (let i = 0; i < value.length; i++) {
@@ -1742,7 +1742,7 @@ if (platformSelectEl) {
 		browser.storage.local.set({ platform }).then(() => {
 			const scrumReport = document.getElementById('scrumReport');
 			if (scrumReport) {
-				scrumReport.innerHTML = '';
+				scrumReport.textContent = '';
 				window.updateCopyButtonState?.();
 			}
 			const generateBtn = document.getElementById('generateReport');
@@ -1809,7 +1809,7 @@ function setPlatformDropdown(value) {
 	}
 	browser.storage.local.set({ platform: value }).then(() => {
 		const scrumReport = document.getElementById('scrumReport');
-		if (scrumReport) scrumReport.innerHTML = '';
+		if (scrumReport) scrumReport.textContent = '';
 		window.updateCopyButtonState?.();
 
 		const generateBtn = document.getElementById('generateReport');

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -114,7 +114,7 @@ document.addEventListener('DOMContentLoaded', () => {
 function showReportMessage(message) {
 	if (!message) return;
 	if (scrumReportEl) {
-		scrumReportEl.innerHTML = '';
+		scrumReportEl.textContent = '';
 		window.updateCopyButtonState?.();
 	}
 	window.scrumHelperToast?.(message, { duration: 2000, variant: 'error' });
@@ -128,7 +128,7 @@ function handleUsernameValidationError(errMessage) {
 	usernameError.textContent = errMessage;
 
 	if (scrumReportEl) {
-		scrumReportEl.innerHTML = '';
+		scrumReportEl.textContent = '';
 		window.updateCopyButtonState?.();
 	}
 }


### PR DESCRIPTION
### 📌 Fixes

Fixes #750


### Problem
The codebase previously cleared element text using `.innerHTML = ''` in `popup.js` and `scrumHelper.js`. While this visually empties the element, it unnecessarily invokes the browser's HTML parser, which is slower and generally goes against modern DOM security best practices.

### Approach
Swapped `.innerHTML = ''` with `.textContent = ''` in 5 distinct places where the sole purpose was to empty the element text. This is a strict, isolated refactor that does not change any extension logic or behavior.

### Validation Evidence
As per the contributing guidelines, I have run the following steps locally before opening this PR:

- [x] `npm run check:write` to align with Biome formatting.
- [x] `npm run lint` - Completed without errors.
- [x] `npm run check` - Completed without errors.
- [x] `npm run build` - Successfully compiled Chrome, Firefox, and Opera extensions.
- [x] Loaded the unpacked extension from `dist/chrome` and manually verified that the empty states, loading states, and report generation still behave exactly as expected without UI regressions.

## Summary by Sourcery

Enhancements:
- Use textContent instead of innerHTML when clearing token preview and scrum report elements to avoid unnecessary HTML parsing and align with DOM security best practices.