### PR TITLE
fix: handle default display mode for Tauri desktop app

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1,9 +1,18 @@
 if (typeof importScripts === 'function') {
 	try {
-		importScripts('browser-polyfill.min.js');
+		// Chrome MV3 service workers resolve relative to extension root
+		importScripts('/scripts/browser-polyfill.min.js');
 	} catch (e) {
-		console.error('Failed to import polyfill in background:', e);
+		try {
+			importScripts('browser-polyfill.min.js');
+		} catch (e2) {
+			console.error('Failed to import polyfill in background:', e2);
+		}
 	}
+}
+
+if (typeof browser === 'undefined') {
+	globalThis.browser = globalThis.chrome;
 }
 
 const openByTabId = new Map();
@@ -23,9 +32,14 @@ function applyDisplayMode(mode) {
 }
 
 // Initialize display mode on startup
-browser.storage.local.get({ displayMode: browser.sidebarAction?.toggle ? 'sidePanel' : 'popup' }).then((result) => {
-	applyDisplayMode(result.displayMode);
-});
+browser.storage.local
+	.get({
+		displayMode:
+			(typeof window !== 'undefined' && window.isTauri) || browser.sidebarAction?.toggle ? 'sidePanel' : 'popup',
+	})
+	.then((result) => {
+		applyDisplayMode(result.displayMode);
+	});
 
 // Listen for changes to displayMode
 browser.storage.onChanged.addListener((changes, area) => {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1475,16 +1475,18 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		}
 
-		browser.storage.local.get({ displayMode: browser.sidebarAction?.toggle ? 'sidePanel' : 'popup' }).then((result) => {
-			applyDisplayModeClass(result.displayMode);
-		});
+		browser.storage.local
+			.get({ displayMode: window.isTauri || browser.sidebarAction?.toggle ? 'sidePanel' : 'popup' })
+			.then((result) => {
+				applyDisplayModeClass(result.displayMode);
+			});
 
 		const displayModeSelect = document.getElementById('displayModeSelect');
 		const displayModeNotice = document.getElementById('displayModeNotice');
 		const displayModeNoticeText = document.getElementById('displayModeNoticeText');
 		if (displayModeSelect) {
 			browser.storage.local
-				.get({ displayMode: browser.sidebarAction?.toggle ? 'sidePanel' : 'popup' })
+				.get({ displayMode: window.isTauri || browser.sidebarAction?.toggle ? 'sidePanel' : 'popup' })
 				.then((result) => {
 					displayModeSelect.value = result.displayMode;
 				});


### PR DESCRIPTION
## Bug Description
In PR #813, the default display mode logic was updated to fallback to `sidePanel` only for browsers with `browser.sidebarAction`, allowing Chromium browsers to safely fallback to `popup`. However, because Tauri mocks the extension API and does not define `browser.sidebarAction`, this unintentionally forced the Tauri desktop app into `popup` mode as well, severely constraining the UI.

## Fix
This PR introduces a `window.isTauri` check into the display mode fallback logic. Since the Tauri app effectively acts as a side panel in a desktop window, this correctly restores the default `sidePanel` behavior for Tauri while maintaining the `popup` fix for Arc and other Chromium browsers.

## Validation Steps
- Checked out a fresh branch from main
- Added `window.isTauri` checks
- Ran `npm run lint`
- Ran `npm run check`
- Ran `npm run build`


Chrome:

<img width="2560" height="1629" alt="telegram-cloud-photo-size-5-6095640182213252199-w" src="https://github.com/user-attachments/assets/dd98f216-1f59-48ec-880a-c9ed2816aecc" />


Arc:
<img width="570" height="737" alt="Screenshot 2026-08-29 at 8 34 23 PM" src="https://github.com/user-attachments/assets/09e81926-6b64-4d21-ba82-601b64665074" />


## Summary by Sourcery

Restore appropriate default display modes for Tauri and Chromium-based extension environments.

Bug Fixes:
- Restore the default side-panel display mode for Tauri desktop apps while retaining popup defaults for Chromium browsers without sidebar support.

Enhancements:
- Improve background-script compatibility across browser extension environments by supporting Chrome’s global API and service-worker polyfill resolution.