### PR TITLE
chore: update platform selction span to full width

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -907,15 +907,31 @@ hr,
 }
 
 #platformDropdownList {
-    min-width: unset;
-    width: unset !important;
+    width: 100% !important;
+    min-width: 100% !important;
+    box-sizing: border-box;
     z-index: 1000 !important;
 }
 
 .dark-mode #platformDropdownList {
-    min-width: unset;
-    width: unset !important;
+    width: 100% !important;
+    min-width: 100% !important;
+    box-sizing: border-box;
     z-index: 1000 !important;
+}
+
+#platformDropdownList svg,
+#platformDropdownBtn svg {
+    width: 18px !important;
+    height: 18px !important;
+    max-width: 18px !important;
+    max-height: 18px !important;
+    flex-shrink: 0;
+}
+
+#platformDropdownList i,
+#platformDropdownBtn i.fab {
+    font-size: 1.25rem !important;
 }
 
 /* Fix platform dropdown highlight in dark mode */

--- a/src/index.css
+++ b/src/index.css
@@ -922,16 +922,11 @@ hr,
 
 #platformDropdownList svg,
 #platformDropdownBtn svg {
-    width: 18px !important;
-    height: 18px !important;
-    max-width: 18px !important;
-    max-height: 18px !important;
+    width: 15px !important;
+    height: 15px !important;
+    max-width: 15px !important;
+    max-height: 15px !important;
     flex-shrink: 0;
-}
-
-#platformDropdownList i,
-#platformDropdownBtn i.fab {
-    font-size: 1.25rem !important;
 }
 
 /* Fix platform dropdown highlight in dark mode */

--- a/src/popup.html
+++ b/src/popup.html
@@ -135,20 +135,20 @@
 							<button type="button" id="platformDropdownBtn"
 								class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 pr-8 flex items-center justify-between focus:outline-none focus:ring-2 focus:ring-blue-500">
 								<span id="platformDropdownSelected" class="flex items-center gap-2">
-									<i class="fab fa-github mr-2"></i> GitHub
+									<i class="fab fa-github mr-2 text-xl"></i> GitHub
 								</span>
 								<i class="fa fa-chevron-down text-gray-500"></i>
 							</button>
 							<ul id="platformDropdownList"
-								class="absolute left-0 right-0 bg-white border-2 border-gray-200 rounded-xl mt-1 shadow-lg z-10 hidden">
+								class="absolute left-0 right-0 w-full bg-white border-2 border-gray-200 rounded-xl mt-1 shadow-lg z-10 hidden">
 								<li class="px-4 py-2 flex items-center gap-2 cursor-pointer hover:bg-gray-100" data-value="github">
-									<i class="fab fa-github text-lg"></i> GitHub
+									<i class="fab fa-github text-xl"></i> GitHub
 								</li>
 								<li class="px-4 py-2 flex items-center gap-2 cursor-pointer hover:bg-gray-100" data-value="gitlab">
-									<i class="fab fa-gitlab text-lg"></i> GitLab
+									<i class="fab fa-gitlab text-xl"></i> GitLab
 								</li>
 								<li class="px-4 py-2 flex items-center gap-2 cursor-pointer hover:bg-gray-100" data-value="codeberg">
-									<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="w-[18px] h-[18px] fill-current">
+									<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="18" height="18" class="w-[18px] h-[18px] fill-current" style="width: 18px; height: 18px; flex-shrink: 0; fill: currentColor;">
 										<title>Codeberg</title>
 										<path d="M11.999.747A11.974 11.974 0 0 0 0 12.75c0 2.254.635 4.465 1.833 6.376L11.837 6.19c.072-.092.251-.092.323 0l4.178 5.402h-2.992l.065.239h3.113l.882 1.138h-3.674l.103.374h3.86l.777 1.003h-4.358l.135.483h4.593l.695.894h-5.038l.165.589h5.326l.609.785h-5.717l.182.65h6.038l.562.727h-6.397l.183.65h6.717A12.003 12.003 0 0 0 24 12.75 11.977 11.977 0 0 0 11.999.747zm3.654 19.104.182.65h5.326c.173-.204.353-.433.513-.65zm.385 1.377.18.65h3.563c.233-.198.485-.428.712-.65zm.383 1.377.182.648h1.203c.356-.204.685-.412 1.042-.648z"/>
 									</svg> Codeberg

