### PR TITLE
fix: correctly handle default display mode for Chromium browsers (Arc support)

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -23,11 +23,9 @@ function applyDisplayMode(mode) {
 }
 
 // Initialize display mode on startup
-browser.storage.local
-	.get({ displayMode: browser.sidebarAction?.toggle || browser.sidePanel?.open ? 'sidePanel' : 'popup' })
-	.then((result) => {
-		applyDisplayMode(result.displayMode);
-	});
+browser.storage.local.get({ displayMode: browser.sidebarAction?.toggle ? 'sidePanel' : 'popup' }).then((result) => {
+	applyDisplayMode(result.displayMode);
+});
 
 // Listen for changes to displayMode
 browser.storage.onChanged.addListener((changes, area) => {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1481,18 +1481,16 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		}
 
-		browser.storage.local
-			.get({ displayMode: browser.sidebarAction?.toggle || browser.sidePanel?.open ? 'sidePanel' : 'popup' })
-			.then((result) => {
-				applyDisplayModeClass(result.displayMode);
-			});
+		browser.storage.local.get({ displayMode: browser.sidebarAction?.toggle ? 'sidePanel' : 'popup' }).then((result) => {
+			applyDisplayModeClass(result.displayMode);
+		});
 
 		const displayModeSelect = document.getElementById('displayModeSelect');
 		const displayModeNotice = document.getElementById('displayModeNotice');
 		const displayModeNoticeText = document.getElementById('displayModeNoticeText');
 		if (displayModeSelect) {
 			browser.storage.local
-				.get({ displayMode: browser.sidebarAction?.toggle || browser.sidePanel?.open ? 'sidePanel' : 'popup' })
+				.get({ displayMode: browser.sidebarAction?.toggle ? 'sidePanel' : 'popup' })
 				.then((result) => {
 					displayModeSelect.value = result.displayMode;
 				});


### PR DESCRIPTION
## Bug Description
The previous PR (`fix/default-display-mode-popup`) inadvertently reverted the default display mode back to `sidePanel` for all Chromium browsers. This occurred because `browser.sidePanel?.open` evaluated to truthy on Chromium—even in browsers like Arc where the side panel is unsupported. This caused Arc to once again fail to open the extension popup.

## Fix
This PR removes the `browser.sidePanel?.open` check so that only browsers with `browser.sidebarAction` (Firefox and Opera) default to the side panel. All Chromium browsers (including Chrome, Arc, and Edge) will safely default to the popup, resolving the issue without breaking the side-panel fallback for browsers that fully support it.

## Validation Steps
- Checked out a fresh branch from main
- Reverted the `browser.sidePanel?.open` condition
- Ran `npm run lint`
- Ran `npm run check`
- Ran `npm run build`

## Summary by Sourcery

Correct default display-mode detection so Chromium browsers open the extension popup while supported sidebar browsers continue to use the side panel.

Bug Fixes:
- Restore popup as the default display mode for Chromium browsers, including browsers that expose an unsupported side-panel API such as Arc.
- Preserve the side-panel default for browsers that provide the Firefox/Opera sidebar action.