### PR TITLE
fix: update display mode initialization to use dynamic detection of s…

### DIFF
--- a/src/manifests/firefox.json
+++ b/src/manifests/firefox.json
@@ -9,6 +9,7 @@
   "background": {
     "scripts": [
       "scripts/browser-polyfill.min.js",
+      "scripts/displayMode.js",
       "scripts/background.js"
     ]
   },

--- a/src/popup.html
+++ b/src/popup.html
@@ -672,6 +672,7 @@
 	 <script src="libs/purify.min.js"></script>
 	 <script src="scripts/domSanitizer.js"></script>
 	<script src="scripts/browser-polyfill.min.js"></script>
+	<script src="scripts/displayMode.js"></script>
 	<script src="scripts/jquery-3.2.1.min.js"></script>
 	<script type="text/javascript" src="materialize/js/materialize.min.js"></script>
 	<script src="scripts/emailClientAdapter.js"></script>

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -23,7 +23,8 @@ function applyDisplayMode(mode) {
 }
 
 // Initialize display mode on startup
-browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
+const defaultDisplayMode = browser.sidePanel?.open ? 'sidePanel' : 'popup';
+browser.storage.local.get({ displayMode: defaultDisplayMode }).then((result) => {
 	applyDisplayMode(result.displayMode);
 });
 

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1,6 +1,6 @@
 if (typeof importScripts === 'function') {
 	try {
-		importScripts('browser-polyfill.min.js');
+		importScripts('browser-polyfill.min.js', 'displayMode.js');
 	} catch (e) {
 		console.error('Failed to import polyfill in background:', e);
 	}
@@ -23,7 +23,7 @@ function applyDisplayMode(mode) {
 }
 
 // Initialize display mode on startup
-const defaultDisplayMode = browser.sidePanel?.open ? 'sidePanel' : 'popup';
+const defaultDisplayMode = getDefaultDisplayMode();
 browser.storage.local.get({ displayMode: defaultDisplayMode }).then((result) => {
 	applyDisplayMode(result.displayMode);
 });

--- a/src/scripts/displayMode.js
+++ b/src/scripts/displayMode.js
@@ -1,0 +1,3 @@
+function getDefaultDisplayMode() {
+	return typeof browser.sidePanel?.open === 'function' ? 'sidePanel' : 'popup';
+}

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1124,8 +1124,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		}
 
-		const defaultDisplayMode = browser.sidePanel?.open ? 'sidePanel' : 'popup';
-		browser.storage.local.get({ displayMode: defaultDisplayMode }).then((result) => {
+		browser.storage.local.get({ displayMode: getDefaultDisplayMode() }).then((result) => {
 			applyDisplayModeClass(result.displayMode);
 		});
 
@@ -1133,7 +1132,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		const displayModeNotice = document.getElementById('displayModeNotice');
 		const displayModeNoticeText = document.getElementById('displayModeNoticeText');
 		if (displayModeSelect) {
-			browser.storage.local.get({ displayMode: defaultDisplayMode }).then((result) => {
+			browser.storage.local.get({ displayMode: getDefaultDisplayMode() }).then((result) => {
 				displayModeSelect.value = result.displayMode;
 			});
 			displayModeSelect.addEventListener('change', () => {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1124,7 +1124,8 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		}
 
-		browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
+		const defaultDisplayMode = browser.sidePanel?.open ? 'sidePanel' : 'popup';
+		browser.storage.local.get({ displayMode: defaultDisplayMode }).then((result) => {
 			applyDisplayModeClass(result.displayMode);
 		});
 
@@ -1132,7 +1133,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		const displayModeNotice = document.getElementById('displayModeNotice');
 		const displayModeNoticeText = document.getElementById('displayModeNoticeText');
 		if (displayModeSelect) {
-			browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
+			browser.storage.local.get({ displayMode: defaultDisplayMode }).then((result) => {
 				displayModeSelect.value = result.displayMode;
 			});
 			displayModeSelect.addEventListener('change', () => {


### PR DESCRIPTION
<html><head></head><body><h1>Fix default display mode for browsers without <code inline="">browser.sidePanel</code></h1><h2>Summary</h2><p>On vertical-tab/sidebar-based Chromium browsers (Arc, Edge vertical tabs, Vivaldi), Scrum Helper fails to open on a fresh install because the default display mode is <code inline="">sidePanel</code>, which calls <code inline="">browser.sidePanel.open()</code>—an API that isn't available on those browsers.</p><p>When <code inline="">sidePanel</code> mode is active, <code inline="">applyDisplayMode()</code> clears the popup (<code inline="">setPopup({ popup: '' })</code>). The <code inline="">onClicked</code> handler then hits the null-check in <code inline="">background.js</code> and returns without opening any UI, leaving the user with no visible interface.</p><h2>Fix</h2><p>Feature-detect <code inline="">browser.sidePanel?.open</code> at startup and fall back to <code inline="">popup</code> when the API is unavailable.</p><h3><code inline="">src/scripts/background.js</code></h3><p>Replace the hardcoded <code inline="">sidePanel</code> default with:</p><pre><code class="language-js">const defaultDisplayMode = browser.sidePanel?.open ? 'sidePanel' : 'popup';
browser.storage.local.get({ displayMode: defaultDisplayMode }).then(...);
</code></pre><h3><code inline="">src/scripts/popup.js</code></h3><p>Apply the same logic to the settings dropdown defaults so the <strong>Display Mode</strong> selector reflects the correct default.</p><h2>Behavior</h2>
Browser | browser.sidePanel | Default mode | Outcome
-- | -- | -- | --
Chrome | Available | sidePanel | Unchanged
Arc / Edge vertical tabs / Vivaldi | Unavailable | popup | Fixed
Firefox | N/A (sidebarAction) | popup | Unaffected

<p>Existing saved settings continue to be read from storage and are respected.</p><h2>Validation</h2><ul><li><p>✅ <code inline="">npm run lint</code></p></li><li><p>✅ <code inline="">npm run check</code></p></li><li><p>✅ <code inline="">npm run build</code> (Chrome, Firefox, and Opera)</p></li></ul><p><strong>Closes #748</strong></p><blockquote><p><strong>Note:</strong> Please apply the <code inline="">release:patch</code> label after opening this PR.</p></blockquote></body></html>

## Summary by Sourcery

Dynamically set the extension’s default display mode based on browser support for the side panel API.

New Features:
- Automatically choose side panel or popup as the initial display mode using runtime feature detection of browser.sidePanel.open.

Bug Fixes:
- Prevent the extension from failing to open on browsers that do not support browser.sidePanel by falling back to popup mode on first run.

Enhancements:
- Align the popup settings UI so the Display Mode selector reflects the feature-detected default instead of always assuming sidePanel.