### PR TITLE
test: add unit tests for toast DOM utilities

### DIFF
--- a/tests/domUtils.test.js
+++ b/tests/domUtils.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import '../src/scripts/main.js';
+
+describe('scrumHelperToast', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		document.body.innerHTML = '';
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('should return null and render nothing when the message is empty', () => {
+		expect(window.scrumHelperToast('')).toBeNull();
+		expect(window.scrumHelperToast(null)).toBeNull();
+		expect(window.scrumHelperToast(undefined)).toBeNull();
+		expect(document.getElementById('scrum-helper-toast')).toBeNull();
+	});
+
+	it('should render the message with the default info variant', () => {
+		const toast = window.scrumHelperToast('saved');
+
+		expect(toast.id).toBe('scrum-helper-toast');
+		expect(toast.textContent).toBe('saved');
+		expect(toast.className).toBe('scrum-toast scrum-toast--info');
+		expect(document.getElementById('scrum-helper-toast')).toBe(toast);
+	});
+
+	it('should apply the requested variant', () => {
+		const toast = window.scrumHelperToast('gone wrong', { variant: 'error' });
+		expect(toast.className).toBe('scrum-toast scrum-toast--error');
+	});
+
+	it('should set assertive live region attributes for errors', () => {
+		const toast = window.scrumHelperToast('gone wrong', { variant: 'error' });
+
+		expect(toast.getAttribute('role')).toBe('alert');
+		expect(toast.getAttribute('aria-live')).toBe('assertive');
+		expect(toast.getAttribute('aria-atomic')).toBe('true');
+	});
+
+	it('should set polite live region attributes for non-errors', () => {
+		const toast = window.scrumHelperToast('saved');
+
+		expect(toast.getAttribute('role')).toBe('status');
+		expect(toast.getAttribute('aria-live')).toBe('polite');
+		expect(toast.getAttribute('aria-atomic')).toBe('true');
+	});
+
+	it('should replace an existing toast rather than stacking', () => {
+		const first = window.scrumHelperToast('first');
+		const second = window.scrumHelperToast('second');
+
+		expect(document.querySelectorAll('.scrum-toast')).toHaveLength(1);
+		expect(first.parentNode).toBeNull();
+		expect(document.getElementById('scrum-helper-toast')).toBe(second);
+	});
+
+	it('should mount into the toast container when one exists', () => {
+		const container = document.createElement('div');
+		container.id = 'scrumHelperToastContainer';
+		document.body.appendChild(container);
+
+		const toast = window.scrumHelperToast('saved');
+
+		expect(toast.parentNode).toBe(container);
+	});
+
+	it('should fall back to document.body when there is no container', () => {
+		const toast = window.scrumHelperToast('saved');
+		expect(toast.parentNode).toBe(document.body);
+	});
+
+	it('should hide and then remove the toast after the duration elapses', () => {
+		const toast = window.scrumHelperToast('saved', { duration: 1000 });
+
+		vi.advanceTimersByTime(999);
+		expect(toast.parentNode).not.toBeNull();
+
+		vi.advanceTimersByTime(1);
+		expect(toast.classList.contains('scrum-toast--visible')).toBe(false);
+		expect(toast.parentNode).not.toBeNull();
+
+		vi.advanceTimersByTime(window.SCRUM_TOAST_ANIM_MS);
+		expect(toast.parentNode).toBeNull();
+	});
+
+	it('should not throw when the toast was already detached before removal', () => {
+		const toast = window.scrumHelperToast('saved', { duration: 100 });
+		toast.remove();
+
+		expect(() => vi.advanceTimersByTime(100 + window.SCRUM_TOAST_ANIM_MS)).not.toThrow();
+	});
+});
+
+describe('clearScrumHelperToast', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		document.body.innerHTML = '';
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('should remove the active toast', () => {
+		window.scrumHelperToast('saved');
+		window.clearScrumHelperToast();
+
+		expect(document.getElementById('scrum-helper-toast')).toBeNull();
+	});
+
+	it('should clear leftover toasts inside the container', () => {
+		const container = document.createElement('div');
+		container.id = 'scrumHelperToastContainer';
+		const stale = document.createElement('div');
+		stale.className = 'scrum-toast';
+		container.appendChild(stale);
+		document.body.appendChild(container);
+
+		window.clearScrumHelperToast();
+
+		expect(container.querySelectorAll('.scrum-toast')).toHaveLength(0);
+	});
+
+	it('should be a no-op when there is nothing to clear', () => {
+		expect(() => window.clearScrumHelperToast()).not.toThrow();
+	});
+});
+
+describe('showPopupMessage', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		document.body.innerHTML = '';
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('should delegate to scrumHelperToast with default options', () => {
+		const spy = vi.spyOn(window, 'scrumHelperToast');
+
+		window.showPopupMessage('saved');
+
+		expect(spy).toHaveBeenCalledWith('saved', { duration: 2000, variant: 'info' });
+		spy.mockRestore();
+	});
+
+	it('should let callers override the defaults', () => {
+		const spy = vi.spyOn(window, 'scrumHelperToast');
+
+		window.showPopupMessage('gone wrong', { variant: 'error', duration: 500 });
+
+		expect(spy).toHaveBeenCalledWith('gone wrong', { duration: 500, variant: 'error' });
+		spy.mockRestore();
+	});
+
+	it('should tolerate a null options argument', () => {
+		expect(() => window.showPopupMessage('saved', null)).not.toThrow();
+		expect(document.getElementById('scrum-helper-toast')).not.toBeNull();
+	});
+});

