### PR TITLE
fix: change default display mode to popup

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -23,9 +23,11 @@ function applyDisplayMode(mode) {
 }
 
 // Initialize display mode on startup
-browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
-	applyDisplayMode(result.displayMode);
-});
+browser.storage.local
+	.get({ displayMode: browser.sidebarAction?.toggle || browser.sidePanel?.open ? 'sidePanel' : 'popup' })
+	.then((result) => {
+		applyDisplayMode(result.displayMode);
+	});
 
 // Listen for changes to displayMode
 browser.storage.onChanged.addListener((changes, area) => {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1481,17 +1481,21 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		}
 
-		browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
-			applyDisplayModeClass(result.displayMode);
-		});
+		browser.storage.local
+			.get({ displayMode: browser.sidebarAction?.toggle || browser.sidePanel?.open ? 'sidePanel' : 'popup' })
+			.then((result) => {
+				applyDisplayModeClass(result.displayMode);
+			});
 
 		const displayModeSelect = document.getElementById('displayModeSelect');
 		const displayModeNotice = document.getElementById('displayModeNotice');
 		const displayModeNoticeText = document.getElementById('displayModeNoticeText');
 		if (displayModeSelect) {
-			browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
-				displayModeSelect.value = result.displayMode;
-			});
+			browser.storage.local
+				.get({ displayMode: browser.sidebarAction?.toggle || browser.sidePanel?.open ? 'sidePanel' : 'popup' })
+				.then((result) => {
+					displayModeSelect.value = result.displayMode;
+				});
 			displayModeSelect.addEventListener('change', () => {
 				const mode = displayModeSelect.value;
 				browser.storage.local.set({ displayMode: mode });


### PR DESCRIPTION
fixes #748 

## Bug Description
In vertical-tab/sidebar-based Chromium browsers (such as Arc), Scrum Helper fails to open or execute when clicking on the extension icon. This is because the extension's default display mode is set to 'Side Panel', which relies on the `chrome.sidePanel` API. This API is unsupported or inaccessible in these environments.

## Fix
Changing the default display mode storage fallback value from 'sidePanel' to 'popup' resolves the issue. This allows browsers without native side panel support (like Arc) to successfully open Scrum Helper in a standard extension popup by default, while still allowing users on supported browsers (like Chrome) to switch to 'Side Panel' mode manually in the settings if they choose.

## Validation Steps
- Ran `npm run lint`
- Ran `npm run check`
- Ran `npm run build`

## Summary by Sourcery

Bug Fixes:
- Use popup as the default display mode so the extension opens reliably in browsers without side panel support.

## Summary by Sourcery

Bug Fixes:
- Select a popup fallback when side panel APIs are unavailable, allowing the extension to open reliably in browsers without native side panel support.