### PR TITLE
fix: validate cacheInput before deriving cache TTL

### DIFF
--- a/src/scripts/codebergHelper.js
+++ b/src/scripts/codebergHelper.js
@@ -109,11 +109,13 @@ class CodebergHelper {
 	/* ---------- CACHE ---------- */
 
 	async getCacheTTL() {
+		const defaultTtl = 10 * 60 * 1000;
 		try {
 			const items = await browser.storage.local.get(['cacheInput']);
-			return items.cacheInput ? Number.parseInt(items.cacheInput, 10) * 60 * 1000 : 10 * 60 * 1000;
+			const minutes = Number.parseInt(items.cacheInput, 10);
+			return Number.isFinite(minutes) && minutes > 0 ? minutes * 60 * 1000 : defaultTtl;
 		} catch {
-			return 10 * 60 * 1000;
+			return defaultTtl;
 		}
 	}
 

--- a/src/scripts/codebergHelper.js
+++ b/src/scripts/codebergHelper.js
@@ -113,7 +113,7 @@ class CodebergHelper {
 		try {
 			const items = await browser.storage.local.get(['cacheInput']);
 			const minutes = Number.parseInt(items.cacheInput, 10);
-			return Number.isFinite(minutes) && minutes > 0 ? minutes * 60 * 1000 : defaultTtl;
+			return Number.isSafeInteger(minutes) && minutes > 0 ? minutes * 60 * 1000 : defaultTtl;
 		} catch {
 			return defaultTtl;
 		}

--- a/src/scripts/gitlabHelper.js
+++ b/src/scripts/gitlabHelper.js
@@ -114,13 +114,14 @@ class GitLabHelper {
 	}
 
 	async getCacheTTL() {
+		const defaultTtl = 10 * 60 * 1000;
 		try {
 			const items = await browser.storage.local.get(['cacheInput']);
-			const ttl = items.cacheInput ? Number.parseInt(items.cacheInput, 10) * 60 * 1000 : 10 * 60 * 1000;
-			return ttl;
+			const minutes = Number.parseInt(items.cacheInput, 10);
+			return Number.isFinite(minutes) && minutes > 0 ? minutes * 60 * 1000 : defaultTtl;
 		} catch (error) {
 			console.error('Error getting cache TTL:', error);
-			return 10 * 60 * 1000;
+			return defaultTtl;
 		}
 	}
 

--- a/src/scripts/gitlabHelper.js
+++ b/src/scripts/gitlabHelper.js
@@ -118,7 +118,7 @@ class GitLabHelper {
 		try {
 			const items = await browser.storage.local.get(['cacheInput']);
 			const minutes = Number.parseInt(items.cacheInput, 10);
-			return Number.isFinite(minutes) && minutes > 0 ? minutes * 60 * 1000 : defaultTtl;
+			return Number.isSafeInteger(minutes) && minutes > 0 ? minutes * 60 * 1000 : defaultTtl;
 		} catch (error) {
 			console.error('Error getting cache TTL:', error);
 			return defaultTtl;

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -504,7 +504,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	function parsePositiveInt(value) {
 		const n = Number.parseInt(value, 10);
-		return Number.isFinite(n) && n > 0 ? n : null;
+		return Number.isSafeInteger(n) && n > 0 ? n : null;
 	}
 
 	function setGenerateButtonLoading(generateBtn, isLoading) {

--- a/tests/cacheTtl.test.js
+++ b/tests/cacheTtl.test.js
@@ -5,9 +5,9 @@ import CodebergHelper from '../src/scripts/codebergHelper.js';
 const DEFAULT_TTL_MS = 10 * 60 * 1000;
 
 function mockCacheInput(value) {
-	browser.storage.local.get = vi
-		.fn()
-		.mockResolvedValue(value === undefined ? {} : { cacheInput: value });
+	vi.spyOn(browser.storage.local, 'get').mockResolvedValue(
+		value === undefined ? {} : { cacheInput: value },
+	);
 }
 
 const helpers = [
@@ -62,14 +62,24 @@ describe.each(helpers)('%s getCacheTTL', (_name, create) => {
 	});
 
 	it('should fall back to the default when storage rejects', async () => {
-		browser.storage.local.get = vi.fn().mockRejectedValue(new Error('storage unavailable'));
+		vi.spyOn(browser.storage.local, 'get').mockRejectedValue(new Error('storage unavailable'));
 		vi.spyOn(console, 'error').mockImplementation(() => {});
 
 		await expect(helper.getCacheTTL()).resolves.toBe(DEFAULT_TTL_MS);
 	});
 
-	it('should never resolve to a value that disables caching', async () => {
-		for (const value of ['abc', '0', '-5', '', undefined, null, {}]) {
+	it('should fall back to the default for a value that overflows to Infinity', async () => {
+		mockCacheInput('9'.repeat(304));
+		await expect(helper.getCacheTTL()).resolves.toBe(DEFAULT_TTL_MS);
+	});
+
+	it('should fall back to the default for a value beyond the safe integer range', async () => {
+		mockCacheInput('9007199254740993');
+		await expect(helper.getCacheTTL()).resolves.toBe(DEFAULT_TTL_MS);
+	});
+
+	it('should always resolve to a finite, positive TTL', async () => {
+		for (const value of ['abc', '0', '-5', '', '9'.repeat(304), undefined, null, {}]) {
 			mockCacheInput(value);
 			const ttl = await helper.getCacheTTL();
 

--- a/tests/cacheTtl.test.js
+++ b/tests/cacheTtl.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import GitLabHelper from '../src/scripts/gitlabHelper.js';
+import CodebergHelper from '../src/scripts/codebergHelper.js';
+
+const DEFAULT_TTL_MS = 10 * 60 * 1000;
+
+function mockCacheInput(value) {
+	browser.storage.local.get = vi
+		.fn()
+		.mockResolvedValue(value === undefined ? {} : { cacheInput: value });
+}
+
+const helpers = [
+	['GitLabHelper', () => new GitLabHelper('https://gitlab.com')],
+	['CodebergHelper', () => new CodebergHelper('https://codeberg.org/api/v1')],
+];
+
+describe.each(helpers)('%s getCacheTTL', (_name, create) => {
+	let helper;
+
+	beforeEach(() => {
+		helper = create();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('should convert a valid minute value to milliseconds', async () => {
+		mockCacheInput('15');
+		await expect(helper.getCacheTTL()).resolves.toBe(15 * 60 * 1000);
+	});
+
+	it('should accept a numeric value as well as a string', async () => {
+		mockCacheInput(15);
+		await expect(helper.getCacheTTL()).resolves.toBe(15 * 60 * 1000);
+	});
+
+	it('should fall back to the default when nothing is stored', async () => {
+		mockCacheInput(undefined);
+		await expect(helper.getCacheTTL()).resolves.toBe(DEFAULT_TTL_MS);
+	});
+
+	it('should fall back to the default for a non-numeric value', async () => {
+		mockCacheInput('abc');
+		await expect(helper.getCacheTTL()).resolves.toBe(DEFAULT_TTL_MS);
+	});
+
+	it('should fall back to the default for zero', async () => {
+		mockCacheInput('0');
+		await expect(helper.getCacheTTL()).resolves.toBe(DEFAULT_TTL_MS);
+	});
+
+	it('should fall back to the default for a negative value', async () => {
+		mockCacheInput('-5');
+		await expect(helper.getCacheTTL()).resolves.toBe(DEFAULT_TTL_MS);
+	});
+
+	it('should fall back to the default for an empty string', async () => {
+		mockCacheInput('');
+		await expect(helper.getCacheTTL()).resolves.toBe(DEFAULT_TTL_MS);
+	});
+
+	it('should fall back to the default when storage rejects', async () => {
+		browser.storage.local.get = vi.fn().mockRejectedValue(new Error('storage unavailable'));
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		await expect(helper.getCacheTTL()).resolves.toBe(DEFAULT_TTL_MS);
+	});
+
+	it('should never resolve to a value that disables caching', async () => {
+		for (const value of ['abc', '0', '-5', '', undefined, null, {}]) {
+			mockCacheInput(value);
+			const ttl = await helper.getCacheTTL();
+
+			expect(Number.isFinite(ttl)).toBe(true);
+			expect(ttl).toBeGreaterThan(0);
+		}
+	});
+});


### PR DESCRIPTION
Fixes #829

## Problem

`getCacheTTL()` in `gitlabHelper.js` and `codebergHelper.js` guarded the stored `cacheInput` with a truthiness check only:

```js
const ttl = items.cacheInput ? Number.parseInt(items.cacheInput, 10) * 60 * 1000 : 10 * 60 * 1000;
```

Anything non-numeric, zero or negative slips through. Measured against `GitLabHelper` before the fix:

| stored `cacheInput` | returned TTL |
| --- | --- |
| `'15'` | `900000` ✅ |
| *(unset)* | `600000` ✅ |
| `'abc'` | **`NaN`** |
| `'0'` | **`0`** |
| `'-5'` | **`-300000`** |

Both helpers then decide freshness with `now - this.cache.timestamp < ttl`, and that comparison is always `false` for `NaN`, `0` or a negative value. The cache is therefore treated as stale on every call and the extension refetches from the API each time a report is generated — caching silently off, with the latency and rate-limit cost that implies, and no signal to the user.

`popup.js` already validates the same setting correctly with `parsePositiveInt(cacheInput) ?? 10`, so its cache-age messaging disagreed with what the helpers actually did.

Worth noting the string `'0'` is truthy while the number `0` is falsy, so those two inputs behaved differently before this change.

## Fix

Validate the parsed value in both helpers, falling back to the 10-minute default unless it is finite and positive — the same semantics as `parsePositiveInt`:

```js
const minutes = Number.parseInt(items.cacheInput, 10);
return Number.isFinite(minutes) && minutes > 0 ? minutes * 60 * 1000 : defaultTtl;
```

## Tests

Adds `tests/cacheTtl.test.js` — 9 cases run against both helpers via `describe.each` (18 tests): valid string and numeric input, unset, non-numeric, zero, negative, empty string, storage rejection, and a sweep asserting the result is always finite and positive.

**Verification:** `npx vitest run` → **23 passed** (5 existing + 18 new).

I also mutation-tested rather than just watching it go green — reverting `gitlabHelper.js` to the old logic fails exactly the 4 tests that describe the bug (non-numeric, zero, negative, and the never-disables-caching sweep), and restoring it returns to 23 passing.

`biome check` is clean on both changed source files.

## Note

This is separate from #828, which covers the DOM/toast half of #482. This one is a behavioural bug fix that happens to come with tests, rather than test coverage alone — the two touch different files and can land in either order.

## Summary by Sourcery

Prevent invalid cache settings from disabling effective caching by enforcing safe positive TTL values across the helpers.

Bug Fixes:
- Ensure GitLab and Codeberg cache TTL calculations reject invalid, non-positive, non-finite, and unsafe values by falling back to the 10-minute default.

Enhancements:
- Align popup cache-input validation with safe-integer semantics.

Tests:
- Add shared coverage for valid cache TTL inputs, invalid values, storage failures, overflow, and the guarantee that both helpers always return a finite positive TTL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache duration handling for GitLab and Codeberg integrations.
  * Invalid, missing, zero, negative, non-numeric, or excessively large durations now safely use the 10-minute default.
  * Prevented cache settings from producing non-positive or invalid expiration times.

* **Tests**
  * Added coverage for valid cache durations, invalid values, overflow scenarios, and storage errors across both integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->