--- a/src/popup.html
+++ b/src/popup.html
@@ -135,20 +135,20 @@
 							<button type="button" id="platformDropdownBtn"
 								class="w-full border-2 border-gray-200 bg-gray-200 rounded-xl text-gray-800 p-2 pr-8 flex items-center justify-between focus:outline-none focus:ring-2 focus:ring-blue-500">
 								<span id="platformDropdownSelected" class="flex items-center gap-2">
-									<i class="fab fa-github mr-2 text-xl"></i> GitHub
+									<i class="fab fa-github mr-2"></i> GitHub
 								</span>
 								<i class="fa fa-chevron-down text-gray-500"></i>
 							</button>
 							<ul id="platformDropdownList"
 								class="absolute left-0 right-0 w-full bg-white border-2 border-gray-200 rounded-xl mt-1 shadow-lg z-10 hidden">
 								<li class="px-4 py-2 flex items-center gap-2 cursor-pointer hover:bg-gray-100" data-value="github">
-									<i class="fab fa-github text-xl"></i> GitHub
+									<i class="fab fa-github text-lg"></i> GitHub
 								</li>
 								<li class="px-4 py-2 flex items-center gap-2 cursor-pointer hover:bg-gray-100" data-value="gitlab">
-									<i class="fab fa-gitlab text-xl"></i> GitLab
+									<i class="fab fa-gitlab text-lg"></i> GitLab
 								</li>
 								<li class="px-4 py-2 flex items-center gap-2 cursor-pointer hover:bg-gray-100" data-value="codeberg">
