### PR TITLE
chore: set-sidebar-mode-as-defult

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -32,9 +32,16 @@ function applyDisplayMode(mode) {
 }
 
 // Initialize display mode on startup
-browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
-	applyDisplayMode(result.displayMode);
-});
+browser.storage.local
+	.get({
+		displayMode:
+			(typeof window !== 'undefined' && window.isTauri) || browser.sidebarAction?.toggle || browser.sidePanel?.open
+				? 'sidePanel'
+				: 'popup',
+	})
+	.then((result) => {
+		applyDisplayMode(result.displayMode);
+	});
 
 // Listen for changes to displayMode
 browser.storage.onChanged.addListener((changes, area) => {

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -32,14 +32,9 @@ function applyDisplayMode(mode) {
 }
 
 // Initialize display mode on startup
-browser.storage.local
-	.get({
-		displayMode:
-			(typeof window !== 'undefined' && window.isTauri) || browser.sidebarAction?.toggle ? 'sidePanel' : 'popup',
-	})
-	.then((result) => {
-		applyDisplayMode(result.displayMode);
-	});
+browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
+	applyDisplayMode(result.displayMode);
+});
 
 // Listen for changes to displayMode
 browser.storage.onChanged.addListener((changes, area) => {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1479,7 +1479,10 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		}
 
-		browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
+		const defaultDisplayMode =
+			window.isTauri || browser.sidebarAction?.toggle || browser.sidePanel?.open ? 'sidePanel' : 'popup';
+
+		browser.storage.local.get({ displayMode: defaultDisplayMode }).then((result) => {
 			applyDisplayModeClass(result.displayMode);
 		});
 
@@ -1487,7 +1490,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		const displayModeNotice = document.getElementById('displayModeNotice');
 		const displayModeNoticeText = document.getElementById('displayModeNoticeText');
 		if (displayModeSelect) {
-			browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
+			browser.storage.local.get({ displayMode: defaultDisplayMode }).then((result) => {
 				displayModeSelect.value = result.displayMode;
 			});
 			displayModeSelect.addEventListener('change', () => {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -1479,21 +1479,17 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		}
 
-		browser.storage.local
-			.get({ displayMode: window.isTauri || browser.sidebarAction?.toggle ? 'sidePanel' : 'popup' })
-			.then((result) => {
-				applyDisplayModeClass(result.displayMode);
-			});
+		browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
+			applyDisplayModeClass(result.displayMode);
+		});
 
 		const displayModeSelect = document.getElementById('displayModeSelect');
 		const displayModeNotice = document.getElementById('displayModeNotice');
 		const displayModeNoticeText = document.getElementById('displayModeNoticeText');
 		if (displayModeSelect) {
-			browser.storage.local
-				.get({ displayMode: window.isTauri || browser.sidebarAction?.toggle ? 'sidePanel' : 'popup' })
-				.then((result) => {
-					displayModeSelect.value = result.displayMode;
-				});
+			browser.storage.local.get({ displayMode: 'sidePanel' }).then((result) => {
+				displayModeSelect.value = result.displayMode;
+			});
 			displayModeSelect.addEventListener('change', () => {
 				const mode = displayModeSelect.value;
 				browser.storage.local.set({ displayMode: mode });


### PR DESCRIPTION
### 📌 Fixes

Fixes #832 


---

### 📝 Summary of Changes

- Updated the default storage fallback for `displayMode` from `'popup'` to `'sidePanel'` in `src/scripts/background.js` and `src/scripts/popup.js`.
- Ensured new installations default to Side Panel (sidebar) mode out of the box while allowing users to switch to Popup mode if desired.

---

### 📸 Screenshots / Demo (if UI-related)

[Screencast from 2026-09-05 20-48-13.webm](https://github.com/user-attachments/assets/71faff28-a9a7-4847-a40a-f80f8fe319ef)

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

- Changes are backward-compatible: existing users who have explicitly set `displayMode` in storage will retain their preference.

## Summary by Sourcery

Default supported browsers to Side Panel mode while retaining users’ saved display-mode preferences.

Bug Fixes:
- Default display mode now selects Side Panel when the browser supports the Side Panel API, including supported new installations.

Enhancements:
- Preserve existing stored display-mode preferences while consistently applying the updated fallback across background and popup contexts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Display mode now defaults to **Side Panel** in Tauri, Firefox sidebar, and supported Chrome/Edge side-panel environments.
  - Other environments continue to default to **Popup**.
  - Saved display-mode preferences are applied consistently during startup and popup initialization.
  - The display-mode selector now accurately reflects the active display mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->