--- a/tests/domUtils.test.js
+++ b/tests/domUtils.test.js
@@ -137,6 +137,7 @@ describe('showPopupMessage', () => {
 
 	afterEach(() => {
 		vi.useRealTimers();
+		vi.restoreAllMocks();
 	});
 
 	it('should delegate to scrumHelperToast with default options', () => {
@@ -145,7 +146,6 @@ describe('showPopupMessage', () => {
 		window.showPopupMessage('saved');
 
 		expect(spy).toHaveBeenCalledWith('saved', { duration: 2000, variant: 'info' });
-		spy.mockRestore();
 	});
 
 	it('should let callers override the defaults', () => {
@@ -154,7 +154,6 @@ describe('showPopupMessage', () => {
 		window.showPopupMessage('gone wrong', { variant: 'error', duration: 500 });
 
 		expect(spy).toHaveBeenCalledWith('gone wrong', { duration: 500, variant: 'error' });
-		spy.mockRestore();
 	});
 
 	it('should tolerate a null options argument', () => {


### PR DESCRIPTION
Refs #482

Adds unit tests for the toast utilities in `src/scripts/main.js` — `scrumHelperToast`, `clearScrumHelperToast` and `showPopupMessage` — which previously had no coverage. Before this, `tests/` contained a single file (`dateUtils.test.js`) covering the date range helpers.

## What's covered

16 tests across three describe blocks:

- **Rendering** — message text, element id, default `info` variant and explicit variant class, and returning `null` for empty/`null`/`undefined` messages without touching the DOM.
- **Accessibility** — that `error` toasts announce as `role="alert"` / `aria-live="assertive"` while other variants use `role="status"` / `aria-live="polite"`, both with `aria-atomic="true"`. This is the behaviour most likely to regress silently, since nothing visually changes when it breaks.
- **Single-toast invariant** — a second toast replaces the first rather than stacking.
- **Mount target** — `#scrumHelperToastContainer` when present, falling back to `document.body`.
- **Timed removal** — using fake timers, that the toast stays until `duration`, then loses `scrum-toast--visible`, then is detached `SCRUM_TOAST_ANIM_MS` later; plus that an already-detached toast doesn't throw on removal.
- **`showPopupMessage`** — delegation with `{ duration: 2000, variant: 'info' }` defaults, caller overrides, and tolerating a `null` options argument.

## Verification

`npx vitest run` → **21 passed** (5 existing + 16 new), no changes to existing tests.

I also mutation-tested the new tests rather than just watching them go green — each of these source mutations was individually applied and confirmed to produce exactly one failure, then reverted:

| Mutation | Result |
| --- | --- |
| `aria-live: 'assertive'` → `'polite'` for errors | 1 failed |
| remove the `existingToast.remove()` replacement | 1 failed |
| ignore `#scrumHelperToastContainer`, always use body | 1 failed |

`src/scripts/main.js` is untouched in this PR — `git diff` on it is empty.

## Notes

- The issue proposes Jest, but the repo has since moved to **Vitest** with `happy-dom`, so these follow the existing `tests/dateUtils.test.js` conventions and the mocks in `tests/setup.js`.
- `biome check` ignores `tests/`, so there's nothing to lint here.
- This is a first slice against #482 rather than the whole thing — the cache and remaining utility modules named in the issue aren't covered yet. Happy to follow up with those in separate PRs if this approach looks right.

## Summary by Sourcery

Tests:
- Add unit coverage for toast rendering, accessibility attributes, replacement behavior, mounting, timed cleanup, clearing, and popup-message delegation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive automated coverage for toast and popup messaging behavior.
  - Verified default and customized message options, accessibility attributes, timed dismissal, replacement of existing messages, and container fallback behavior.
  - Added coverage for clearing messages, handling missing elements or options, and safely managing already-removed notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->