-									<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="18" height="18" class="w-[18px] h-[18px] fill-current" style="width: 18px; height: 18px; flex-shrink: 0; fill: currentColor;">
+									<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="15" height="15" class="w-[15px] h-[15px] fill-current" style="width: 15px; height: 15px; flex-shrink: 0; fill: currentColor;">
 										<title>Codeberg</title>
 										<path d="M11.999.747A11.974 11.974 0 0 0 0 12.75c0 2.254.635 4.465 1.833 6.376L11.837 6.19c.072-.092.251-.092.323 0l4.178 5.402h-2.992l.065.239h3.113l.882 1.138h-3.674l.103.374h3.86l.777 1.003h-4.358l.135.483h4.593l.695.894h-5.038l.165.589h5.326l.609.785h-5.717l.182.65h6.038l.562.727h-6.397l.183.65h6.717A12.003 12.003 0 0 0 24 12.75 11.977 11.977 0 0 0 11.999.747zm3.654 19.104.182.65h5.326c.173-.204.353-.433.513-.65zm.385 1.377.18.65h3.563c.233-.198.485-.428.712-.65zm.383 1.377.182.648h1.203c.356-.204.685-.412 1.042-.648z"/>
 									</svg> Codeberg

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -2398,15 +2398,15 @@ function buildScrumSubjectFromPopup() {
 function setPlatformDropdown(value) {
 	if (dropdownSelected) {
 		if (value === 'gitlab') {
-			dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2 text-xl"></i> GitLab';
+			dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
 		} else if (value === 'codeberg') {
 			dropdownSelected.innerHTML = `
-				<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="width: 18px; height: 18px; display: inline-block; vertical-align: middle; margin-right: 8px; fill: currentColor;">
+				<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="width: 15px; height: 15px; display: inline-block; vertical-align: middle; margin-right: 8px; fill: currentColor;">
 					<title>Codeberg</title>
 					<path d="M11.999.747A11.974 11.974 0 0 0 0 12.75c0 2.254.635 4.465 1.833 6.376L11.837 6.19c.072-.092.251-.092.323 0l4.178 5.402h-2.992l.065.239h3.113l.882 1.138h-3.674l.103.374h3.86l.777 1.003h-4.358l.135.483h4.593l.695.894h-5.038l.165.589h5.326l.609.785h-5.717l.182.65h6.038l.562.727h-6.397l.183.65h6.717A12.003 12.003 0 0 0 24 12.75 11.977 11.977 0 0 0 11.999.747zm3.654 19.104.182.65h5.326c.173-.204.353-.433.513-.65zm.385 1.377.18.65h3.563c.233-.198.485-.428.712-.65zm.383 1.377.182.648h1.203c.356-.204.685-.412 1.042-.648z"/>
 				</svg> Codeberg`;
 		} else {
-			dropdownSelected.innerHTML = '<i class="fab fa-github mr-2 text-xl"></i> GitHub';
+			dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
 		}
 	}
 
@@ -2543,15 +2543,15 @@ browser.storage.local.get(['platform']).then((result) => {
 	// Just update the UI without clearing username when restoring from storage
 	if (dropdownSelected) {
 		if (platform === 'gitlab') {
-			dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2 text-xl"></i> GitLab';
+			dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
 		} else if (platform === 'codeberg') {
 			dropdownSelected.innerHTML = `
-				<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="width: 18px; height: 18px; display: inline-block; vertical-align: middle; margin-right: 8px; fill: currentColor;">
+				<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="width: 15px; height: 15px; display: inline-block; vertical-align: middle; margin-right: 8px; fill: currentColor;">
 					<title>Codeberg</title>
 					<path d="M11.999.747A11.974 11.974 0 0 0 0 12.75c0 2.254.635 4.465 1.833 6.376L11.837 6.19c.072-.092.251-.092.323 0l4.178 5.402h-2.992l.065.239h3.113l.882 1.138h-3.674l.103.374h3.86l.777 1.003h-4.358l.135.483h4.593l.695.894h-5.038l.165.589h5.326l.609.785h-5.717l.182.65h6.038l.562.727h-6.397l.183.65h6.717A12.003 12.003 0 0 0 24 12.75 11.977 11.977 0 0 0 11.999.747zm3.654 19.104.182.65h5.326c.173-.204.353-.433.513-.65zm.385 1.377.18.65h3.563c.233-.198.485-.428.712-.65zm.383 1.377.182.648h1.203c.356-.204.685-.412 1.042-.648z"/>
 				</svg> Codeberg`;
 		} else {
-			dropdownSelected.innerHTML = '<i class="fab fa-github mr-2 text-xl"></i> GitHub';
+			dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
 		}
 	}
 	if (platformSelectHidden) {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -2398,7 +2398,7 @@ function buildScrumSubjectFromPopup() {
 function setPlatformDropdown(value) {
 	if (dropdownSelected) {
 		if (value === 'gitlab') {
-			dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
+			dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2 text-xl"></i> GitLab';
 		} else if (value === 'codeberg') {
 			dropdownSelected.innerHTML = `
 				<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="width: 18px; height: 18px; display: inline-block; vertical-align: middle; margin-right: 8px; fill: currentColor;">
@@ -2406,7 +2406,7 @@ function setPlatformDropdown(value) {
 					<path d="M11.999.747A11.974 11.974 0 0 0 0 12.75c0 2.254.635 4.465 1.833 6.376L11.837 6.19c.072-.092.251-.092.323 0l4.178 5.402h-2.992l.065.239h3.113l.882 1.138h-3.674l.103.374h3.86l.777 1.003h-4.358l.135.483h4.593l.695.894h-5.038l.165.589h5.326l.609.785h-5.717l.182.65h6.038l.562.727h-6.397l.183.65h6.717A12.003 12.003 0 0 0 24 12.75 11.977 11.977 0 0 0 11.999.747zm3.654 19.104.182.65h5.326c.173-.204.353-.433.513-.65zm.385 1.377.18.65h3.563c.233-.198.485-.428.712-.65zm.383 1.377.182.648h1.203c.356-.204.685-.412 1.042-.648z"/>
 				</svg> Codeberg`;
 		} else {
-			dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
+			dropdownSelected.innerHTML = '<i class="fab fa-github mr-2 text-xl"></i> GitHub';
 		}
 	}
 
@@ -2543,7 +2543,7 @@ browser.storage.local.get(['platform']).then((result) => {
 	// Just update the UI without clearing username when restoring from storage
 	if (dropdownSelected) {
 		if (platform === 'gitlab') {
-			dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2"></i> GitLab';
+			dropdownSelected.innerHTML = '<i class="fab fa-gitlab mr-2 text-xl"></i> GitLab';
 		} else if (platform === 'codeberg') {
 			dropdownSelected.innerHTML = `
 				<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="width: 18px; height: 18px; display: inline-block; vertical-align: middle; margin-right: 8px; fill: currentColor;">
@@ -2551,7 +2551,7 @@ browser.storage.local.get(['platform']).then((result) => {
 					<path d="M11.999.747A11.974 11.974 0 0 0 0 12.75c0 2.254.635 4.465 1.833 6.376L11.837 6.19c.072-.092.251-.092.323 0l4.178 5.402h-2.992l.065.239h3.113l.882 1.138h-3.674l.103.374h3.86l.777 1.003h-4.358l.135.483h4.593l.695.894h-5.038l.165.589h5.326l.609.785h-5.717l.182.65h6.038l.562.727h-6.397l.183.65h6.717A12.003 12.003 0 0 0 24 12.75 11.977 11.977 0 0 0 11.999.747zm3.654 19.104.182.65h5.326c.173-.204.353-.433.513-.65zm.385 1.377.18.65h3.563c.233-.198.485-.428.712-.65zm.383 1.377.182.648h1.203c.356-.204.685-.412 1.042-.648z"/>
 				</svg> Codeberg`;
 		} else {
-			dropdownSelected.innerHTML = '<i class="fab fa-github mr-2"></i> GitHub';
+			dropdownSelected.innerHTML = '<i class="fab fa-github mr-2 text-xl"></i> GitHub';
 		}
 	}
 	if (platformSelectHidden) {


### PR DESCRIPTION
### 📌 Fixes

Fixes #832 

---

### 📝 Summary of Changes

- Updated `#platformDropdownList` to span full width (`width: 100%`) matching the platform selector trigger button in both light and dark modes.
- Fixed Codeberg SVG icon dimensions (`18px × 18px`) and constrained dropdown SVGs to prevent layout overflow.
- Adjusted GitHub and GitLab icon sizing (`text-xl` / `1.25rem`) across HTML, CSS, and JS to optically balance them with the Codeberg icon.

---

### 📸 Screenshots / Demo (if UI-related)

#### Before
<img width="484" height="864" alt="image" src="https://github.com/user-attachments/assets/261a9689-7229-47bc-afa4-c147775ee755" />


#### After
<img width="484" height="864" alt="image" src="https://github.com/user-attachments/assets/0c4baaab-6967-4579-b404-61129cc581e7" />

---

### ✅ Checklist

- [x] I’ve tested my changes locally
- [ ] I’ve added tests (if applicable)
- [ ] I’ve updated documentation (if applicable)
- [x] My code follows the project’s code style guidelines

---

### 👀 Reviewer Notes

## Summary by Sourcery

Ensure the platform selector dropdown spans the full trigger width and displays consistently sized icons.

Bug Fixes:
- Fix the platform selector dropdown width and icon layout so the menu aligns with its trigger without overflowing.

Enhancements:
- Standardize platform icon sizing across the selector for more consistent visual alignment in light and dark modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the platform dropdown to span the full available width in standard and dark modes.
  * Standardized platform selector icons at 15px for consistent sizing and alignment.
  * Adjusted Codeberg, GitHub, and GitLab icon presentation across platform selection and stored-platform restoration views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->