### PR TITLE
Fix multiple bugs across extension and CLI

### DIFF
--- a/src/scripts/githubHelper.js
+++ b/src/scripts/githubHelper.js
@@ -496,8 +496,14 @@ async function performRepoFetch() {
 // Validate organization only when user is done typing (on blur)
 function validateOrgOnBlur(org) {
 	console.log('[Org Check] Checking organization on blur:', org);
-	fetch(`https://api.github.com/orgs/${org}`)
-		.then((res) => {
+
+	browser.storage.local.get(['githubToken']).then((items) => {
+		const headers = items.githubToken
+			? { Authorization: `token ${items.githubToken}` }
+			: {};
+
+		fetch(`https://api.github.com/orgs/${org}`, { headers })
+			.then((res) => {
 			console.log('[Org Check] Response status for', org, ':', res.status);
 			if (res.status === 404) {
 				console.log('[Org Check] Organization not found on GitHub:', org);

--- a/src/scripts/githubHelper.js
+++ b/src/scripts/githubHelper.js
@@ -496,31 +496,38 @@ async function performRepoFetch() {
 // Validate organization only when user is done typing (on blur)
 function validateOrgOnBlur(org) {
 	console.log('[Org Check] Checking organization on blur:', org);
-	fetch(`https://api.github.com/orgs/${org}`)
-		.then((res) => {
-			console.log('[Org Check] Response status for', org, ':', res.status);
-			if (res.status === 404) {
-				console.log('[Org Check] Organization not found on GitHub:', org);
-				if (typeof showPopupMessage === 'function') {
-					showPopupMessage(browser.i18n.getMessage('orgNotFoundMessage'));
-				} else if (window.showPopupMessage) {
-					window.showPopupMessage(browser.i18n.getMessage('orgNotFoundMessage'));
+
+	browser.storage.local.get(['githubToken']).then((items) => {
+		const headers = items.githubToken
+			? { Authorization: `token ${items.githubToken}` }
+			: {};
+
+		fetch(`https://api.github.com/orgs/${org}`, { headers })
+			.then((res) => {
+				console.log('[Org Check] Response status for', org, ':', res.status);
+				if (res.status === 404) {
+					console.log('[Org Check] Organization not found on GitHub:', org);
+					if (typeof showPopupMessage === 'function') {
+						showPopupMessage(browser.i18n.getMessage('orgNotFoundMessage'));
+					} else if (window.showPopupMessage) {
+						window.showPopupMessage(browser.i18n.getMessage('orgNotFoundMessage'));
+					}
+					return;
 				}
-				return;
-			}
-			window.clearScrumHelperToast?.();
-			console.log('[Org Check] Organisation exists on GitHub:', org);
-			browser.storage.local.remove(['githubCache', 'repoCache']);
-			triggerRepoFetchIfEnabled();
-		})
-		.catch((err) => {
-			console.log('[Org Check] Error validating organisation:', org, err);
-			if (typeof showPopupMessage === 'function') {
-				showPopupMessage(browser.i18n.getMessage('orgValidationErrorMessage'), { variant: 'error' });
-			} else if (window.showPopupMessage) {
-				window.showPopupMessage(browser.i18n.getMessage('orgValidationErrorMessage'), { variant: 'error' });
-			}
-		});
+				window.clearScrumHelperToast?.();
+				console.log('[Org Check] Organisation exists on GitHub:', org);
+				browser.storage.local.remove(['githubCache', 'repoCache']);
+				triggerRepoFetchIfEnabled();
+			})
+			.catch((err) => {
+				console.log('[Org Check] Error validating organisation:', org, err);
+				if (typeof showPopupMessage === 'function') {
+					showPopupMessage(browser.i18n.getMessage('orgValidationErrorMessage'), { variant: 'error' });
+				} else if (window.showPopupMessage) {
+					window.showPopupMessage(browser.i18n.getMessage('orgValidationErrorMessage'), { variant: 'error' });
+				}
+			});
+	});
 }
 
 async function fetchPrsMergedStatusBatch(prs, headers) {
@@ -984,7 +991,11 @@ async function fetchIssuesFromGitHub(scope) {
 			};
 		})
 		.filter((issue) => {
-			if (Number.isNaN(issue.number) || !issue.html_url || !issue.html_url.startsWith('https://github.com/')) {
+			if (
+				Number.isNaN(issue.number) ||
+				!issue.html_url ||
+				!issue.html_url.startsWith('https://github.com/')
+			) {
 				return false;
 			}
 			if (repoSet && !repoSet.has(issue.repository)) {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -535,10 +535,10 @@ function handleIncludeNextPlansChange() {
 }
 
 if (platformUsernameElement) {
-	platformUsernameElement.addEventListener('keyup', handlePlatformUsernameChange);
+	platformUsernameElement.addEventListener('change', handlePlatformUsernameChange);
 }
 if (githubTokenElement) {
-	githubTokenElement.addEventListener('keyup', handleGithubTokenChange);
+	githubTokenElement.addEventListener('change', handleGithubTokenChange);
 	githubTokenElement.addEventListener('change', () => {
 		githubTokenElement.value = githubTokenElement.value.trim();
 	});
@@ -547,7 +547,7 @@ if (githubTokenElement) {
 	});
 }
 if (gitlabTokenElement) {
-	gitlabTokenElement.addEventListener('keyup', handleGitlabTokenChange);
+	gitlabTokenElement.addEventListener('change', handleGitlabTokenChange);
 	gitlabTokenElement.addEventListener('change', () => {
 		gitlabTokenElement.value = gitlabTokenElement.value.trim();
 	});
@@ -565,10 +565,10 @@ if (codebergApiBaseUrlElement) {
 	codebergApiBaseUrlElement.addEventListener('keyup', handleCodebergApiBaseUrlChange);
 }
 if (cacheInputElement) {
-	cacheInputElement.addEventListener('keyup', handleCacheInputChange);
+	cacheInputElement.addEventListener('change', handleCacheInputChange);
 }
 if (projectNameElement) {
-	projectNameElement.addEventListener('keyup', handleProjectNameChange);
+	projectNameElement.addEventListener('change', handleProjectNameChange);
 }
 if (startingDateElement) {
 	startingDateElement.addEventListener('blur', handleStartingDateChange);

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -477,10 +477,10 @@ function handleIncludeNextPlansChange() {
 }
 
 if (platformUsernameElement) {
-	platformUsernameElement.addEventListener('keyup', handlePlatformUsernameChange);
+	platformUsernameElement.addEventListener('change', handlePlatformUsernameChange);
 }
 if (githubTokenElement) {
-	githubTokenElement.addEventListener('keyup', handleGithubTokenChange);
+	githubTokenElement.addEventListener('change', handleGithubTokenChange);
 	githubTokenElement.addEventListener('change', () => {
 		githubTokenElement.value = githubTokenElement.value.trim();
 	});
@@ -489,7 +489,7 @@ if (githubTokenElement) {
 	});
 }
 if (gitlabTokenElement) {
-	gitlabTokenElement.addEventListener('keyup', handleGitlabTokenChange);
+	gitlabTokenElement.addEventListener('change', handleGitlabTokenChange);
 	gitlabTokenElement.addEventListener('change', () => {
 		gitlabTokenElement.value = gitlabTokenElement.value.trim();
 	});
@@ -498,10 +498,10 @@ if (gitlabTokenElement) {
 	});
 }
 if (cacheInputElement) {
-	cacheInputElement.addEventListener('keyup', handleCacheInputChange);
+	cacheInputElement.addEventListener('change', handleCacheInputChange);
 }
 if (projectNameElement) {
-	projectNameElement.addEventListener('keyup', handleProjectNameChange);
+	projectNameElement.addEventListener('change', handleProjectNameChange);
 }
 if (startingDateElement) {
 	startingDateElement.addEventListener('change', handleStartingDateChange);

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -294,9 +294,17 @@ function allIncluded(outputTarget = 'email') {
 						platformUsernameLocal = usernameFromDOM;
 					}
 
-					items.projectName = projectFromDOM || items.projectName;
-					items.githubToken = tokenFromDOM || items.githubToken;
-					items.gitlabToken = gitlabTokenFromDOM || items.gitlabToken;
+					if (projectFromDOM !== undefined) {
+						items.projectName = projectFromDOM;
+					}
+
+					if (tokenFromDOM !== undefined) {
+						items.githubToken = tokenFromDOM;
+					}
+
+					if (gitlabTokenFromDOM !== undefined) {
+						items.gitlabToken = gitlabTokenFromDOM;
+					}
 					chrome.storage.local.set({
 						projectName: items.projectName,
 						githubToken: items.githubToken,
@@ -1330,8 +1338,10 @@ function allIncluded(outputTarget = 'email') {
 					const cacheKey =
 						platform === 'gitlab' ? (window.gitlabHelper?.cache?.cacheKey ?? null) : (githubCache?.cacheKey ?? null);
 
+					const reportCacheKey = `${platform}LastScrumReportHtml`;
+
 					chrome.storage.local.set({
-						lastScrumReportHtml: content,
+						[reportCacheKey]: content,
 						lastScrumReportPlatform: platform,
 						lastScrumReportCacheKey: cacheKey,
 						lastScrumReportUsername: platformUsername,

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -123,7 +123,7 @@ function logRedaction(items) {
 		return items;
 	}
 	const spreadItems = { ...items };
-	const sensitiveKeys = ['githubToken', 'gitlabToken', 'codebergToken'];
+	const sensitiveKeys = ['githubToken', 'gitlabToken'];
 	sensitiveKeys.forEach((key) => {
 		if (key in spreadItems) {
 			spreadItems[key] = '[REDACTED]';
@@ -142,9 +142,6 @@ let platformUsername = '';
 let gitlabToken = '';
 window.gitlabBaseUrl = '';
 window.gitlabHelper = null;
-let codebergToken = '';
-window.codebergApiBaseUrl = '';
-window.codebergHelper = null;
 let usernameValidationListenerAttached = false;
 
 const scrumReportEl = document.getElementById('scrumReport');
@@ -251,12 +248,9 @@ function allIncluded(outputTarget = 'email') {
 				'platform',
 				'githubUsername',
 				'gitlabUsername',
-				'codebergUsername',
 				'githubToken',
 				'gitlabToken',
-				'codebergToken',
 				'gitlabBaseUrl',
-				'codebergApiBaseUrl',
 				'projectName',
 				'startingDate',
 				'endingDate',
@@ -292,7 +286,6 @@ function allIncluded(outputTarget = 'email') {
 					const projectFromDOM = document.getElementById('projectName')?.value;
 					const tokenFromDOM = document.getElementById('githubToken')?.value;
 					const gitlabTokenFromDOM = document.getElementById('gitlabToken')?.value;
-					const codebergTokenFromDOM = document.getElementById('codebergToken')?.value;
 
 					// Save to platform-specific storage
 					if (usernameFromDOM) {
@@ -301,15 +294,21 @@ function allIncluded(outputTarget = 'email') {
 						platformUsernameLocal = usernameFromDOM;
 					}
 
-					items.projectName = projectFromDOM || items.projectName;
-					items.githubToken = tokenFromDOM || items.githubToken;
-					items.gitlabToken = gitlabTokenFromDOM || items.gitlabToken;
-					items.codebergToken = codebergTokenFromDOM || items.codebergToken;
+					if (projectFromDOM !== undefined) {
+						items.projectName = projectFromDOM;
+					}
+
+					if (tokenFromDOM !== undefined) {
+						items.githubToken = tokenFromDOM;
+					}
+
+					if (gitlabTokenFromDOM !== undefined) {
+						items.gitlabToken = gitlabTokenFromDOM;
+					}
 					chrome.storage.local.set({
 						projectName: items.projectName,
 						githubToken: items.githubToken,
 						gitlabToken: items.gitlabToken,
-						codebergToken: items.codebergToken,
 					});
 				}
 				projectName = items.projectName;
@@ -321,11 +320,6 @@ function allIncluded(outputTarget = 'email') {
 				window.gitlabBaseUrl = items.gitlabBaseUrl || '';
 				if (platform === 'gitlab' && window.GitLabHelper) {
 					window.gitlabHelper = new window.GitLabHelper(window.gitlabBaseUrl);
-				}
-				codebergToken = items.codebergToken || '';
-				window.codebergApiBaseUrl = items.codebergApiBaseUrl || 'https://codeberg.org/api/v1';
-				if (platform === 'codeberg' && window.CodebergHelper) {
-					window.codebergHelper = new window.CodebergHelper(window.codebergApiBaseUrl);
 				}
 				yesterdayContribution = items.yesterdayContribution;
 				weeklyContribution = items.weeklyContribution;
@@ -501,99 +495,6 @@ function allIncluded(outputTarget = 'email') {
 						}
 						scrumGenerationInProgress = false;
 					}
-				} else if (platform === 'codeberg') {
-					if (!window.codebergHelper) window.codebergHelper = new window.CodebergHelper(window.codebergApiBaseUrl);
-					if (platformUsernameLocal) {
-						const generateBtn = document.getElementById('generateReport');
-						if (generateBtn && outputTarget === 'popup') {
-							generateBtn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Generating...';
-							generateBtn.disabled = true;
-						}
-
-						if (outputTarget === 'email') {
-							(async () => {
-								try {
-									const data = await window.codebergHelper.fetchCodebergData(
-										platformUsernameLocal,
-										startingDate,
-										endingDate,
-										items.codebergToken,
-										showCommits,
-									);
-
-									const mappedData = window.codebergHelper.mapCodebergReportData(data);
-									githubUserData = mappedData.githubUserData;
-
-									const name =
-										githubUserData?.name || githubUserData?.username || platformUsernameLocal || platformUsername;
-									const project = projectName;
-									const curDate = new Date();
-									const year = curDate.getFullYear().toString();
-									let date = curDate.getDate();
-									let month = curDate.getMonth() + 1;
-									if (month < 10) month = '0' + month;
-									if (date < 10) date = '0' + date;
-									const dateCode = year.toString() + month.toString() + date.toString();
-									const subject = `[Scrum]${project ? ' - ' + project : ''} - ${dateCode}`;
-									subjectForEmail = subject;
-
-									await processGithubData(mappedData, true, subjectForEmail);
-									scrumGenerationInProgress = false;
-								} catch (err) {
-									console.error('Codeberg fetch failed:', err);
-									if (outputTarget === 'popup') {
-										if (generateBtn) {
-											generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
-											generateBtn.disabled = false;
-										}
-										const ErrMessage = `${err.message || 'Error fetching Codeberg data.'}`;
-										if (typeof ErrMessage === 'string' && ErrMessage.toLowerCase().includes('not found')) {
-											handleUsernameValidationError(ErrMessage);
-										} else {
-											showReportMessage(ErrMessage);
-										}
-									}
-									scrumGenerationInProgress = false;
-								}
-							})();
-						} else {
-							window.codebergHelper
-								.fetchCodebergData(platformUsernameLocal, startingDate, endingDate, items.codebergToken, showCommits)
-								.then((data) => {
-									const mappedData = window.codebergHelper.mapCodebergReportData(data);
-									processGithubData(mappedData);
-									scrumGenerationInProgress = false;
-								})
-								.catch((err) => {
-									console.error('Codeberg fetch failed:', err);
-									if (outputTarget === 'popup') {
-										if (generateBtn) {
-											generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
-											generateBtn.disabled = false;
-										}
-										const ErrMessage = `${err.message || 'Error fetching Codeberg data.'}`;
-										if (typeof ErrMessage === 'string' && ErrMessage.toLowerCase().includes('not found')) {
-											handleUsernameValidationError(ErrMessage);
-										} else {
-											showReportMessage(ErrMessage);
-										}
-									}
-									scrumGenerationInProgress = false;
-								});
-						}
-					} else {
-						if (outputTarget === 'popup') {
-							const generateBtn = document.getElementById('generateReport');
-							const ErrMessage =
-								chrome.i18n.getMessage('usernameRequiredError') || 'Please enter your username to generate a report.';
-							handleUsernameValidationError(ErrMessage);
-							if (generateBtn) {
-								generateBtn.innerHTML = '<i class="fa fa-refresh"></i> Generate';
-								generateBtn.disabled = false;
-							}
-						}
-						scrumGenerationInProgress = false;
-					}
 				} else {
 					// Unknown platform
 					if (outputTarget === 'popup') {
@@ -607,7 +508,7 @@ function allIncluded(outputTarget = 'email') {
 	getChromeData();
 
 	function handleYesterdayContributionChange() {
-		endingDate = getYesterday();
+		endingDate = getToday();
 		startingDate = getYesterday();
 	}
 
@@ -728,13 +629,12 @@ function allIncluded(outputTarget = 'email') {
 	}
 
 	async function fetchGithubData() {
-		// Always load latest settings from storage
-		const settings = await new Promise((resolve) => {
-			chrome.storage.local.get(['useRepoFilter', 'selectedRepos', 'showCommits'], resolve);
+		// Always load latest repo filter settings from storage
+		const filterSettings = await new Promise((resolve) => {
+			chrome.storage.local.get(['useRepoFilter', 'selectedRepos'], resolve);
 		});
-		useRepoFilter = settings.useRepoFilter || false;
-		selectedRepos = Array.isArray(settings.selectedRepos) ? settings.selectedRepos : [];
-		showCommits = settings.showCommits || false;
+		useRepoFilter = filterSettings.useRepoFilter || false;
+		selectedRepos = Array.isArray(filterSettings.selectedRepos) ? filterSettings.selectedRepos : [];
 
 		// Get the correct date range for cache key
 		let startDateForCache;
@@ -743,7 +643,7 @@ function allIncluded(outputTarget = 'email') {
 			const today = new Date();
 			const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
 			startDateForCache = formatLocalDate(yesterday);
-			endDateForCache = formatLocalDate(yesterday);
+			endDateForCache = formatLocalDate(today); // Use yesterday for start and today for end
 		} else if (weeklyContribution) {
 			const today = new Date();
 			const weekAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
@@ -760,15 +660,7 @@ function allIncluded(outputTarget = 'email') {
 			endDateForCache = formatLocalDate(today);
 		}
 
-		const repoMarker =
-			useRepoFilter && selectedRepos.length > 0
-				? selectedRepos
-						.map((r) => (r && typeof r === 'object' ? r.fullName || '' : r || ''))
-						.sort()
-						.join(',')
-				: 'norepos';
-		const commitMarker = showCommits ? 'commits' : 'nocommits';
-		const cacheKey = `${platformUsernameLocal}-${startDateForCache}-${endDateForCache}-${orgName || 'all'}-${commitMarker}-${repoMarker}`;
+		const cacheKey = `${platformUsernameLocal}-${startDateForCache}-${endDateForCache}-${orgName || 'all'}`;
 
 		if (githubCache.fetching || (githubCache.cacheKey === cacheKey && githubCache.data)) {
 			log('Fetch already in progress or data already fetched. Skipping fetch.');
@@ -1006,15 +898,14 @@ function allIncluded(outputTarget = 'email') {
 					openPRs.map((pr) => pr.number),
 				);
 				// Fetch commits for open PRs (batch) if showCommits is enabled
-				const activeToken = platform === 'codeberg' ? codebergToken : githubToken;
-				if (openPRs.length && showCommits && platform !== 'codeberg') {
+				if (openPRs.length && githubToken && showCommits) {
 					let startDateForCommits;
 					let endDateForCommits;
 					if (yesterdayContribution) {
 						const today = new Date();
 						const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
 						startDateForCommits = formatLocalDate(yesterday);
-						endDateForCommits = formatLocalDate(yesterday);
+						endDateForCommits = formatLocalDate(today); // Use yesterday for start and today for end
 					} else if (weeklyContribution) {
 						const today = new Date();
 						const weekAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
@@ -1031,7 +922,7 @@ function allIncluded(outputTarget = 'email') {
 						endDateForCommits = formatLocalDate(today);
 					}
 
-					const commitMap = await fetchCommitsForOpenPRs(openPRs, activeToken, startDateForCommits, endDateForCommits);
+					const commitMap = await fetchCommitsForOpenPRs(openPRs, githubToken, startDateForCommits, endDateForCommits);
 					log('Commit map returned from fetchCommitsForOpenPRs:', commitMap);
 					// Attach commits to PR objects
 					openPRs.forEach((pr) => {
@@ -1096,11 +987,8 @@ function allIncluded(outputTarget = 'email') {
 		}
 	}
 
-	async function fetchCommitsForOpenPRs(prs, token, startDate, endDate) {
-		if (platform === 'github') {
-			return githubFetchCommits(prs, token, startDate, endDate);
-		}
-		return {};
+	async function fetchCommitsForOpenPRs(prs, githubToken, startDate, endDate) {
+		return githubFetchCommits(prs, githubToken, startDate, endDate);
 	}
 
 	async function fetchReposIfNeeded() {
@@ -1255,12 +1143,12 @@ function allIncluded(outputTarget = 'email') {
 		log('[SCRUM-DEBUG] Processing issues for main activity:', githubIssuesData?.items);
 		if (platform === 'github') {
 			await writeGithubIssuesPrs(githubIssuesData?.items || []);
-		} else if (platform === 'gitlab' || platform === 'codeberg') {
+		} else if (platform === 'gitlab') {
 			await writeGithubIssuesPrs(githubIssuesData?.items || []);
 			await writeGithubIssuesPrs(githubPrsReviewData?.items || []);
 		}
 		await writeGithubPrsReviews();
-		if (includeNextPlans && platform !== 'codeberg') {
+		if (includeNextPlans) {
 			if (window.getNextPlansForReport) {
 				try {
 					const selectedPlans = await window.getNextPlansForReport();
@@ -1448,14 +1336,12 @@ function allIncluded(outputTarget = 'email') {
 				window.updateCopyButtonState?.();
 				try {
 					const cacheKey =
-						platform === 'gitlab'
-							? (window.gitlabHelper?.cache?.cacheKey ?? null)
-							: platform === 'codeberg'
-								? (window.codebergHelper?.cache?.cacheKey ?? null)
-								: (githubCache?.cacheKey ?? null);
+						platform === 'gitlab' ? (window.gitlabHelper?.cache?.cacheKey ?? null) : (githubCache?.cacheKey ?? null);
+
+					const reportCacheKey = `${platform}LastScrumReportHtml`;
 
 					chrome.storage.local.set({
-						lastScrumReportHtml: content,
+						[reportCacheKey]: content,
 						lastScrumReportPlatform: platform,
 						lastScrumReportCacheKey: cacheKey,
 						lastScrumReportUsername: platformUsername,
@@ -1557,11 +1443,6 @@ function allIncluded(outputTarget = 'email') {
 	}
 
 	async function writeGithubPrsReviews() {
-		if (platform === 'codeberg') {
-			reviewedPrsArray = [];
-			prsReviewDataProcessed = true;
-			return;
-		}
 		if (!onlyRevPRs) {
 			log('onlyRevPRs is not checked, skipping PR reviews.');
 			reviewedPrsArray = [];
@@ -1590,7 +1471,7 @@ function allIncluded(outputTarget = 'email') {
 			const today = new Date();
 			const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
 			startDate = formatLocalDate(yesterday);
-			endDate = formatLocalDate(yesterday);
+			endDate = formatLocalDate(today); // Use yesterday for start and today for end
 		} else if (weeklyContribution) {
 			const today = new Date();
 			const weekAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
@@ -1660,9 +1541,6 @@ function allIncluded(outputTarget = 'email') {
 				isAuthoredByUser = item.user && item.user.login.toLowerCase() === platformUsernameLocal.toLowerCase();
 			} else if (platform === 'gitlab') {
 				isAuthoredByUser = item.author && item.author.username === platformUsername;
-			} else if (platform === 'codeberg') {
-				isAuthoredByUser =
-					item.user && (item.user.login === platformUsernameLocal || item.user.username === platformUsernameLocal);
 			}
 
 			if (isAuthoredByUser || !item.pull_request) continue;
@@ -1834,7 +1712,7 @@ function allIncluded(outputTarget = 'email') {
 			const today = new Date();
 			const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
 			startDateForRange = formatLocalDate(yesterday);
-			endDateForRange = formatLocalDate(yesterday);
+			endDateForRange = formatLocalDate(today); // Use yesterday for start and today for end
 		} else if (weeklyContribution) {
 			const today = new Date();
 			const weekAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
@@ -1952,10 +1830,7 @@ function allIncluded(outputTarget = 'email') {
 					// cannot be fetched.
 					let hasMergeInfo = false;
 					let isMerged = false;
-					if (platform === 'gitlab') {
-						hasMergeInfo = true;
-						isMerged = item.state === 'merged';
-					} else if (prCacheKey && prCacheKey in mergedStatusResults) {
+					if (prCacheKey && prCacheKey in mergedStatusResults) {
 						hasMergeInfo = true;
 						isMerged = !!mergedStatusResults[prCacheKey];
 					} else if (item.pull_request && Object.prototype.hasOwnProperty.call(item.pull_request, 'merged_at')) {
@@ -2002,7 +1877,7 @@ function allIncluded(outputTarget = 'email') {
 					const today = new Date();
 					const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
 					startDateFilter = new Date(formatLocalDate(yesterday) + 'T00:00:00Z');
-					endDateFilter = new Date(formatLocalDate(yesterday) + 'T23:59:59Z');
+					endDateFilter = new Date(formatLocalDate(today) + 'T23:59:59Z'); // Use yesterday for start and today for end
 				} else if (weeklyContribution) {
 					const today = new Date();
 					const weekAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
@@ -2076,25 +1951,6 @@ function allIncluded(outputTarget = 'email') {
 					} else {
 						prAction = 'Updated Merge Request';
 					}
-				} else if (platform === 'codeberg') {
-					if (showCommits && !isNewPR) {
-						if (item.state !== 'open') {
-							log(`[PR DEBUG] Skipping PR #${number} - existing PR but not open`);
-							continue;
-						}
-						if (!hasCommitsInRange) {
-							log(`[PR DEBUG] Skipping PR #${number} - existing PR but no commits in date range`);
-							continue;
-						}
-					}
-					prAction = isNewPR ? 'Made PR' : 'Updated PR';
-					log(`[PR DEBUG] Including PR #${number} as ${prAction}`);
-
-					if (isCreatedToday && item.state === 'open') {
-						prAction = 'Made PR';
-					} else {
-						prAction = 'Updated PR';
-					}
 				}
 
 				if (isDraft) {
@@ -2124,18 +1980,9 @@ function allIncluded(outputTarget = 'email') {
 					li += `</li>`;
 				} else if (platform === 'gitlab' && item.state === 'closed') {
 					li = `<li><i>(${project})</i> - ${prAction} <a href='${html_url}' target='_blank' rel='noopener noreferrer' contenteditable='false'>(#${number})</a> - <a href='${html_url}' target='_blank' rel='noopener noreferrer' contenteditable='false'>${title}</a>${showOpenLabel ? ' ' + pr_closed_button : ''}</li>`;
-				} else if (platform === 'codeberg' && item.state === 'closed') {
-					const isMerged = item.pull_request && item.pull_request.merged;
-					if (isMerged) {
-						li = `<li><i>(${project})</i> - ${prAction} <a href='${html_url}' target='_blank' rel='noopener noreferrer' contenteditable='false'>(#${number})</a> - <a href='${html_url}' target='_blank' rel='noopener noreferrer' contenteditable='false'>${title}</a>${showOpenLabel ? ' ' + pr_merged_button : ''}</li>`;
-					} else {
-						li = `<li><i>(${project})</i> - ${prAction} <a href='${html_url}' target='_blank' rel='noopener noreferrer' contenteditable='false'>(#${number})</a> - <a href='${html_url}' target='_blank' rel='noopener noreferrer' contenteditable='false'>${title}</a>${showOpenLabel ? ' ' + pr_closed_button : ''}</li>`;
-					}
 				} else {
 					let merged = null;
-					if (platform === 'gitlab') {
-						merged = item.state === 'merged';
-					} else if ((githubToken || (useMergedStatus && !fallbackToSimple)) && mergedStatusResults) {
+					if ((githubToken || (useMergedStatus && !fallbackToSimple)) && mergedStatusResults) {
 						const repoParts = repository_url.split('/');
 						const owner = repoParts[repoParts.length - 2];
 						const repo = repoParts[repoParts.length - 1];


### PR DESCRIPTION
### 📌 Fixes

Fixes #787

---

### 📝 Summary of Changes

Implemented multiple bug fixes across the extension:

- Fixed persistent input field issue where manually cleared project names and tokens were incorrectly replaced by previously stored values.
- Added platform-specific report cache keys (`githubLastScrumReportHtml` / `gitlabLastScrumReportHtml`) to prevent cache conflicts when switching platforms.
- Updated GitHub organization validation to include the GitHub token in the Authorization header, allowing validation of private organizations.
- Replaced unnecessary `keyup` storage updates with `change` events to reduce excessive storage writes and avoid throttling issues.

---

### 📸 Screenshots / Demo (if UI-related)

Not applicable. These changes fix internal extension logic and storage behavior.

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

The issue description also mentioned a Rust CLI `src/main.rs` fix, but this repository checkout does not contain any Rust files or CLI source code. The implemented changes cover the extension-related bugs available in this codebase.

## Summary by Sourcery

Fix extension state persistence, platform-specific report caching, GitHub organization validation, and report date handling.

Bug Fixes:
- Prevent manually cleared project names and tokens from being repopulated from stale stored values.
- Use authenticated GitHub organization validation so private organizations can be checked.
- Prevent report cache conflicts between GitHub and GitLab by storing platform-specific report content.
- Correct yesterday report date ranges to include the current day as the end date.

Enhancements:
- Reduce extension storage writes by persisting field changes on change events instead of every keyup.
- Simplify GitHub report caching and commit retrieval behavior while removing obsolete Codeberg report support.