### PR TITLE
feat: separate and group report activity by issues and PRs

### DIFF
--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1152,12 +1152,36 @@ function allIncluded(outputTarget = 'email') {
 			return wrapCompactText('No activity to report for the selected time period.');
 		}
 
-		let activityList = '<ul>';
-		for (let i = 0; i < lastWeekIssuesArray.length; i++) activityList += lastWeekIssuesArray[i];
-		for (let i = 0; i < lastWeekPrsArray.length; i++) activityList += lastWeekPrsArray[i];
-		for (let i = 0; i < reviewedPrsArray.length; i++) activityList += reviewedPrsArray[i];
-		activityList += '</ul>';
-		return activityList;
+		const sections = [];
+
+		if (lastWeekIssuesArray.length > 0) {
+			let issuesHtml = '<b>Issues:</b><ul>';
+			for (let i = 0; i < lastWeekIssuesArray.length; i++) {
+				issuesHtml += lastWeekIssuesArray[i];
+			}
+			issuesHtml += '</ul>';
+			sections.push(issuesHtml);
+		}
+
+		if (lastWeekPrsArray.length > 0) {
+			let prsHtml = '<b>Pull Requests:</b><ul>';
+			for (let i = 0; i < lastWeekPrsArray.length; i++) {
+				prsHtml += lastWeekPrsArray[i];
+			}
+			prsHtml += '</ul>';
+			sections.push(prsHtml);
+		}
+
+		if (reviewedPrsArray.length > 0) {
+			let reviewedHtml = '<b>Reviewed Pull Requests:</b><ul>';
+			for (let i = 0; i < reviewedPrsArray.length; i++) {
+				reviewedHtml += reviewedPrsArray[i];
+			}
+			reviewedHtml += '</ul>';
+			sections.push(reviewedHtml);
+		}
+
+		return sections.join('<br>');
 	}
 
 	function buildNextWeekListHtml() {

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -152,7 +152,8 @@ function allIncluded(outputTarget = 'email') {
 	let platformUsernameLocal = '';
 	let githubToken = '';
 	let projectName = '';
-	let lastWeekArray = [];
+	let lastWeekIssuesArray = [];
+	let lastWeekPrsArray = [];
 	let nextWeekArray = [];
 	let reviewedPrsArray = [];
 	let githubIssuesData = null;
@@ -1061,7 +1062,8 @@ function allIncluded(outputTarget = 'email') {
 			filtered: useRepoFilter,
 		});
 
-		lastWeekArray = [];
+		lastWeekIssuesArray = [];
+		lastWeekPrsArray = [];
 		nextWeekArray = [];
 		reviewedPrsArray = [];
 		githubPrsReviewDataProcessed = {};
@@ -1146,12 +1148,13 @@ function allIncluded(outputTarget = 'email') {
 	}
 
 	function buildActivityListHtml() {
-		if (lastWeekArray.length === 0 && reviewedPrsArray.length === 0) {
+		if (lastWeekIssuesArray.length === 0 && lastWeekPrsArray.length === 0 && reviewedPrsArray.length === 0) {
 			return wrapCompactText('No activity to report for the selected time period.');
 		}
 
 		let activityList = '<ul>';
-		for (let i = 0; i < lastWeekArray.length; i++) activityList += lastWeekArray[i];
+		for (let i = 0; i < lastWeekIssuesArray.length; i++) activityList += lastWeekIssuesArray[i];
+		for (let i = 0; i < lastWeekPrsArray.length; i++) activityList += lastWeekPrsArray[i];
 		for (let i = 0; i < reviewedPrsArray.length; i++) activityList += reviewedPrsArray[i];
 		activityList += '</ul>';
 		return activityList;
@@ -1854,8 +1857,8 @@ ${blockerText}`;
 						li = `<li><i>(${project})</i> - ${prAction} <a href='${html_url}' target='_blank' rel='noopener noreferrer' contenteditable='false'>(#${number})</a> - <a href='${html_url}' target='_blank' rel='noopener noreferrer' contenteditable='false'>${title}</a>${showOpenLabel ? ' ' + pr_closed_button : ''}</li>`;
 					}
 				}
-				log('[SCRUM-DEBUG] Added PR/MR to lastWeekArray:', li, item);
-				lastWeekArray.push(li);
+				log('[SCRUM-DEBUG] Added PR/MR to lastWeekPrsArray:', li, item);
+				lastWeekPrsArray.push(li);
 				continue; // Prevent issue logic from overwriting PR li
 			} else {
 				// Only process as issue if not a PR
@@ -1926,11 +1929,12 @@ ${blockerText}`;
 					li = `<li><i>(${project})</i> - ${issueActionText}(#${number}) - <a href='${html_url}'>${title}</a></li>`;
 				}
 
-				log('[SCRUM-DEBUG] Added issue to lastWeekArray:', li, item);
-				lastWeekArray.push(li);
+				log('[SCRUM-DEBUG] Added issue to lastWeekIssuesArray:', li, item);
+				lastWeekIssuesArray.push(li);
 			}
 		}
-		log('[SCRUM-DEBUG] Final lastWeekArray:', lastWeekArray);
+		log('[SCRUM-DEBUG] Final lastWeekIssuesArray:', lastWeekIssuesArray);
+		log('[SCRUM-DEBUG] Final lastWeekPrsArray:', lastWeekPrsArray);
 		issuesDataProcessed = true;
 	}
 


### PR DESCRIPTION
### 📌 Fixes

Resolves #746 

---

### 📝 Summary of Changes

- **Separated and Ordered Activity Data**: Replaced the mixed `lastWeekArray` list with two separate arrays: `lastWeekIssuesArray` and `lastWeekPrsArray`.
- **Added Grouped Headings**: Introduced bold section subheadings (`Issues:`, `Pull Requests:`, and `Reviewed Pull Requests:`) dynamically within `buildActivityListHtml()` to organize work items.
- **Improved Spacing**: Separated the active sections with vertical spacing using `<br>` tags, ensuring headings and spacers only display if the respective section contains items.

---

### 📸 Screenshots / Demo (if UI-related)

<img width="490" height="867" alt="image" src="https://github.com/user-attachments/assets/dbd67674-a8f4-44ce-bc46-336afbf13a3a" />

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

The changes are scoped purely to `src/scripts/scrumHelper.js` and keep the layout cleaner by sorting and labeling issues first, then PRs, followed by reviewed PRs.

## Summary by Sourcery

Separate weekly activity reporting for issues and pull requests and group them under distinct headings in the generated report output.

Enhancements:
- Split previous combined weekly activity list into dedicated issue and pull request collections for clearer separation of work items.
- Update activity HTML generation to render grouped sections for issues, pull requests, and reviewed pull requests only when data is present.
- Adjust debug logging to reflect the new separate issue and pull request activity arrays.