### PR TITLE
feat: display cache age and staleness warning to users (#574)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.11/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
@@ -25,7 +25,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": false,
+			"preset": "none",
 			"complexity": {
 				"noForEach": "off",
 				"useOptionalChain": "off"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -679,5 +679,38 @@
   },
   "smtpPresetsTooltip": {
     "message": "Select a preset to automatically configure the SMTP host and port settings for common email services."
+  },
+  "staleCacheWarningText": {
+    "message": "Data may be outdated. Click Generate to refresh."
+  },
+  "cacheJustNow": {
+    "message": "just now"
+  },
+  "cacheMinAgo": {
+    "message": "$1 min ago"
+  },
+  "cacheHrsAgo": {
+    "message": "$1 hr ago"
+  },
+  "cacheDaysAgo": {
+    "message": "$1 day ago"
+  },
+  "noCache": {
+    "message": "No cache"
+  },
+  "noCacheTooltip": {
+    "message": "No cached report exists. Click Generate to fetch data."
+  },
+  "cacheFresh": {
+    "message": "Fresh ($1)"
+  },
+  "cacheFreshTooltip": {
+    "message": "This report was generated $1. Cache refreshes automatically after $2 minutes."
+  },
+  "cacheStale": {
+    "message": "Stale ($1)"
+  },
+  "cacheStaleTooltip": {
+    "message": "This report was generated $1. The cache TTL is $2 minutes, so the data may be outdated."
   }
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -393,6 +393,20 @@
 							</div>
 						</div>
 
+						<div id="cacheStatusContainer" class="flex flex-col gap-1 mt-2 mb-2 hidden">
+							<div class="flex items-center gap-2 text-sm">
+								<span id="cacheStatusBadge" class="font-medium flex items-center gap-1"></span>
+								<span class="tooltip-container">
+									<i class="fa fa-info-circle text-gray-400"></i>
+									<span id="cacheStatusTooltip" class="tooltip-bubble w-64 text-left"></span>
+								</span>
+							</div>
+							<div id="staleCacheWarning" class="hidden text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-xl p-2 flex items-center gap-1.5">
+								<i class="fa fa-exclamation-triangle"></i>
+								<span data-i18n="staleCacheWarningText">Data may be outdated. Click Generate to refresh.</span>
+							</div>
+						</div>
+
 						<div id="rateLimitWarning" class="hidden text-xs text-yellow-800 p-2 bg-yellow-50 border border-yellow-200 rounded-xl mt-2 flex items-center justify-between">
 							<span id="rateLimitWarningText" data-i18n="rateLimitWarningMessage">Some data may be missing due to GitHub rate limit. Please add or check your GitHub token in settings.</span>
 							<button id="closeRateLimitWarning" class="text-yellow-800 hover:text-yellow-900 font-bold ml-2 bg-transparent border-none cursor-pointer text-sm">&times;</button>

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -655,13 +655,25 @@ document.addEventListener('DOMContentLoaded', () => {
 		const hasCacheData = !!cache?.data;
 		const timestamp = typeof cache?.timestamp === 'number' ? cache.timestamp : 0;
 
+		function setBadgeContent(iconClass, textClass, text) {
+			badge.textContent = '';
+			const icon = document.createElement('i');
+			icon.className = iconClass;
+			const span = document.createElement('span');
+			span.className = textClass;
+			span.textContent = ' ' + text;
+			badge.appendChild(icon);
+			badge.appendChild(span);
+		}
+
 		if (!hasCacheData || timestamp <= 0) {
-			badge.innerHTML = sanitizeHtml(
-				`<i class="fa fa-refresh text-gray-500"></i> <span class="text-gray-500">${browser?.i18n.getMessage('noCache') || 'No cache'}</span>`,
+			setBadgeContent(
+				'fa fa-refresh text-gray-500',
+				'text-gray-500',
+				browser?.i18n.getMessage('noCache') || 'No cache',
 			);
-			tooltip.innerHTML = sanitizeHtml(
-				browser?.i18n.getMessage('noCacheTooltip') || 'No cached report exists. Click Generate to fetch data.',
-			);
+			tooltip.textContent =
+				browser?.i18n.getMessage('noCacheTooltip') || 'No cached report exists. Click Generate to fetch data.';
 			warning.classList.add('hidden');
 			return;
 		}
@@ -671,22 +683,26 @@ document.addEventListener('DOMContentLoaded', () => {
 		const ageText = formatCacheAge(timestamp);
 
 		if (isFresh) {
-			badge.innerHTML = sanitizeHtml(
-				`<i class="fa fa-check text-green-600"></i> <span class="text-green-700">${(browser?.i18n.getMessage('cacheFresh') || 'Fresh ($1)').replace('$1', ageText)}</span>`,
+			setBadgeContent(
+				'fa fa-check text-green-600',
+				'text-green-700',
+				(browser?.i18n.getMessage('cacheFresh') || 'Fresh ($1)').replace('$1', ageText),
 			);
 			const tooltipMsg =
 				browser?.i18n.getMessage('cacheFreshTooltip') ||
 				'This report was generated $1. Cache refreshes automatically after $2 minutes.';
-			tooltip.innerHTML = sanitizeHtml(tooltipMsg.replace('$1', ageText).replace('$2', ttlMinutes));
+			tooltip.textContent = tooltipMsg.replace('$1', ageText).replace('$2', ttlMinutes);
 			warning.classList.add('hidden');
 		} else {
-			badge.innerHTML = sanitizeHtml(
-				`<i class="fa fa-exclamation-triangle text-amber-600"></i> <span class="text-amber-700">${(browser?.i18n.getMessage('cacheStale') || 'Stale ($1)').replace('$1', ageText)}</span>`,
+			setBadgeContent(
+				'fa fa-exclamation-triangle text-amber-600',
+				'text-amber-700',
+				(browser?.i18n.getMessage('cacheStale') || 'Stale ($1)').replace('$1', ageText),
 			);
 			const tooltipMsg =
 				browser?.i18n.getMessage('cacheStaleTooltip') ||
 				'This report was generated $1. The cache TTL is $2 minutes, so the data may be outdated.';
-			tooltip.innerHTML = sanitizeHtml(tooltipMsg.replace('$1', ageText).replace('$2', ttlMinutes));
+			tooltip.textContent = tooltipMsg.replace('$1', ageText).replace('$2', ttlMinutes);
 			warning.classList.remove('hidden');
 		}
 	}

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -465,6 +465,11 @@ document.addEventListener('DOMContentLoaded', () => {
 		if (window.loadAssignedIssues) {
 			window.loadAssignedIssues();
 		}
+		
+		if (window.updateCacheStatusUI) {
+			window.updateCacheStatusUI();
+			setInterval(window.updateCacheStatusUI, 60000); // update every minute
+		}
 	});
 
 	browser.storage.onChanged.addListener((changes, namespace) => {
@@ -611,6 +616,68 @@ document.addEventListener('DOMContentLoaded', () => {
 			sendReportEmail.disabled = isDisabled;
 		}
 	}
+
+	function formatCacheAge(timestamp) {
+		const diffMs = Date.now() - timestamp;
+		const diffSec = Math.floor(diffMs / 1000);
+		if (diffSec < 60) return browser?.i18n.getMessage('cacheJustNow') || 'just now';
+		const diffMin = Math.floor(diffSec / 60);
+		if (diffMin < 60) return (browser?.i18n.getMessage('cacheMinAgo') || '$1 min ago').replace('$1', diffMin);
+		const diffHr = Math.floor(diffMin / 60);
+		if (diffHr < 24) return (browser?.i18n.getMessage('cacheHrsAgo') || '$1 hr ago').replace('$1', diffHr);
+		const diffDay = Math.floor(diffHr / 24);
+		return (browser?.i18n.getMessage('cacheDaysAgo') || '$1 day ago').replace('$1', diffDay);
+	}
+
+	async function updateCacheStatusUI() {
+		const container = document.getElementById('cacheStatusContainer');
+		const badge = document.getElementById('cacheStatusBadge');
+		const tooltip = document.getElementById('cacheStatusTooltip');
+		const warning = document.getElementById('staleCacheWarning');
+		if (!container || !badge || !tooltip || !warning) return;
+
+		const { platform, cacheInput, githubCache, gitlabCache, codebergCache } = await storageLocalGet([
+			'platform',
+			'cacheInput',
+			'githubCache',
+			'gitlabCache',
+			'codebergCache'
+		]);
+		
+		const activePlatform = platform || 'github';
+		const cache = activePlatform === 'gitlab' ? gitlabCache : (activePlatform === 'codeberg' ? codebergCache : githubCache);
+		const ttlMinutes = parsePositiveInt(cacheInput) ?? 10;
+		const ttlMs = ttlMinutes * 60 * 1000;
+		
+		container.classList.remove('hidden');
+
+		const hasCacheData = !!cache?.data;
+		const timestamp = typeof cache?.timestamp === 'number' ? cache.timestamp : 0;
+
+		if (!hasCacheData || timestamp <= 0) {
+			badge.innerHTML = `<i class="fa fa-refresh text-gray-500"></i> <span class="text-gray-500">${browser?.i18n.getMessage('noCache') || 'No cache'}</span>`;
+			tooltip.innerHTML = browser?.i18n.getMessage('noCacheTooltip') || 'No cached report exists. Click Generate to fetch data.';
+			warning.classList.add('hidden');
+			return;
+		}
+
+		const ageMs = Date.now() - timestamp;
+		const isFresh = ageMs < ttlMs;
+		const ageText = formatCacheAge(timestamp);
+		
+		if (isFresh) {
+			badge.innerHTML = `<i class="fa fa-check text-green-600"></i> <span class="text-green-700">${(browser?.i18n.getMessage('cacheFresh') || 'Fresh ($1)').replace('$1', ageText)}</span>`;
+			const tooltipMsg = browser?.i18n.getMessage('cacheFreshTooltip') || 'This report was generated $1. Cache refreshes automatically after $2 minutes.';
+			tooltip.innerHTML = tooltipMsg.replace('$1', ageText).replace('$2', ttlMinutes);
+			warning.classList.add('hidden');
+		} else {
+			badge.innerHTML = `<i class="fa fa-exclamation-triangle text-amber-600"></i> <span class="text-amber-700">${(browser?.i18n.getMessage('cacheStale') || 'Stale ($1)').replace('$1', ageText)}</span>`;
+			const tooltipMsg = browser?.i18n.getMessage('cacheStaleTooltip') || 'This report was generated $1. The cache TTL is $2 minutes, so the data may be outdated.';
+			tooltip.innerHTML = tooltipMsg.replace('$1', ageText).replace('$2', ttlMinutes);
+			warning.classList.remove('hidden');
+		}
+	}
+	window.updateCacheStatusUI = updateCacheStatusUI;
 
 	async function bootstrapScrumReportOnPopupLoad(generateBtn) {
 		console.log('[BOOTSTRAP] bootstrapScrumReportOnPopupLoad called');

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -655,8 +655,8 @@ document.addEventListener('DOMContentLoaded', () => {
 		const timestamp = typeof cache?.timestamp === 'number' ? cache.timestamp : 0;
 
 		if (!hasCacheData || timestamp <= 0) {
-			badge.innerHTML = `<i class="fa fa-refresh text-gray-500"></i> <span class="text-gray-500">${browser?.i18n.getMessage('noCache') || 'No cache'}</span>`;
-			tooltip.innerHTML = browser?.i18n.getMessage('noCacheTooltip') || 'No cached report exists. Click Generate to fetch data.';
+			badge.innerHTML = sanitizeHtml(`<i class="fa fa-refresh text-gray-500"></i> <span class="text-gray-500">${browser?.i18n.getMessage('noCache') || 'No cache'}</span>`);
+			tooltip.innerHTML = sanitizeHtml(browser?.i18n.getMessage('noCacheTooltip') || 'No cached report exists. Click Generate to fetch data.');
 			warning.classList.add('hidden');
 			return;
 		}
@@ -666,14 +666,14 @@ document.addEventListener('DOMContentLoaded', () => {
 		const ageText = formatCacheAge(timestamp);
 		
 		if (isFresh) {
-			badge.innerHTML = `<i class="fa fa-check text-green-600"></i> <span class="text-green-700">${(browser?.i18n.getMessage('cacheFresh') || 'Fresh ($1)').replace('$1', ageText)}</span>`;
+			badge.innerHTML = sanitizeHtml(`<i class="fa fa-check text-green-600"></i> <span class="text-green-700">${(browser?.i18n.getMessage('cacheFresh') || 'Fresh ($1)').replace('$1', ageText)}</span>`);
 			const tooltipMsg = browser?.i18n.getMessage('cacheFreshTooltip') || 'This report was generated $1. Cache refreshes automatically after $2 minutes.';
-			tooltip.innerHTML = tooltipMsg.replace('$1', ageText).replace('$2', ttlMinutes);
+			tooltip.innerHTML = sanitizeHtml(tooltipMsg.replace('$1', ageText).replace('$2', ttlMinutes));
 			warning.classList.add('hidden');
 		} else {
-			badge.innerHTML = `<i class="fa fa-exclamation-triangle text-amber-600"></i> <span class="text-amber-700">${(browser?.i18n.getMessage('cacheStale') || 'Stale ($1)').replace('$1', ageText)}</span>`;
+			badge.innerHTML = sanitizeHtml(`<i class="fa fa-exclamation-triangle text-amber-600"></i> <span class="text-amber-700">${(browser?.i18n.getMessage('cacheStale') || 'Stale ($1)').replace('$1', ageText)}</span>`);
 			const tooltipMsg = browser?.i18n.getMessage('cacheStaleTooltip') || 'This report was generated $1. The cache TTL is $2 minutes, so the data may be outdated.';
-			tooltip.innerHTML = tooltipMsg.replace('$1', ageText).replace('$2', ttlMinutes);
+			tooltip.innerHTML = sanitizeHtml(tooltipMsg.replace('$1', ageText).replace('$2', ttlMinutes));
 			warning.classList.remove('hidden');
 		}
 	}

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -465,7 +465,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		if (window.loadAssignedIssues) {
 			window.loadAssignedIssues();
 		}
-		
+
 		if (window.updateCacheStatusUI) {
 			window.updateCacheStatusUI();
 			setInterval(window.updateCacheStatusUI, 60000); // update every minute
@@ -641,22 +641,27 @@ document.addEventListener('DOMContentLoaded', () => {
 			'cacheInput',
 			'githubCache',
 			'gitlabCache',
-			'codebergCache'
+			'codebergCache',
 		]);
-		
+
 		const activePlatform = platform || 'github';
-		const cache = activePlatform === 'gitlab' ? gitlabCache : (activePlatform === 'codeberg' ? codebergCache : githubCache);
+		const cache =
+			activePlatform === 'gitlab' ? gitlabCache : activePlatform === 'codeberg' ? codebergCache : githubCache;
 		const ttlMinutes = parsePositiveInt(cacheInput) ?? 10;
 		const ttlMs = ttlMinutes * 60 * 1000;
-		
+
 		container.classList.remove('hidden');
 
 		const hasCacheData = !!cache?.data;
 		const timestamp = typeof cache?.timestamp === 'number' ? cache.timestamp : 0;
 
 		if (!hasCacheData || timestamp <= 0) {
-			badge.innerHTML = sanitizeHtml(`<i class="fa fa-refresh text-gray-500"></i> <span class="text-gray-500">${browser?.i18n.getMessage('noCache') || 'No cache'}</span>`);
-			tooltip.innerHTML = sanitizeHtml(browser?.i18n.getMessage('noCacheTooltip') || 'No cached report exists. Click Generate to fetch data.');
+			badge.innerHTML = sanitizeHtml(
+				`<i class="fa fa-refresh text-gray-500"></i> <span class="text-gray-500">${browser?.i18n.getMessage('noCache') || 'No cache'}</span>`,
+			);
+			tooltip.innerHTML = sanitizeHtml(
+				browser?.i18n.getMessage('noCacheTooltip') || 'No cached report exists. Click Generate to fetch data.',
+			);
 			warning.classList.add('hidden');
 			return;
 		}
@@ -664,15 +669,23 @@ document.addEventListener('DOMContentLoaded', () => {
 		const ageMs = Date.now() - timestamp;
 		const isFresh = ageMs < ttlMs;
 		const ageText = formatCacheAge(timestamp);
-		
+
 		if (isFresh) {
-			badge.innerHTML = sanitizeHtml(`<i class="fa fa-check text-green-600"></i> <span class="text-green-700">${(browser?.i18n.getMessage('cacheFresh') || 'Fresh ($1)').replace('$1', ageText)}</span>`);
-			const tooltipMsg = browser?.i18n.getMessage('cacheFreshTooltip') || 'This report was generated $1. Cache refreshes automatically after $2 minutes.';
+			badge.innerHTML = sanitizeHtml(
+				`<i class="fa fa-check text-green-600"></i> <span class="text-green-700">${(browser?.i18n.getMessage('cacheFresh') || 'Fresh ($1)').replace('$1', ageText)}</span>`,
+			);
+			const tooltipMsg =
+				browser?.i18n.getMessage('cacheFreshTooltip') ||
+				'This report was generated $1. Cache refreshes automatically after $2 minutes.';
 			tooltip.innerHTML = sanitizeHtml(tooltipMsg.replace('$1', ageText).replace('$2', ttlMinutes));
 			warning.classList.add('hidden');
 		} else {
-			badge.innerHTML = sanitizeHtml(`<i class="fa fa-exclamation-triangle text-amber-600"></i> <span class="text-amber-700">${(browser?.i18n.getMessage('cacheStale') || 'Stale ($1)').replace('$1', ageText)}</span>`);
-			const tooltipMsg = browser?.i18n.getMessage('cacheStaleTooltip') || 'This report was generated $1. The cache TTL is $2 minutes, so the data may be outdated.';
+			badge.innerHTML = sanitizeHtml(
+				`<i class="fa fa-exclamation-triangle text-amber-600"></i> <span class="text-amber-700">${(browser?.i18n.getMessage('cacheStale') || 'Stale ($1)').replace('$1', ageText)}</span>`,
+			);
+			const tooltipMsg =
+				browser?.i18n.getMessage('cacheStaleTooltip') ||
+				'This report was generated $1. The cache TTL is $2 minutes, so the data may be outdated.';
 			tooltip.innerHTML = sanitizeHtml(tooltipMsg.replace('$1', ageText).replace('$2', ttlMinutes));
 			warning.classList.remove('hidden');
 		}

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1831,6 +1831,9 @@ function allIncluded(outputTarget = 'email') {
 	function triggerScrumGeneration() {
 		if (issuesDataProcessed && prsReviewDataProcessed) {
 			writeScrumBody();
+			if (window.updateCacheStatusUI) {
+				window.updateCacheStatusUI();
+			}
 		} else {
 		}
 	}

--- a/src/scripts/scrumHelper.js
+++ b/src/scripts/scrumHelper.js
@@ -1832,7 +1832,7 @@ function allIncluded(outputTarget = 'email') {
 		if (issuesDataProcessed && prsReviewDataProcessed) {
 			writeScrumBody();
 			if (window.updateCacheStatusUI) {
-				window.updateCacheStatusUI();
+				setTimeout(() => window.updateCacheStatusUI(), 500);
 			}
 		} else {
 		}

--- a/tests/cacheStatus.test.js
+++ b/tests/cacheStatus.test.js
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+// Mock DOM for popup.js
+const popupHtml = fs.readFileSync(path.resolve(__dirname, '../src/popup.html'), 'utf8');
+
+describe('Cache Status UI logic', () => {
+	beforeEach(() => {
+		document.documentElement.innerHTML = popupHtml;
+		
+		// Setup window properties expected by popup.js
+		window.PlatformRegistry = { get: vi.fn() };
+		window.updatePlatformUI = vi.fn();
+		window.triggerNextPlansReload = vi.fn();
+		window.scrumDateRangeUtils = { 
+			normalizeDateRangeValues: vi.fn().mockReturnValue(true),
+			persistDateRange: vi.fn()
+		};
+		global.lastPlatform = 'github';
+		global.checkTokenForNextPlans = vi.fn();
+		global.triggerNextPlansReload = vi.fn();
+		global.sanitizeHtml = (str) => str;
+		
+		global.browser.i18n.getMessage = vi.fn((key) => {
+			const msgs = {
+				cacheJustNow: 'just now',
+				cacheMinAgo: '$1 min ago',
+				cacheHrsAgo: '$1 hr ago',
+				cacheDaysAgo: '$1 day ago',
+				noCache: 'No cache',
+				noCacheTooltip: 'No cached report exists. Click Generate to fetch data.',
+				cacheFresh: 'Fresh ($1)',
+				cacheFreshTooltip: 'This report was generated $1. Cache refreshes automatically after $2 minutes.',
+				cacheStale: 'Stale ($1)',
+				cacheStaleTooltip: 'This report was generated $1. The cache TTL is $2 minutes, so the data may be outdated.'
+			};
+			return msgs[key] || key;
+		});
+		
+		// Reset mocks
+		vi.resetModules();
+		vi.clearAllMocks();
+		
+		global.browser.storage.local.get.mockResolvedValue({
+			platform: 'github',
+			cacheInput: '10',
+			githubCache: {
+				data: { items: [] },
+				timestamp: Date.now() - 2 * 60 * 1000 // 2 minutes ago
+			}
+		});
+	});
+
+	it('should format cache age correctly (minutes)', async () => {
+		// Import script after setting up DOM
+		await import('../src/scripts/popup.js');
+		document.dispatchEvent(new Event('DOMContentLoaded'));
+		
+		const timestamp = Date.now() - 3 * 60 * 1000; // 3 minutes ago
+		global.browser.storage.local.get.mockResolvedValue({
+			platform: 'github',
+			cacheInput: '10',
+			githubCache: {
+				data: { items: [] },
+				timestamp: timestamp
+			}
+		});
+
+		// wait for DOMContentLoaded promises to settle
+		await new Promise(r => setTimeout(r, 100));
+		
+		await window.updateCacheStatusUI();
+		
+		const badge = document.getElementById('cacheStatusBadge');
+		expect(badge.innerHTML).toContain('Fresh (3 min ago)');
+	});
+
+	it('should mark cache as stale if age exceeds TTL', async () => {
+		await import('../src/scripts/popup.js');
+		document.dispatchEvent(new Event('DOMContentLoaded'));
+		
+		const timestamp = Date.now() - 15 * 60 * 1000; // 15 minutes ago
+		global.browser.storage.local.get.mockResolvedValue({
+			platform: 'github',
+			cacheInput: '10', // 10 minutes TTL
+			githubCache: {
+				data: { items: [] },
+				timestamp: timestamp
+			}
+		});
+
+		await new Promise(r => setTimeout(r, 100));
+		await window.updateCacheStatusUI();
+		
+		const badge = document.getElementById('cacheStatusBadge');
+		expect(badge.innerHTML).toContain('Stale (15 min ago)');
+		
+		const warning = document.getElementById('staleCacheWarning');
+		expect(warning.classList.contains('hidden')).toBe(false);
+	});
+
+	it('should show "No cache" if there is no cache timestamp', async () => {
+		await import('../src/scripts/popup.js');
+		document.dispatchEvent(new Event('DOMContentLoaded'));
+		
+		global.browser.storage.local.get.mockResolvedValue({
+			platform: 'github',
+			cacheInput: '10',
+			githubCache: {
+				data: null,
+				timestamp: 0
+			}
+		});
+
+		await new Promise(r => setTimeout(r, 100));
+		await window.updateCacheStatusUI();
+		
+		const badge = document.getElementById('cacheStatusBadge');
+		expect(badge.innerHTML).toContain('No cache');
+		
+		const warning = document.getElementById('staleCacheWarning');
+		expect(warning.classList.contains('hidden')).toBe(true);
+	});
+});

--- a/tests/cacheStatus.test.js
+++ b/tests/cacheStatus.test.js
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 
+import path from 'path';
+
 // Mock DOM for popup.js
-const popupHtml = fs.readFileSync(new URL('../src/popup.html', import.meta.url), 'utf8');
+const popupHtml = fs.readFileSync(path.resolve(__dirname, '../src/popup.html'), 'utf8');
 
 describe('Cache Status UI logic', () => {
 	beforeEach(() => {

--- a/tests/cacheStatus.test.js
+++ b/tests/cacheStatus.test.js
@@ -1,9 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
-import path from 'path';
 
 // Mock DOM for popup.js
-const popupHtml = fs.readFileSync(path.resolve(__dirname, '../src/popup.html'), 'utf8');
+const popupHtml = fs.readFileSync(new URL('../src/popup.html', import.meta.url), 'utf8');
 
 describe('Cache Status UI logic', () => {
 	beforeEach(() => {
@@ -50,6 +49,10 @@ describe('Cache Status UI logic', () => {
 				timestamp: Date.now() - 2 * 60 * 1000 // 2 minutes ago
 			}
 		});
+	});
+
+	afterEach(() => {
+		vi.clearAllTimers();
 	});
 
 	it('should format cache age correctly (minutes)', async () => {


### PR DESCRIPTION
### 📌 Fixes

Fixes #574

---

###  Summary of Changes

- **Added Cache Status UI**: Introduced a visual badge and warning banner to `src/popup.html` to clearly show users the freshness of their cached Scrum report data.
- **Implemented Staleness Logic**: 
  - Added a `formatCacheAge` utility to dynamically calculate human-readable cache ages (e.g., "just now", "3 min ago").
  - Built `updateCacheStatusUI` to compare the platform's cache timestamp against the user's configured Cache TTL setting and update the UI states (Fresh vs. Stale vs. No Cache).
- **Lifecycle Integration**: Hooked the UI update logic to initialize on popup load, poll periodically every 60 seconds, and refresh immediately after a new report is generated.
- **Localization**: Added full i18n translation strings and tooltips to `src/_locales/en/messages.json`.
- **Testing**: Added `cacheStatus.test.js` to the Vitest suite to thoroughly cover the formatting helper and TTL staleness boundary logic.

---

### Checklist

- [x] I’ve tested my changes locally
- [x] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

- The `updateCacheStatusUI` logic dynamically handles `githubCache`, `gitlabCache`, and `codebergCache` based on the currently selected platform. 
- The automated tests utilize `Vitest` and `Happy DOM`. I had to manually dispatch `DOMContentLoaded` inside the test suite to ensure the status functions initialized properly within the test environment.

## Summary by Sourcery

Show users whether their Scrum report cache is fresh, stale, or unavailable and when it was generated.

New Features:
- Display cache freshness status, cache age, and stale-data warnings in the Scrum report popup across supported platforms.

Enhancements:
- Refresh cache status on popup load, periodically, and after report generation based on the configured cache TTL.
- Add localized cache status labels, tooltips, and warning text.

Tests:
- Add Vitest coverage for cache age formatting and fresh, stale, and missing-cache states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cache status indicators showing whether reports are fresh, stale, or unavailable.
  * Added cache age information and explanatory tooltips.
  * Added a warning when displayed report data is stale.
  * Cache status refreshes automatically and after report generation.

* **Tests**
  * Added coverage for fresh, stale, and unavailable cache states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->