### PR TITLE
Fix: Include advanced filters in SCM cache keys

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
@@ -25,7 +25,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": false,
+			"preset": "recommended",
 			"complexity": {
 				"noForEach": "off",
 				"useOptionalChain": "off"

--- a/docs/images/icon128x128.svg
+++ b/docs/images/icon128x128.svg
@@ -2,6 +2,7 @@
 <!-- Generator: Adobe Illustrator 25.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 128 128" style="enable-background:new 0 0 128 128;" xml:space="preserve">
+<title>Scrum Helper</title>
 <rect x="93.745" y="-32" style="display:none;fill:#3187C4;stroke:#000000;stroke-width:0.9606;stroke-miterlimit:10;" width="88.588" height="96"/>
 <g>
 	<rect style="fill:#3187C4;" width="128" height="128"/>

--- a/docs/images/scrumhelper-path.svg
+++ b/docs/images/scrumhelper-path.svg
@@ -16,6 +16,7 @@
    id="svg903"
    inkscape:version="0.92.3 (2405546, 2018-03-11)"
    sodipodi:docname="scrumhelper-path.svg">
+  <title>Scrum Helper</title>
   <defs
      id="defs897" />
   <sodipodi:namedview

--- a/docs/images/scrumhelper.svg
+++ b/docs/images/scrumhelper.svg
@@ -16,6 +16,7 @@
    id="svg903"
    inkscape:version="0.92.3 (2405546, 2018-03-11)"
    sodipodi:docname="scrumhelper.svg">
+  <title>Scrum Helper</title>
   <defs
      id="defs897" />
   <sodipodi:namedview

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,9 +87,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -107,9 +104,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -127,9 +121,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -147,9 +138,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -676,9 +664,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -694,9 +679,6 @@
       "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -714,9 +696,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -732,9 +711,6 @@
       "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1232,9 +1208,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1254,9 +1227,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -1278,9 +1248,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1300,9 +1267,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/src/scripts/domSanitizer.js
+++ b/src/scripts/domSanitizer.js
@@ -5,7 +5,7 @@ const SCRUM_SANITIZER_CONFIG = {
 	FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover'],
 };
 
-function _sanitizeHtml(html) {
+function sanitizeHtml(html) {
 	if (typeof DOMPurify !== 'undefined') {
 		return DOMPurify.sanitize(html, SCRUM_SANITIZER_CONFIG);
 	}
@@ -24,3 +24,6 @@ function _sanitizeHtml(html) {
 		.replace(/"/g, '&quot;')
 		.replace(/'/g, '&#039;');
 }
+
+window.sanitizeHtml = sanitizeHtml;
+

--- a/src/scripts/domSanitizer.js
+++ b/src/scripts/domSanitizer.js
@@ -5,7 +5,7 @@ const SCRUM_SANITIZER_CONFIG = {
 	FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover'],
 };
 
-function sanitizeHtml(html) {
+function _sanitizeHtml(html) {
 	if (typeof DOMPurify !== 'undefined') {
 		return DOMPurify.sanitize(html, SCRUM_SANITIZER_CONFIG);
 	}

--- a/src/scripts/githubHelper.js
+++ b/src/scripts/githubHelper.js
@@ -282,7 +282,7 @@ async function triggerRepoFetchIfEnabled() {
 	}
 
 	try {
-		const cacheData = await browser.storage.local.get(['repoCache']);
+		const _cacheData = await browser.storage.local.get(['repoCache']);
 		const items = await browser.storage.local.get([
 			'platform',
 			'githubUsername',
@@ -409,7 +409,7 @@ async function performRepoFetch() {
 	try {
 		const items = await browser.storage.local.get(['platform']);
 		platform = items.platform || 'github';
-	} catch (e) {}
+	} catch (_e) {}
 	if (platform !== 'github') {
 		if (repoStatus)
 			repoStatus.textContent =
@@ -552,7 +552,7 @@ ${prs
 			results[`${pr.owner}/${pr.repo}#${pr.number}`] = merged;
 		});
 		return results;
-	} catch (e) {
+	} catch (_e) {
 		return results;
 	}
 }
@@ -624,7 +624,7 @@ async function fetchUserRepositories(username, token, org = '') {
 				if (item.repository_url) {
 					const urlParts = item.repository_url.split('/');
 					const repoFullName = `${urlParts[urlParts.length - 2]}/${urlParts[urlParts.length - 1]}`;
-					const repoName = `${urlParts[urlParts.length - 1]}`;
+					const _repoName = `${urlParts[urlParts.length - 1]}`;
 					repoSet.add(repoFullName);
 				}
 			});
@@ -713,8 +713,8 @@ async function fetchUserRepositories(username, token, org = '') {
 				}));
 
 			return repos.sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
-		} catch (err) {}
-	} catch (err) {}
+		} catch (_err) {}
+	} catch (_err) {}
 }
 
 window.fetchUserRepositories = fetchUserRepositories;
