### PR TITLE
Fix: Change default display mode to popup (#748)

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -23,7 +23,7 @@ function applyDisplayMode(mode) {
 }
 
 // Initialize display mode on startup
-browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
+browser.storage.local.get({ displayMode: 'popup' }).then((result) => {
 	applyDisplayMode(result.displayMode);
 });
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1124,7 +1124,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		}
 
-		browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
+		browser.storage.local.get({ displayMode: 'popup' }).then((result) => {
 			applyDisplayModeClass(result.displayMode);
 		});
 
@@ -1132,7 +1132,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		const displayModeNotice = document.getElementById('displayModeNotice');
 		const displayModeNoticeText = document.getElementById('displayModeNoticeText');
 		if (displayModeSelect) {
-			browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
+			browser.storage.local.get({ displayMode: 'popup' }).then((result) => {
 				displayModeSelect.value = result.displayMode;
 			});
 			displayModeSelect.addEventListener('change', () => {


### PR DESCRIPTION
Closes #748.

This PR changes the default display mode fallback from `'sidePanel'` to `'popup'`.
This ensures that the extension works out-of-the-box on browsers without native side panel support (like Arc), falling back to a standard popup window. Users on supported browsers can still switch to 'Side Panel' mode manually in the settings.

## Summary by Sourcery

Change the browser extension’s default display mode fallback to use a popup instead of the side panel so it works by default on browsers without native side panel support.

Bug Fixes:
- Ensure the extension initializes correctly on browsers that do not support the side panel by defaulting to popup mode.

Enhancements:
- Align popup UI and background initialization with the new popup default display mode.