### PR TITLE
chore:  move home and screen icon position

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -91,18 +91,9 @@
 	
 	<div id="popupRoot" class="pl-1 py-2 rounded-2xl">
 		<div class="bg-white px-4 py-4 mx-2 mb-2 rounded-3xl">
-			<div class="flex justify-between py-2">
+			<div class="flex justify-between py-0">
 				<h3 id="scrumHelperHeading" class="text-3xl font-semibold cursor-pointer">Scrum Helper</h3>
-				<img src="icons/night-mode.png" alt="Night Mode" class="w-7 h-7 mx-3 cursor-pointer"
-					id="darkModeToggle">
-			</div>
-			<div>
-				<p class="" data-i18n="appDescription">Report your development progress by auto-fetching your Git
-					activity for a selected period
-				</p>
-			</div>
-
-			<div class="center mt-2 flex justify-end">
+					<div class="center flex justify-end">
 				<div class="flex">
 					<button id="homeButton"
 						class="ml-1 p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition flex items-center justify-center"
@@ -120,8 +111,19 @@
 						data-i18n-title="mailSettingsTitle">
 						<i class="fa fa-envelope text-3xl text-gray-600 dark:text-gray-300"></i>
 					</button>
+						<img src="icons/night-mode.png" alt="Night Mode" class="w-6 h-6 mx-3 my-2 cursor-pointer"
+					id="darkModeToggle">
 				</div>
 			</div>
+			
+			</div>
+			<div>
+				<p class="" data-i18n="appDescription">Report your development progress by auto-fetching your Git
+					activity for a selected period
+				</p>
+			</div>
+
+		
 		</div>
 
 		<div class="rounded-2xl">


### PR DESCRIPTION
### 📌 Fixes

Fixes #832 

---

### 📝 Summary of Changes

- Moved the home and settings buttons before to the night mode icon  in the header.
- Removed unnecessary padding (`py-2` → `py-0`) for a more compact header layout.
- Restored the app description below the header.
- Improved visual alignment of header icons using `flex items-center`.

---

### 📸 Screenshots / Demo (if UI-related)

### Before

<img width="495" height="534" alt="image" src="https://github.com/user-attachments/assets/443b5daf-e301-4370-92de-d906815fe44b" />

### After

<img width="495" height="534" alt="image" src="https://github.com/user-attachments/assets/b93283e3-1781-4c96-90b7-ef36559c9f63" />

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

This change only affects the header layout of the popup UI. The functionality remains unchanged. The goal is to make the header more compact and visually aligned.

## Summary by Sourcery

Enhancements:
- Reorganize and compact the popup header layout by placing navigation and settings controls alongside the theme toggle, improving icon alignment, and restoring the application description beneath the header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved popup header layout and spacing.
  * Adjusted dark mode and night mode control sizing and alignment.
  * Repositioned the app description and settings controls for a cleaner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->