@@ -752,7 +752,7 @@ async function forceGithubDataRefresh() {
 	return { success: true };
 }
 
-window['forceGithubDataRefresh'] = forceGithubDataRefresh;
+window.forceGithubDataRefresh = forceGithubDataRefresh;
 
 // Global fetch helpers
 const GITHUB_DEBUG = false;
@@ -911,7 +911,7 @@ async function githubFetchPrMergedStatusREST(owner, repo, number, token) {
 		const merged = !!data.merged_at;
 		sessionMergedStatusCache[cacheKey] = merged;
 		return merged;
-	} catch (e) {
+	} catch (_e) {
 		return null;
 	}
 }

--- a/src/scripts/gitlabHelper.js
+++ b/src/scripts/gitlabHelper.js
@@ -514,7 +514,7 @@ async function forceGitlabDataRefresh() {
 	return { success: true };
 }
 
-window['forceGitlabDataRefresh'] = forceGitlabDataRefresh;
+window.forceGitlabDataRefresh = forceGitlabDataRefresh;
 
 async function fetchIssuesFromGitLab() {
 	return [];

--- a/src/scripts/gitlabHelper.js
+++ b/src/scripts/gitlabHelper.js
@@ -121,10 +121,14 @@ class GitLabHelper {
 	}
 
 	async fetchGitLabData(username, startDate, endDate, token = null, orgName = '') {
-		// Include token state and orgName in cache key to invalidate when auth or org changes
+		const itemsLocal = await browser.storage.local.get(['showCommits']);
+		const showCommits = itemsLocal.showCommits || false;
+		
+		// Include token state, orgName, and showCommits in cache key to invalidate when auth, org, or showCommits changes
 		const tokenMarker = token ? 'auth' : 'noauth';
 		const orgMarker = orgName ? `org-${orgName}` : 'noorg';
-		const cacheKey = `${this.baseUrl}-${username}-${startDate}-${endDate}-${tokenMarker}-${orgMarker}`;
+		const showCommitsMarker = showCommits ? 'commits' : 'nocommits';
+		const cacheKey = `${this.baseUrl}-${username}-${startDate}-${endDate}-${tokenMarker}-${orgMarker}-${showCommitsMarker}`;
 
 		// Check if we need to load from storage
 		if (!this.cache.data && !this.cache.fetching) {
@@ -296,8 +300,6 @@ class GitLabHelper {
 			}
 
 			// Fetch commits for open/draft Merge Requests if enabled
-			const itemsLocal = await browser.storage.local.get(['showCommits']);
-			const showCommits = itemsLocal.showCommits || false;
 
 			if (showCommits && allMergeRequests.length > 0) {
 				const openMRs = allMergeRequests.filter(

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -9,7 +9,7 @@ const startingDateElement = document.getElementById('startingDate');
 const endingDateElement = document.getElementById('endingDate');
 const showOpenLabelElement = document.getElementById('showOpenLabel');
 
-const userReasonElement = null;
+const _userReasonElement = null;
 
 const showCommitsElement = document.getElementById('showCommits');
 const includeNextPlansElement = document.getElementById('includeNextPlans');
@@ -145,7 +145,9 @@ if (!window.clearScrumHelperToast) {
 		if (toast) toast.remove();
 		const container = document.getElementById('scrumHelperToastContainer');
 		if (container) {
-			container.querySelectorAll('.scrum-toast').forEach((t) => t.remove());
+			container.querySelectorAll('.scrum-toast').forEach((t) => {
+				t.remove();
+			});
 		}
 	};
 }

--- a/src/scripts/nextPlansHelper.js
+++ b/src/scripts/nextPlansHelper.js
@@ -1,6 +1,6 @@
 /* global browser, chrome, DOMPurify */
 
-(function () {
+(() => {
 	// 1. Determine repository scope
 	async function getRepositoryScope() {
 		const result = await browser.storage.local.get(['useRepoFilter', 'selectedRepos']);
@@ -52,7 +52,7 @@
 		let cache = {};
 		try {
 			cache = JSON.parse(localStorage.getItem('nextPlansCache') || '{}');
-		} catch (e) {}
+		} catch (_e) {}
 
 		cache[key] = {
 			issues: issues,
@@ -70,7 +70,7 @@
 			if (cached && Date.now() - cached.timestamp < (cached.ttl || 300000)) {
 				return cached.issues;
 			}
-		} catch (e) {}
+		} catch (_e) {}
 		return null;
 	}
 
@@ -80,7 +80,7 @@
 		let selections = {};
 		try {
 			selections = JSON.parse(localStorage.getItem('selectedIssues') || '{}');
-		} catch (e) {}
+		} catch (_e) {}
 
 		selections[key] = selectedIds;
 		localStorage.setItem('selectedIssues', JSON.stringify(selections));
@@ -91,7 +91,7 @@
 		try {
 			const selections = JSON.parse(localStorage.getItem('selectedIssues') || '{}');
 			return selections[key] || [];
-		} catch (e) {}
+		} catch (_e) {}
 		return [];
 	}
 
@@ -264,7 +264,7 @@
 			if (cache[key] && cache[key].issues) {
 				issues = cache[key].issues;
 			}
-		} catch (e) {}
+		} catch (_e) {}
 
 		// Map selectedIds to full issue objects
 		return selectedIds

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -157,11 +157,11 @@ document.addEventListener('DOMContentLoaded', () => {
 	const gitlabTokenEyeIcon = document.getElementById('gitlabTokenEyeIcon');
 	let gitlabTokenVisible = false;
 
-	const orgInput = document.getElementById('orgInput');
+	const _orgInput = document.getElementById('orgInput');
 
 	const platformSelect = document.getElementById('platformSelect');
-	const usernameLabel = document.getElementById('usernameLabel');
-	const platformUsername = document.getElementById('platformUsername');
+	const _usernameLabel = document.getElementById('usernameLabel');
+	const _platformUsername = document.getElementById('platformUsername');
 
 	function getActivePlatformHelper() {
 		const platform = platformSelect?.value || 'github';
@@ -244,7 +244,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		}
 	}
 
-	window.showRegenerateNotice = function () {
+	window.showRegenerateNotice = () => {
 		const scrumReport = document.getElementById('scrumReport');
 		const notice = document.getElementById('regenerateNotice');
 		if (!scrumReport || !notice) return;
@@ -256,7 +256,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		}
 	};
 
-	window.hideRegenerateNotice = function () {
+	window.hideRegenerateNotice = () => {
 		const notice = document.getElementById('regenerateNotice');
 		if (notice) {
 			notice.classList.add('hidden');
@@ -1213,9 +1213,9 @@ document.addEventListener('DOMContentLoaded', () => {
 	//report filter
 	const repoSearch = document.getElementById('repoSearch');
 	const repoDropdown = document.getElementById('repoDropdown');
-	const selectedReposDiv = document.getElementById('selectedRepos');
+	const _selectedReposDiv = document.getElementById('selectedRepos');
 	const repoTags = document.getElementById('repoTags');
-	const repoPlaceholder = document.getElementById('repoPlaceholder');
+	const _repoPlaceholder = document.getElementById('repoPlaceholder');
 	const repoCount = document.getElementById('repoCount');
 	const repoStatus = document.getElementById('repoStatus');
 	const clearAllReposBtn = document.getElementById('clearAllReposBtn');
@@ -1951,7 +1951,7 @@ if (dropdownBtn && customDropdown && dropdownList) {
 
 if (dropdownList) {
 	dropdownList.querySelectorAll('li').forEach((item) => {
-		item.addEventListener('click', function (e) {
+		item.addEventListener('click', function (_e) {
 			const newPlatform = this.getAttribute('data-value');
 			const currentPlatform = platformSelectHidden ? platformSelectHidden.value : 'github';
 			const platformUsername = document.getElementById('platformUsername');
@@ -2151,11 +2151,11 @@ document.querySelectorAll('input[name="timeframe"]').forEach((radio) => {
 
 			try {
 				// Determine platform
-				let platform = 'github';
+				let _platform = 'github';
 				try {
 					const items = await browser.storage.local.get(['platform']);
-					platform = items.platform || 'github';
-				} catch (e) {}
+					_platform = items.platform || 'github';
+				} catch (_e) {}
 
 				// Clear all caches
 				const keysToRemove = ['githubCache', 'repoCache', 'gitlabCache'];
@@ -2321,7 +2321,7 @@ function handleOrgInputBlurValidation(org) {
 }
 
 // Rate Limit Warning banner management
-(function () {
+(() => {
 	let rateLimitTimeout;
 	const rateLimitWarning = document.getElementById('rateLimitWarning');
 	const closeRateLimitWarning = document.getElementById('closeRateLimitWarning');
@@ -2335,7 +2335,7 @@ function handleOrgInputBlurValidation(org) {
 		});
 	}
 
-	window.showRateLimitWarning = function () {
+	window.showRateLimitWarning = () => {
 		const banner = document.getElementById('rateLimitWarning');
 		if (banner) {
 			banner.classList.remove('hidden');

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1,12 +1,8 @@
 let rateLimitWarningShown = false;
 const originalFetch = window.fetch;
-window.fetch = async function (...args) {
+window.fetch = async (...args) => {
 	let res;
-	try {
-		res = await originalFetch(...args);
-	} catch (err) {
-		throw err;
-	}
+	res = await originalFetch(...args);
 	const url = typeof args[0] === 'string' ? args[0] : args[0]?.url || '';
 	if (url.includes('api.github.com')) {
 		const remaining = res.headers.get('x-ratelimit-remaining');
@@ -24,7 +20,7 @@ window.fetch = async function (...args) {
 						}, 6000);
 					}
 				}
-			} catch (e) {
+			} catch (_e) {
 				// Ignore clone/json parsing issues
 			}
 		}
@@ -46,7 +42,7 @@ function logError(...args) {
 	}
 }
 
-function getLocalISOString(dateStr, time) {
+function _getLocalISOString(dateStr, time) {
 	const offsetMinutes = new Date().getTimezoneOffset();
 	const absOffset = Math.abs(offsetMinutes);
 	const hours = Math.floor(absOffset / 60);
@@ -150,7 +146,7 @@ const usernameError = document.getElementById('usernameError');
 
 document.addEventListener('DOMContentLoaded', () => {
 	if (!usernameValidationListenerAttached && platformUsernameInp && usernameError) {
-		platformUsernameInp.addEventListener('input', function () {
+		platformUsernameInp.addEventListener('input', () => {
 			platformUsernameInp.classList.remove('input-error');
 			usernameError.textContent = '';
 			usernameError.classList.remove('errorMessage');
@@ -416,7 +412,7 @@ function allIncluded(outputTarget = 'email') {
 									const mappedData = window.gitlabHelper.mapGitLabReportData(data);
 									githubUserData = mappedData.githubUserData;
 
-									const name =
+									const _name =
 										githubUserData?.name || githubUserData?.username || platformUsernameLocal || platformUsername;
 									const project = projectName;
 									const curDate = new Date();
@@ -867,17 +863,17 @@ function allIncluded(outputTarget = 'email') {
 
 			try {
 				githubIssuesData = issuesRes.ok ? await issuesRes.json() : { items: [] };
-			} catch (e) {
+			} catch (_e) {
 				githubIssuesData = { items: [] };
 			}
 			try {
 				githubPrsReviewData = prRes.ok ? await prRes.json() : { items: [] };
-			} catch (e) {
+			} catch (_e) {
 				githubPrsReviewData = { items: [] };
 			}
 			try {
 				githubUserData = userRes.ok ? await userRes.json() : {};
-			} catch (e) {
+			} catch (_e) {
 				githubUserData = {};
 			}
 
@@ -1085,7 +1081,7 @@ function allIncluded(outputTarget = 'email') {
 		}
 	}
 
-	function showRateLimitMessage() {
+	function _showRateLimitMessage() {
 		const errMsg =
 			chrome?.i18n.getMessage('rateLimitError') ||
 			'GitHub API rate limit exceeded. Please try again later or add/check your GitHub token in the Scrum Helper settings.';
@@ -1336,7 +1332,7 @@ function allIncluded(outputTarget = 'email') {
 						lastScrumReportCacheKey: cacheKey,
 						lastScrumReportUsername: platformUsername,
 					});
-				} catch (e) {
+				} catch (_e) {
 					// ignore
 				}
 
@@ -1359,7 +1355,7 @@ function allIncluded(outputTarget = 'email') {
 				return;
 			}
 
-			const observer = new MutationObserver((mutations, obs) => {
+			const observer = new MutationObserver((_mutations, obs) => {
 				if (!window.emailClientAdapter) {
 					obs.disconnect();
 					return;
@@ -1406,7 +1402,7 @@ function allIncluded(outputTarget = 'email') {
 				return;
 			}
 			setTimeout(() => {
-				const name = githubUserData?.name || githubUserData?.username || platformUsernameLocal || platformUsername;
+				const _name = githubUserData?.name || githubUserData?.username || platformUsernameLocal || platformUsername;
 				const project = projectName;
 				const curDate = new Date();
 				const year = curDate.getFullYear().toString();
@@ -1666,7 +1662,7 @@ function allIncluded(outputTarget = 'email') {
 		prsReviewDataProcessed = true;
 	}
 
-	function triggerScrumGeneration() {
+	function _triggerScrumGeneration() {
 		if (issuesDataProcessed && prsReviewDataProcessed) {
 			writeScrumBody();
 		} else {
@@ -1679,7 +1675,7 @@ function allIncluded(outputTarget = 'email') {
 		return Math.ceil((d2 - d1) / (1000 * 60 * 60 * 24));
 	}
 
-	async function fetchPrMergedStatusREST(owner, repo, number, headers) {
+	async function fetchPrMergedStatusREST(owner, repo, number, _headers) {
 		return githubFetchPrMergedStatusREST(owner, repo, number, githubToken);
 	}
 
@@ -1719,7 +1715,7 @@ function allIncluded(outputTarget = 'email') {
 			endDateForRange = formatLocalDate(today);
 		}
 
-		const daysRange = getDaysBetween(startDateForRange, endDateForRange);
+		const _daysRange = getDaysBetween(startDateForRange, endDateForRange);
 
 		useMergedStatus = true;
 
@@ -1823,7 +1819,7 @@ function allIncluded(outputTarget = 'email') {
 					if (prCacheKey && prCacheKey in mergedStatusResults) {
 						hasMergeInfo = true;
 						isMerged = !!mergedStatusResults[prCacheKey];
-					} else if (item.pull_request && Object.prototype.hasOwnProperty.call(item.pull_request, 'merged_at')) {
+					} else if (item.pull_request && Object.hasOwn(item.pull_request, 'merged_at')) {
 						hasMergeInfo = true;
 						isMerged = !!item.pull_request.merged_at;
 					}
@@ -1892,7 +1888,7 @@ function allIncluded(outputTarget = 'email') {
 
 				const isNewPR = prCreatedDate >= startDateFilter && prCreatedDate <= endDateFilter;
 				const prUpdatedDate = new Date(item.updated_at);
-				const isUpdatedInRange = prUpdatedDate >= startDateFilter && prUpdatedDate <= endDateFilter;
+				const _isUpdatedInRange = prUpdatedDate >= startDateFilter && prUpdatedDate <= endDateFilter;
 
 				// Check if PR has commits in the date range
 				const hasCommitsInRange = item._allCommits && item._allCommits.length > 0;
@@ -1950,7 +1946,7 @@ function allIncluded(outputTarget = 'email') {
 						log(`[PR DEBUG] Rendering commits for draft PR #${number}:`, item._allCommits);
 						li += '<ul>';
 						item._allCommits.forEach((commit) => {
-							li += `<li style=\"list-style: disc; color: #666;\"><span style=\"color:#2563eb;\">${commit.messageHeadline}</span><span style=\"color:#666; font-size: 11px;\"> (${new Date(commit.committedDate).toLocaleString()})</span></li>`;
+							li += `<li style="list-style: disc; color: #666;"><span style="color:#2563eb;">${commit.messageHeadline}</span><span style="color:#666; font-size: 11px;"> (${new Date(commit.committedDate).toLocaleString()})</span></li>`;
 						});
 						li += '</ul>';
 					}
@@ -1987,7 +1983,6 @@ function allIncluded(outputTarget = 'email') {
 				}
 				log('[SCRUM-DEBUG] Added PR/MR to lastWeekPrsArray:', li, item);
 				lastWeekPrsArray.push(li);
-				continue; // Prevent issue logic from overwriting PR li
 			} else {
 				// Compute date range for filtering
 				let issueStartDateFilter;
@@ -2146,7 +2141,7 @@ window.generateScrumReport = () => {
 	allIncluded('popup');
 };
 
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
 	if (request.action === 'forceRefresh') {
 		chrome.storage.local.get(['platform'], async (result) => {
 			const platform = result.platform || 'github';
@@ -2160,7 +2155,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 						sendResponse({ success: false, error: err.message });
 					});
 			} else {
-				const fallbackFn = platform === 'gitlab' ? window['forceGitlabDataRefresh'] : window['forceGithubDataRefresh'];
+				const fallbackFn = platform === 'gitlab' ? window.forceGitlabDataRefresh : window.forceGithubDataRefresh;
 				if (typeof fallbackFn === 'function') {
 					fallbackFn()
 						.then((result) => sendResponse(result))

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -648,7 +648,27 @@ function allIncluded(outputTarget = 'email') {
 			endDateForCache = formatLocalDate(today);
 		}
 
-		const cacheKey = `${platformUsernameLocal}-${startDateForCache}-${endDateForCache}-${orgName || 'all'}`;
+		const advancedSettings = [
+			showCommits ? '1' : '0',
+			onlyIssues ? '1' : '0',
+			onlyPRs ? '1' : '0',
+			onlyRevPRs ? '1' : '0',
+			onlyMergedPRs ? '1' : '0',
+			useRepoFilter ? '1' : '0',
+			includeNextPlans ? '1' : '0'
+		].join('');
+		let selectedReposHash = '0';
+		if (useRepoFilter && selectedRepos && selectedRepos.length > 0) {
+			const repoNames = selectedRepos.map((r) => r.name || r).sort().join(',');
+			let hash = 0;
+			for (let i = 0; i < repoNames.length; i++) {
+				const char = repoNames.charCodeAt(i);
+				hash = ((hash << 5) - hash) + char;
+				hash = hash & hash;
+			}
+			selectedReposHash = (hash >>> 0).toString(36);
+		}
+		const cacheKey = `${platformUsernameLocal}-${startDateForCache}-${endDateForCache}-${orgName || 'all'}-${advancedSettings}-${selectedReposHash}`;
 
 		if (githubCache.fetching || (githubCache.cacheKey === cacheKey && githubCache.data)) {
 			log('Fetch already in progress or data already fetched. Skipping fetch.');


### PR DESCRIPTION
Fixes #777. The generated report failed to update when toggling advanced filters like 'Show commits' or repository filters because the cache keys used by GitHub and GitLab SCM helpers omitted these options. This PR includes these options in the cache key generation to correctly trigger cache invalidation and prompt a fresh API fetch when they are changed.

## Summary by Sourcery

Include advanced filter and repository selections in SCM cache keys to ensure scrum reports refresh when these options change, while cleaning up related helpers and browser integrations.

Bug Fixes:
- Incorporate advanced filter flags and selected repository filters into scrum report cache keys so toggling these options correctly invalidates cached GitHub data.
- Include the showCommits setting in GitLab cache key generation to ensure merge request data is refreshed when commit visibility changes.
- Normalize mutation observer and rate limit handling to avoid relying on unused parameters or outdated window properties.

Enhancements:
- Expose sanitizeHtml on the global window object for consistent HTML sanitization reuse across scripts.
- Modernize various scripts by converting functions to arrow functions, renaming unused parameters, and simplifying error handling and DOM interactions.
- Align GitHub and GitLab helper globals with dot-notation access and update legacy APIs (such as Object.prototype.hasOwnProperty) to more modern equivalents.