### PR TITLE
fix: minimize the border for scrum body

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,11 @@ body {
     position: relative;
 }
 
+#scrumReport:focus {
+    outline: 1px solid #000;
+    outline-offset: -1px;
+}
+
 .scrum-toast-container {
     position: fixed;
     top: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,7 @@ body {
 }
 
 #scrumReport:focus {
-    outline: 1px solid #000;
+    outline: 1px solid #2563eb;
     outline-offset: -1px;
 }
 


### PR DESCRIPTION
### 📌 Fixes

 Closes #832 

---

### 📝 Summary of Changes

- Reduced the focus outline thickness on the Scrum report area (`#scrumReport`) from the browser default to a thinner 1px black border for a cleaner look.

---

### 📸 Screenshots / Demo (if UI-related)

### Before

<img width="442" height="297" alt="image" src="https://github.com/user-attachments/assets/a0111a36-3bea-4e01-afe3-206b683bccef" />


### After

<img width="442" height="297" alt="image" src="https://github.com/user-attachments/assets/d54c21fa-1a6b-4bec-9005-c41f1ae36fe4" />


---

### ✅ Checklist

- [x] I've tested my changes locally
- [ ] I've added tests (if applicable)
- [ ] I've updated documentation (if applicable)
- [x] My code follows the project's code style guidelines

---

### 👀 Reviewer Notes

This change only affects the focus state of the report content area. The border remains black but is now thinner (1px) for a more polished appearance.

## Summary by Sourcery

Bug Fixes:
- Refine the Scrum report focus state with a thinner, inset outline for a cleaner visual presentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Updated the Scrum Report focus outline to blue for clearer keyboard-focus visibility.
  * Retained the existing 1px outline width and offset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->